### PR TITLE
feat: envoyer le devis PDF par email via Resend

### DIFF
--- a/app/(bureau)/devis/[id]/preview/actions.ts
+++ b/app/(bureau)/devis/[id]/preview/actions.ts
@@ -76,22 +76,3 @@ export async function saveQuoteAction(
   }
 }
 
-export async function sendQuoteAction(
-  quoteId: string
-): Promise<{ success: boolean; error?: string }> {
-  try {
-    const supabase = await createClient()
-    await updateQuote(supabase, quoteId, {
-      status: "sent",
-      sent_at: new Date().toISOString(),
-    })
-    revalidatePath(`/devis/${quoteId}/preview`)
-    return { success: true }
-  } catch (err) {
-    console.error("[sendQuoteAction]", err)
-    return {
-      success: false,
-      error: err instanceof Error ? err.message : "Erreur inconnue",
-    }
-  }
-}

--- a/app/(bureau)/devis/[id]/preview/page.tsx
+++ b/app/(bureau)/devis/[id]/preview/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation"
 import Link from "next/link"
 import { ArrowLeft, FileText } from "lucide-react"
 import { createClient } from "@/lib/supabase/server"
-import { getQuote } from "@/lib/quotes"
+import { getQuoteWithContext } from "@/lib/quotes"
 import { QuoteEditor } from "@/components/devis/quote-editor"
 
 export async function generateMetadata({
@@ -27,7 +27,7 @@ export default async function QuotePreviewPage({
 
   let quote
   try {
-    quote = await getQuote(supabase, id)
+    quote = await getQuoteWithContext(supabase, id)
   } catch {
     notFound()
   }

--- a/app/api/devis/[id]/send/route.ts
+++ b/app/api/devis/[id]/send/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server"
+import { Resend } from "resend"
+import { renderToBuffer } from "@react-pdf/renderer"
+import React from "react"
+import { createClient } from "@/lib/supabase/server"
+import { getQuoteWithContext, updateQuote } from "@/lib/quotes"
+import { QuotePDFDocument } from "@/components/devis/quote-pdf-document"
+import { buildQuoteEmailHtml, buildQuoteEmailSubject } from "@/lib/email/quote"
+import { env } from "@/lib/env"
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  let quote
+  try {
+    quote = await getQuoteWithContext(supabase, id)
+  } catch {
+    return NextResponse.json({ error: "Devis introuvable" }, { status: 404 })
+  }
+
+  const clientEmail = quote.project.client.email
+  if (!clientEmail) {
+    return NextResponse.json(
+      { error: "Le client n'a pas d'adresse email" },
+      { status: 422 }
+    )
+  }
+
+  // Generate PDF buffer
+  let pdfBuffer: Buffer
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const element = React.createElement(QuotePDFDocument, { quote }) as any
+    pdfBuffer = await renderToBuffer(element)
+  } catch (err) {
+    console.error("[send] pdf render error", err)
+    return NextResponse.json(
+      { error: "Erreur de génération du PDF" },
+      { status: 500 }
+    )
+  }
+
+  const ref = quote.reference ?? `DEV-${quote.id.slice(0, 8).toUpperCase()}`
+
+  // Send email via Resend
+  const resend = new Resend(env.RESEND_API_KEY)
+  try {
+    await resend.emails.send({
+      from: "BTP × AI Métallerie <devis@btpxai.fr>",
+      to: [clientEmail],
+      subject: buildQuoteEmailSubject(quote),
+      html: buildQuoteEmailHtml(quote),
+      attachments: [
+        {
+          filename: `${ref}.pdf`,
+          content: pdfBuffer,
+        },
+      ],
+    })
+  } catch (err) {
+    console.error("[send] resend error", err)
+    return NextResponse.json(
+      { error: "Erreur lors de l'envoi de l'email" },
+      { status: 500 }
+    )
+  }
+
+  // Update quote status
+  try {
+    await updateQuote(supabase, id, {
+      status: "sent",
+      sent_at: new Date().toISOString(),
+    })
+  } catch (err) {
+    console.error("[send] db update error", err)
+    return NextResponse.json(
+      { error: "Email envoyé mais erreur lors de la mise à jour du statut" },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/components/devis/quote-editor.tsx
+++ b/components/devis/quote-editor.tsx
@@ -23,11 +23,8 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
-import type { QuoteWithItems, QuoteStatus } from "@/types"
-import {
-  saveQuoteAction,
-  sendQuoteAction,
-} from "@/app/(bureau)/devis/[id]/preview/actions"
+import type { QuoteWithContext, QuoteStatus } from "@/types"
+import { saveQuoteAction } from "@/app/(bureau)/devis/[id]/preview/actions"
 
 // ─── Local types ──────────────────────────────────────────────────────────────
 
@@ -86,7 +83,7 @@ function newTempId() {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 interface QuoteEditorProps {
-  quote: QuoteWithItems
+  quote: QuoteWithContext
 }
 
 export function QuoteEditor({ quote }: QuoteEditorProps) {
@@ -204,15 +201,18 @@ export function QuoteEditor({ quote }: QuoteEditorProps) {
         toast.error(saveResult.error ?? "Erreur lors de la sauvegarde")
         return
       }
-      const sendResult = await sendQuoteAction(quote.id)
-      if (sendResult.success) {
+      const res = await fetch(`/api/devis/${quote.id}/send`, { method: "POST" })
+      const data = await res.json()
+      if (res.ok) {
         setStatus("sent")
         setDeletedItemIds([])
         setIsDirty(false)
-        toast.success("Devis envoyé")
+        toast.success("Devis envoyé par email au client")
       } else {
-        toast.error(sendResult.error ?? "Erreur lors de l'envoi")
+        toast.error(data.error ?? "Erreur lors de l'envoi")
       }
+    } catch {
+      toast.error("Erreur lors de l'envoi")
     } finally {
       setIsSending(false)
     }
@@ -652,9 +652,17 @@ export function QuoteEditor({ quote }: QuoteEditorProps) {
             <DialogTitle>Envoyer le devis ?</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            Le devis sera sauvegardé et marqué comme envoyé. Le statut passera
-            à <strong className="text-foreground">Envoyé</strong> et ne pourra
-            plus être modifié.
+            Le devis sera sauvegardé et envoyé par email{" "}
+            {quote.project.client.email ? (
+              <>
+                à{" "}
+                <strong className="text-foreground">
+                  {quote.project.client.email}
+                </strong>{" "}
+              </>
+            ) : null}
+            avec le PDF en pièce jointe. Le statut passera à{" "}
+            <strong className="text-foreground">Envoyé</strong>.
           </p>
           <DialogFooter>
             <Button

--- a/lib/email/quote.ts
+++ b/lib/email/quote.ts
@@ -1,0 +1,93 @@
+import type { QuoteWithContext } from "@/types"
+
+function fmtEur(n: number) {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(n)
+}
+
+export function buildQuoteEmailSubject(quote: QuoteWithContext): string {
+  const ref = quote.reference ?? `DEV-${quote.id.slice(0, 8).toUpperCase()}`
+  return `Votre devis ${ref} — BTP × AI Métallerie`
+}
+
+export function buildQuoteEmailHtml(quote: QuoteWithContext): string {
+  const ref = quote.reference ?? `DEV-${quote.id.slice(0, 8).toUpperCase()}`
+  const clientName = quote.project.client.name
+  const totalHT = quote.total_ht ?? 0
+  const tvaRate = quote.tva_rate ?? 20
+  const totalTTC = Math.round(totalHT * (1 + tvaRate / 100) * 100) / 100
+  const validityDays = quote.validity_days ?? 30
+  const projectTitle = quote.project.title || "vos travaux"
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Devis ${ref}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:system-ui,-apple-system,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;border:1px solid #e4e4e7;">
+          <tr>
+            <td style="background:#18181b;padding:32px 40px;">
+              <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">BTP × AI Métallerie</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#a1a1aa;">12 rue de la Forge, 75001 Paris · 01 23 45 67 89</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px;">
+              <p style="margin:0 0 24px;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.1em;font-weight:600;">DEVIS N° ${ref}</p>
+              <p style="margin:0 0 16px;font-size:16px;color:#18181b;">Bonjour ${clientName},</p>
+              <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+                Veuillez trouver ci-joint votre devis pour <strong>${projectTitle}</strong>.
+                Nous restons à votre disposition pour toute question ou modification.
+              </p>
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#fafafa;border:1px solid #e4e4e7;border-radius:6px;margin-bottom:24px;">
+                <tr>
+                  <td style="padding:20px 24px;border-bottom:1px solid #e4e4e7;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Référence</p>
+                    <p style="margin:0;font-size:15px;font-weight:600;color:#18181b;">${ref}</p>
+                  </td>
+                  <td style="padding:20px 24px;border-bottom:1px solid #e4e4e7;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Validité</p>
+                    <p style="margin:0;font-size:15px;font-weight:600;color:#18181b;">${validityDays} jours</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:20px 24px;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Total H.T.</p>
+                    <p style="margin:0;font-size:15px;font-weight:600;color:#18181b;">${fmtEur(totalHT)}</p>
+                  </td>
+                  <td style="padding:20px 24px;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Total T.T.C. (TVA ${tvaRate} %)</p>
+                    <p style="margin:0;font-size:18px;font-weight:700;color:#18181b;">${fmtEur(totalTTC)}</p>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 32px;font-size:14px;color:#3f3f46;line-height:1.6;">
+                Le devis complet est disponible en pièce jointe (PDF). Pour l'accepter ou demander des modifications, contactez-nous en répondant à cet email.
+              </p>
+              <p style="margin:0;font-size:14px;color:#3f3f46;line-height:1.6;">Cordialement,</p>
+              <p style="margin:4px 0 0;font-size:14px;font-weight:600;color:#18181b;">L'équipe BTP × AI Métallerie</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:#fafafa;padding:20px 40px;border-top:1px solid #e4e4e7;">
+              <p style="margin:0;font-size:12px;color:#a1a1aa;text-align:center;">
+                BTP × AI Métallerie · SIRET 123 456 789 00010 · contact@btpxai.fr
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.74.0",
+        "resend": "^6.12.2",
         "shadcn": "^4.5.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -3118,6 +3119,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -7902,6 +7909,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -11561,6 +11574,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -12064,6 +12083,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -12850,6 +12890,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/start-server-and-test": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.2.tgz",
@@ -13307,6 +13357,29 @@
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC"
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.74.0",
+    "resend": "^6.12.2",
     "shadcn": "^4.5.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/tests/unit/email/quote.test.ts
+++ b/tests/unit/email/quote.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest"
+import { buildQuoteEmailHtml, buildQuoteEmailSubject } from "@/lib/email/quote"
+import type { QuoteWithContext } from "@/types"
+
+const mockQuote: QuoteWithContext = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  project_id: "p1",
+  status: "draft",
+  total_ht: 1500,
+  tva_rate: 20,
+  notes: null,
+  validity_days: 30,
+  reference: "DEV-2026-001",
+  created_at: "2026-04-27T00:00:00Z",
+  sent_at: null,
+  items: [
+    {
+      id: "i1",
+      quote_id: "550e8400-e29b-41d4-a716-446655440000",
+      label: "Cornière acier S235",
+      quantity: 10,
+      unit_price: 150,
+      unit: "ml",
+    },
+  ],
+  project: {
+    id: "p1",
+    client_id: "c1",
+    title: "Portail acier sur mesure",
+    description: null,
+    status: "in_progress",
+    created_at: "2026-04-27T00:00:00Z",
+    client: {
+      id: "c1",
+      name: "Jean Dupont",
+      email: "jean.dupont@example.com",
+      phone: null,
+      address: null,
+      created_at: "2026-04-27T00:00:00Z",
+    },
+  },
+}
+
+// ─── buildQuoteEmailSubject ───────────────────────────────────────────────────
+
+describe("buildQuoteEmailSubject", () => {
+  it("includes the quote reference", () => {
+    expect(buildQuoteEmailSubject(mockQuote)).toContain("DEV-2026-001")
+  })
+
+  it("falls back to generated reference when reference is null", () => {
+    const q = { ...mockQuote, reference: null }
+    const subject = buildQuoteEmailSubject(q)
+    expect(subject).toContain("DEV-")
+    expect(subject).toContain(q.id.slice(0, 8).toUpperCase())
+  })
+})
+
+// ─── buildQuoteEmailHtml ──────────────────────────────────────────────────────
+
+describe("buildQuoteEmailHtml", () => {
+  it("includes client name", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    expect(html).toContain("Jean Dupont")
+  })
+
+  it("includes quote reference", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    expect(html).toContain("DEV-2026-001")
+  })
+
+  it("includes formatted total HT", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    // fr-FR uses narrow no-break space (U+202F) as thousands separator
+    expect(html).toContain("500,00")
+  })
+
+  it("includes formatted total TTC with TVA applied", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    // 1500 * 1.20 = 1800
+    expect(html).toContain("800,00")
+  })
+
+  it("includes validity period", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    expect(html).toContain("30 jours")
+  })
+
+  it("includes project title", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    expect(html).toContain("Portail acier sur mesure")
+  })
+
+  it("includes TVA rate", () => {
+    const html = buildQuoteEmailHtml(mockQuote)
+    expect(html).toContain("20 %")
+  })
+
+  it("uses generated reference when reference is null", () => {
+    const q = { ...mockQuote, reference: null }
+    const html = buildQuoteEmailHtml(q)
+    expect(html).toContain("DEV-550E8400")
+  })
+
+  it("falls back to 'vos travaux' when project title is empty", () => {
+    const q = {
+      ...mockQuote,
+      project: { ...mockQuote.project, title: "" },
+    }
+    const html = buildQuoteEmailHtml(q)
+    expect(html).toContain("vos travaux")
+  })
+})


### PR DESCRIPTION
- Installe Resend et cree la route POST /api/devis/[id]/send
  qui genere le PDF, l'envoie en piece jointe et met a jour
  le statut a sent + sent_at
- Ajoute lib/email/quote.ts avec buildQuoteEmailHtml et
  buildQuoteEmailSubject (template HTML responsive)
- La page preview utilise getQuoteWithContext pour avoir
  l'email client disponible dans l'editeur
- Le QuoteEditor affiche l'email destinataire dans la modale de
  confirmation et toast Devis envoye par email au client
- 11 tests Vitest couvrant la construction du sujet et du body

https://claude.ai/code/session_01SZDsuPJ1FbKVeXk6ixfvfv