### PR TITLE
feat: page /devis avec tableau paginé, filtres et actions rapides

### DIFF
--- a/app/(bureau)/devis/page.tsx
+++ b/app/(bureau)/devis/page.tsx
@@ -4,7 +4,7 @@ import { FileText, Plus } from "lucide-react"
 import { createClient } from "@/lib/supabase/server"
 import { getQuotesForTable } from "@/lib/quotes"
 import { QuotesTable } from "@/components/devis/quotes-table"
-import { Button } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 
 export const metadata: Metadata = {
   title: "Devis — BTP×AI",
@@ -31,12 +31,10 @@ export default async function DevisPage() {
             {quotes.length} devis au total · suivi des statuts et actions rapides
           </p>
         </div>
-        <Button asChild>
-          <Link href="/devis/nouveau">
-            <Plus className="size-4" />
-            Nouveau devis
-          </Link>
-        </Button>
+        <Link href="/devis/nouveau" className={buttonVariants()}>
+          <Plus className="size-4" />
+          Nouveau devis
+        </Link>
       </div>
 
       <QuotesTable quotes={quotes} />

--- a/app/(bureau)/devis/page.tsx
+++ b/app/(bureau)/devis/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { FileText, Plus } from "lucide-react"
+import { createClient } from "@/lib/supabase/server"
+import { getQuotesForTable } from "@/lib/quotes"
+import { QuotesTable } from "@/components/devis/quotes-table"
+import { Button } from "@/components/ui/button"
+
+export const metadata: Metadata = {
+  title: "Devis — BTP×AI",
+}
+
+export default async function DevisPage() {
+  const supabase = await createClient()
+  const quotes = await getQuotesForTable(supabase).catch(() => [])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <FileText className="size-3.5 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground tracking-wider uppercase">
+              Gestion
+            </span>
+          </div>
+          <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+            Devis
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {quotes.length} devis au total · suivi des statuts et actions rapides
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/devis/nouveau">
+            <Plus className="size-4" />
+            Nouveau devis
+          </Link>
+        </Button>
+      </div>
+
+      <QuotesTable quotes={quotes} />
+    </div>
+  )
+}

--- a/app/api/devis/[id]/duplicate/route.ts
+++ b/app/api/devis/[id]/duplicate/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { duplicateQuote } from "@/lib/quotes"
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  try {
+    const quote = await duplicateQuote(supabase, id)
+    return NextResponse.json(quote)
+  } catch {
+    return NextResponse.json(
+      { error: "Impossible de dupliquer le devis" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/devis/[id]/status/route.ts
+++ b/app/api/devis/[id]/status/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient } from "@/lib/supabase/server"
+import { updateQuote } from "@/lib/quotes"
+
+const schema = z.object({
+  status: z.enum(["draft", "sent", "accepted", "rejected", "expired"]),
+})
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps invalide" }, { status: 400 })
+  }
+
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Statut invalide" }, { status: 400 })
+  }
+
+  try {
+    const quote = await updateQuote(supabase, id, { status: parsed.data.status })
+    return NextResponse.json(quote)
+  } catch {
+    return NextResponse.json(
+      { error: "Impossible de mettre à jour le statut" },
+      { status: 500 }
+    )
+  }
+}

--- a/components/devis/quotes-table.tsx
+++ b/components/devis/quotes-table.tsx
@@ -1,0 +1,566 @@
+"use client"
+
+import { useState, useMemo, useTransition, useCallback } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import {
+  Eye,
+  Send,
+  Copy,
+  Archive,
+  Search,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  ChevronDown,
+  Calendar,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { QuoteForTable } from "@/types"
+import type { QuoteStatus } from "@/types"
+
+const STATUS_CONFIG: Record<
+  QuoteStatus,
+  { label: string; className: string; dot: string }
+> = {
+  draft: {
+    label: "Brouillon",
+    className:
+      "bg-muted/60 text-muted-foreground border-border/80",
+    dot: "bg-muted-foreground",
+  },
+  sent: {
+    label: "Envoyé",
+    className:
+      "bg-amber-500/10 text-amber-400 border-amber-500/30",
+    dot: "bg-amber-400",
+  },
+  accepted: {
+    label: "Accepté",
+    className:
+      "bg-emerald-500/10 text-emerald-400 border-emerald-500/30",
+    dot: "bg-emerald-400",
+  },
+  rejected: {
+    label: "Refusé",
+    className: "bg-red-500/10 text-red-400 border-red-500/30",
+    dot: "bg-red-400",
+  },
+  expired: {
+    label: "Expiré",
+    className:
+      "bg-slate-500/10 text-slate-500 border-slate-500/20",
+    dot: "bg-slate-500",
+  },
+}
+
+const ALL_STATUSES: QuoteStatus[] = [
+  "draft",
+  "sent",
+  "accepted",
+  "rejected",
+  "expired",
+]
+
+const PER_PAGE = 15
+
+type Props = { quotes: QuoteForTable[] }
+
+export function QuotesTable({ quotes }: Props) {
+  const router = useRouter()
+  const [, startTransition] = useTransition()
+  const [search, setSearch] = useState("")
+  const [statusFilters, setStatusFilters] = useState<QuoteStatus[]>([])
+  const [dateFrom, setDateFrom] = useState("")
+  const [dateTo, setDateTo] = useState("")
+  const [page, setPage] = useState(1)
+
+  const stats = useMemo(
+    () =>
+      ALL_STATUSES.reduce(
+        (acc, s) => ({ ...acc, [s]: quotes.filter((q) => q.status === s).length }),
+        {} as Record<QuoteStatus, number>
+      ),
+    [quotes]
+  )
+
+  const filtered = useMemo(() => {
+    let result = quotes
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      result = result.filter(
+        (r) =>
+          r.reference?.toLowerCase().includes(q) ||
+          r.project?.client?.name.toLowerCase().includes(q) ||
+          r.project?.title.toLowerCase().includes(q)
+      )
+    }
+    if (statusFilters.length > 0) {
+      result = result.filter((r) => statusFilters.includes(r.status))
+    }
+    if (dateFrom) {
+      result = result.filter((r) => r.created_at >= dateFrom)
+    }
+    if (dateTo) {
+      result = result.filter((r) => r.created_at <= dateTo + "T23:59:59")
+    }
+    return result
+  }, [quotes, search, statusFilters, dateFrom, dateTo])
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PER_PAGE))
+  const paginated = filtered.slice((page - 1) * PER_PAGE, page * PER_PAGE)
+
+  const toggleStatus = (s: QuoteStatus) => {
+    setPage(1)
+    setStatusFilters((prev) =>
+      prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]
+    )
+  }
+
+  const clearFilters = () => {
+    setSearch("")
+    setStatusFilters([])
+    setDateFrom("")
+    setDateTo("")
+    setPage(1)
+  }
+
+  const hasFilters =
+    !!search || statusFilters.length > 0 || !!dateFrom || !!dateTo
+
+  const handleStatusChange = useCallback(
+    async (id: string, status: string) => {
+      const res = await fetch(`/api/devis/${id}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      })
+      if (res.ok) {
+        toast.success("Statut mis à jour")
+        startTransition(() => router.refresh())
+      } else {
+        toast.error("Impossible de modifier le statut")
+      }
+    },
+    [router]
+  )
+
+  const handleSend = useCallback(
+    async (id: string) => {
+      const res = await fetch(`/api/devis/${id}/send`, { method: "POST" })
+      if (res.ok) {
+        toast.success("Devis envoyé par email")
+        startTransition(() => router.refresh())
+      } else {
+        toast.error("Impossible d'envoyer le devis")
+      }
+    },
+    [router]
+  )
+
+  const handleDuplicate = useCallback(
+    async (id: string) => {
+      const res = await fetch(`/api/devis/${id}/duplicate`, { method: "POST" })
+      if (res.ok) {
+        const newQuote = await res.json() as { id: string }
+        toast.success("Devis dupliqué")
+        router.push(`/devis/${newQuote.id}/preview`)
+      } else {
+        toast.error("Impossible de dupliquer le devis")
+      }
+    },
+    [router]
+  )
+
+  const handleArchive = useCallback(
+    async (id: string) => {
+      const res = await fetch(`/api/devis/${id}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "expired" }),
+      })
+      if (res.ok) {
+        toast.success("Devis archivé")
+        startTransition(() => router.refresh())
+      } else {
+        toast.error("Impossible d'archiver le devis")
+      }
+    },
+    [router]
+  )
+
+  return (
+    <div className="space-y-4">
+      {/* Status stat pills */}
+      <div className="flex flex-wrap gap-2" data-testid="status-filters">
+        {ALL_STATUSES.map((s) => (
+          <button
+            key={s}
+            onClick={() => toggleStatus(s)}
+            data-testid={`status-filter-${s}`}
+            aria-pressed={statusFilters.includes(s)}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1 rounded-sm text-xs font-medium border transition-all",
+              STATUS_CONFIG[s].className,
+              statusFilters.includes(s)
+                ? "opacity-100 ring-1 ring-primary/40 shadow-sm"
+                : "opacity-55 hover:opacity-80"
+            )}
+          >
+            <span
+              className={cn(
+                "size-1.5 rounded-full shrink-0",
+                STATUS_CONFIG[s].dot
+              )}
+            />
+            {STATUS_CONFIG[s].label}
+            <span className="font-mono tabular-nums opacity-80">
+              {stats[s]}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-col sm:flex-row gap-2">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+          <Input
+            placeholder="Référence, client, projet…"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setPage(1)
+            }}
+            className="pl-8 h-8 text-sm"
+            data-testid="search-input"
+          />
+        </div>
+
+        <div className="flex gap-2 shrink-0">
+          <div className="relative">
+            <Calendar className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none z-10" />
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => {
+                setDateFrom(e.target.value)
+                setPage(1)
+              }}
+              title="Date de début"
+              className="h-8 pl-6 pr-2 text-xs bg-input border border-border rounded-sm text-foreground [color-scheme:dark] focus:outline-none focus:ring-1 focus:ring-ring"
+              data-testid="date-from"
+            />
+          </div>
+          <div className="relative">
+            <Calendar className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none z-10" />
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => {
+                setDateTo(e.target.value)
+                setPage(1)
+              }}
+              title="Date de fin"
+              className="h-8 pl-6 pr-2 text-xs bg-input border border-border rounded-sm text-foreground [color-scheme:dark] focus:outline-none focus:ring-1 focus:ring-ring"
+              data-testid="date-to"
+            />
+          </div>
+          {hasFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearFilters}
+              className="h-8 gap-1.5 text-muted-foreground"
+              data-testid="clear-filters"
+            >
+              <X className="size-3.5" />
+              Effacer
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Result count */}
+      {hasFilters && (
+        <p className="text-xs text-muted-foreground">
+          {filtered.length} résultat{filtered.length !== 1 ? "s" : ""} sur{" "}
+          {quotes.length}
+        </p>
+      )}
+
+      {/* Table */}
+      <div className="rounded-sm border border-border overflow-hidden">
+        <table
+          className="w-full text-sm"
+          data-testid="quotes-table"
+        >
+          <thead>
+            <tr className="border-b border-border bg-muted/20">
+              <th className="text-left text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-4 py-2.5">
+                Référence
+              </th>
+              <th className="text-left text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-3 py-2.5">
+                Client
+              </th>
+              <th className="text-left text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-3 py-2.5 hidden md:table-cell">
+                Projet
+              </th>
+              <th className="text-left text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-3 py-2.5">
+                Statut
+              </th>
+              <th className="text-right text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell">
+                Total HT
+              </th>
+              <th className="text-left text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell">
+                Créé le
+              </th>
+              <th className="text-right text-[10px] font-medium text-muted-foreground uppercase tracking-wider px-4 py-2.5">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60">
+            {paginated.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="text-center py-16">
+                  <div className="flex flex-col items-center gap-3">
+                    <div className="size-12 rounded-sm bg-muted/40 flex items-center justify-center">
+                      <FileText className="size-5 text-muted-foreground/40" />
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Aucun devis trouvé
+                    </p>
+                    {hasFilters && (
+                      <button
+                        onClick={clearFilters}
+                        className="text-xs text-primary hover:underline underline-offset-4"
+                      >
+                        Effacer les filtres
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              paginated.map((quote) => (
+                <QuoteRow
+                  key={quote.id}
+                  quote={quote}
+                  onStatusChange={handleStatusChange}
+                  onSend={handleSend}
+                  onDuplicate={handleDuplicate}
+                  onArchive={handleArchive}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-1">
+          <p className="text-xs text-muted-foreground">
+            {filtered.length} devis · page {page} / {totalPages}
+          </p>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={page === 1}
+              onClick={() => setPage((p) => p - 1)}
+              aria-label="Page précédente"
+            >
+              <ChevronLeft className="size-3.5" />
+            </Button>
+
+            {Array.from({ length: Math.min(totalPages, 7) }, (_, i) => {
+              const pageNum = i + 1
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => setPage(pageNum)}
+                  className={cn(
+                    "size-7 rounded-sm text-xs transition-colors",
+                    page === pageNum
+                      ? "bg-primary text-primary-foreground font-medium"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  )}
+                >
+                  {pageNum}
+                </button>
+              )
+            })}
+
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={page === totalPages}
+              onClick={() => setPage((p) => p + 1)}
+              aria-label="Page suivante"
+            >
+              <ChevronRight className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// QuoteRow
+// ---------------------------------------------------------------------------
+
+type RowProps = {
+  quote: QuoteForTable
+  onStatusChange: (id: string, status: string) => Promise<void>
+  onSend: (id: string) => Promise<void>
+  onDuplicate: (id: string) => Promise<void>
+  onArchive: (id: string) => Promise<void>
+}
+
+function QuoteRow({
+  quote,
+  onStatusChange,
+  onSend,
+  onDuplicate,
+  onArchive,
+}: RowProps) {
+  const reference =
+    quote.reference ?? `DEV-${quote.id.slice(0, 8).toUpperCase()}`
+  const config = STATUS_CONFIG[quote.status]
+
+  return (
+    <tr
+      data-testid="quotes-table-row"
+      className="group hover:bg-primary/[0.04] transition-colors"
+    >
+      {/* Reference */}
+      <td className="px-4 py-3">
+        <Link
+          href={`/devis/${quote.id}/preview`}
+          data-testid="action-view"
+          className="font-mono text-xs font-medium text-primary hover:underline underline-offset-4"
+        >
+          {reference}
+        </Link>
+      </td>
+
+      {/* Client */}
+      <td className="px-3 py-3 max-w-[180px]">
+        <span className="text-sm text-foreground truncate block">
+          {quote.project?.client?.name ?? "—"}
+        </span>
+      </td>
+
+      {/* Project */}
+      <td className="px-3 py-3 hidden md:table-cell max-w-[220px]">
+        <span className="text-xs text-muted-foreground truncate block">
+          {quote.project?.title ?? "—"}
+        </span>
+      </td>
+
+      {/* Status — native select overlaid on badge */}
+      <td className="px-3 py-3">
+        <div
+          className="relative inline-flex"
+          data-testid="status-badge"
+          data-status={quote.status}
+        >
+          <span
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-sm border font-medium select-none pointer-events-none",
+              config.className
+            )}
+          >
+            <span className={cn("size-1.5 rounded-full shrink-0", config.dot)} />
+            {config.label}
+            <ChevronDown className="size-2.5 opacity-50" />
+          </span>
+          <select
+            value={quote.status}
+            onChange={(e) => onStatusChange(quote.id, e.target.value)}
+            className="absolute inset-0 opacity-0 cursor-pointer w-full h-full"
+            aria-label="Modifier le statut"
+          >
+            {ALL_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {STATUS_CONFIG[s].label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </td>
+
+      {/* Total HT */}
+      <td className="px-3 py-3 hidden sm:table-cell text-right">
+        <span className="font-mono text-xs text-foreground tabular-nums">
+          {quote.total_ht != null
+            ? new Intl.NumberFormat("fr-FR", {
+                style: "currency",
+                currency: "EUR",
+              }).format(quote.total_ht)
+            : "—"}
+        </span>
+      </td>
+
+      {/* Created at */}
+      <td className="px-3 py-3 hidden lg:table-cell">
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {new Date(quote.created_at).toLocaleDateString("fr-FR", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+          })}
+        </span>
+      </td>
+
+      {/* Actions */}
+      <td className="px-4 py-3">
+        <div className="flex items-center justify-end gap-0.5">
+          <Link
+            href={`/devis/${quote.id}/preview`}
+            title="Voir le devis"
+          >
+            <span className="size-7 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer">
+              <Eye className="size-3.5" />
+            </span>
+          </Link>
+
+          <button
+            onClick={() => onSend(quote.id)}
+            title="Envoyer par email"
+            className="size-7 flex items-center justify-center rounded-sm text-muted-foreground hover:text-amber-400 hover:bg-amber-400/10 transition-colors"
+            data-testid="action-send"
+          >
+            <Send className="size-3.5" />
+          </button>
+
+          <button
+            onClick={() => onDuplicate(quote.id)}
+            title="Dupliquer le devis"
+            className="size-7 flex items-center justify-center rounded-sm text-muted-foreground hover:text-sky-400 hover:bg-sky-400/10 transition-colors"
+            data-testid="action-duplicate"
+          >
+            <Copy className="size-3.5" />
+          </button>
+
+          <button
+            onClick={() => onArchive(quote.id)}
+            title="Archiver le devis"
+            className="size-7 flex items-center justify-center rounded-sm text-muted-foreground hover:text-red-400 hover:bg-red-400/10 transition-colors"
+            data-testid="action-archive"
+          >
+            <Archive className="size-3.5" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/cypress/e2e/devis-list.cy.ts
+++ b/cypress/e2e/devis-list.cy.ts
@@ -1,0 +1,137 @@
+// Tests for /devis — paginated table, filters, quick actions.
+// Auth tests run unconditionally. Table/filter/action tests require
+// CYPRESS_BUREAU_EMAIL + CYPRESS_BUREAU_PASSWORD env vars.
+
+describe("Devis list — /devis", () => {
+  describe("Auth guard", () => {
+    it("redirige les utilisateurs non authentifiés vers /login", () => {
+      cy.visit("/devis", { failOnStatusCode: false })
+      cy.url().should("include", "/login")
+    })
+  })
+
+  describe("Navigation et filtres", () => {
+    before(function () {
+      if (!Cypress.env("BUREAU_EMAIL") || !Cypress.env("BUREAU_PASSWORD")) {
+        this.skip()
+      }
+    })
+
+    beforeEach(() => {
+      cy.session(
+        "bureau",
+        () => {
+          cy.visit("/login")
+          cy.get('input[type="email"]').type(
+            Cypress.env("BUREAU_EMAIL") as string
+          )
+          cy.get('input[type="password"]').type(
+            Cypress.env("BUREAU_PASSWORD") as string
+          )
+          cy.get('button[type="submit"]').click()
+          cy.url().should("include", "/dashboard")
+        },
+        { cacheAcrossSpecs: true }
+      )
+
+      cy.visit("/devis")
+    })
+
+    it("affiche le titre de la page", () => {
+      cy.get("h1").should("contain.text", "Devis")
+    })
+
+    it("affiche le tableau des devis", () => {
+      cy.get('[data-testid="quotes-table"]').should("exist")
+    })
+
+    it("affiche les boutons de filtre par statut", () => {
+      cy.get('[data-testid="status-filters"]').should("be.visible")
+      cy.get('[data-testid="status-filter-draft"]').should("exist")
+      cy.get('[data-testid="status-filter-sent"]').should("exist")
+      cy.get('[data-testid="status-filter-accepted"]').should("exist")
+      cy.get('[data-testid="status-filter-rejected"]').should("exist")
+      cy.get('[data-testid="status-filter-expired"]').should("exist")
+    })
+
+    it("filtre les devis par statut au clic", () => {
+      cy.get('[data-testid="quotes-table-row"]').then(($allRows) => {
+        const totalRows = $allRows.length
+        if (totalRows === 0) return
+
+        cy.get('[data-testid="status-filter-draft"]').click()
+
+        cy.get('[data-testid="quotes-table-row"]').each(($row) => {
+          cy.wrap($row)
+            .find('[data-testid="status-badge"]')
+            .should("have.attr", "data-status", "draft")
+        })
+      })
+    })
+
+    it("efface les filtres de statut après un second clic", () => {
+      cy.get('[data-testid="quotes-table-row"]').then(($allRows) => {
+        const totalBefore = $allRows.length
+        if (totalBefore === 0) return
+
+        cy.get('[data-testid="status-filter-sent"]').click()
+        cy.get('[data-testid="status-filter-sent"]').click()
+
+        cy.get('[data-testid="quotes-table-row"]').should(
+          "have.length",
+          totalBefore
+        )
+      })
+    })
+
+    it("filtre les devis par recherche", () => {
+      cy.get('[data-testid="search-input"]').type("inexistant-xyz-123")
+      cy.get('[data-testid="quotes-table-row"]').should("have.length", 0)
+      cy.get('[data-testid="quotes-table"]').should(
+        "contain.text",
+        "Aucun devis trouvé"
+      )
+    })
+
+    it("efface les filtres avec le bouton Effacer", () => {
+      cy.get('[data-testid="search-input"]').type("inexistant-xyz-123")
+      cy.get('[data-testid="clear-filters"]').click()
+      cy.get('[data-testid="search-input"]').should("have.value", "")
+    })
+
+    it("navigue vers la page de prévisualisation au clic sur la référence", () => {
+      cy.get('[data-testid="quotes-table-row"]').then(($rows) => {
+        if ($rows.length === 0) return
+
+        cy.get('[data-testid="quotes-table-row"]')
+          .first()
+          .find('[data-testid="action-view"]')
+          .click()
+
+        cy.url().should("match", /\/devis\/.+\/preview/)
+      })
+    })
+
+    it("affiche les actions rapides sur chaque ligne", () => {
+      cy.get('[data-testid="quotes-table-row"]').then(($rows) => {
+        if ($rows.length === 0) return
+
+        cy.get('[data-testid="quotes-table-row"]')
+          .first()
+          .within(() => {
+            cy.get('[data-testid="action-send"]').should("exist")
+            cy.get('[data-testid="action-duplicate"]').should("exist")
+            cy.get('[data-testid="action-archive"]').should("exist")
+          })
+      })
+    })
+
+    it("affiche le bouton Nouveau devis", () => {
+      cy.contains("a", "Nouveau devis").should(
+        "have.attr",
+        "href",
+        "/devis/nouveau"
+      )
+    })
+  })
+})

--- a/lib/quotes.ts
+++ b/lib/quotes.ts
@@ -5,6 +5,7 @@ import type {
   QuoteItem,
   QuoteWithItems,
   QuoteWithContext,
+  QuoteForTable,
   CreateQuoteInput,
   UpdateQuoteInput,
   CreateQuoteItemInput,
@@ -21,6 +22,55 @@ export async function getQuotes(supabase: Supabase): Promise<Quote[]> {
 
   if (error) throw error
   return data
+}
+
+export async function getQuotesForTable(
+  supabase: Supabase
+): Promise<QuoteForTable[]> {
+  const { data, error } = await supabase
+    .from("quotes")
+    .select("*, project:projects(id, title, client:clients(id, name))")
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+  return data as unknown as QuoteForTable[]
+}
+
+export async function duplicateQuote(
+  supabase: Supabase,
+  id: string
+): Promise<Quote> {
+  const original = await getQuote(supabase, id)
+
+  const newQuote = await createQuote(supabase, {
+    project_id: original.project_id,
+    tva_rate: original.tva_rate,
+    notes: original.notes,
+    validity_days: original.validity_days,
+  })
+
+  if (original.items.length > 0) {
+    const { error } = await supabase.from("quote_items").insert(
+      original.items.map((item) => ({
+        quote_id: newQuote.id,
+        label: item.label,
+        quantity: item.quantity,
+        unit_price: item.unit_price,
+        unit: item.unit,
+      }))
+    )
+    if (error) throw error
+  }
+
+  const total_ht =
+    Math.round(
+      original.items.reduce(
+        (sum, item) => sum + item.quantity * item.unit_price,
+        0
+      ) * 100
+    ) / 100
+
+  return await updateQuote(supabase, newQuote.id, { total_ht })
 }
 
 export async function getQuote(

--- a/types/index.ts
+++ b/types/index.ts
@@ -24,6 +24,10 @@ export type QuoteWithContext = QuoteWithItems & {
   }
 }
 
+export type QuoteForTable = Quote & {
+  project: (Project & { client: Pick<Client, "id" | "name"> }) | null
+}
+
 export type CreateQuoteInput = {
   project_id: string
   tva_rate?: number


### PR DESCRIPTION
- Nouvelle page `app/(bureau)/devis/page.tsx` listant tous les devis
- Composant client `QuotesTable` : filtres par statut (pills), recherche
  texte, plage de dates, pagination 15 lignes/page
- Badge statut cliquable (select natif overlay) pour mise à jour directe
- Actions rapides par ligne : voir, envoyer, dupliquer, archiver
- `getQuotesForTable()` dans lib/quotes.ts — jointure projet + client
- `duplicateQuote()` dans lib/quotes.ts — copie devis + lignes
- API PATCH `/api/devis/[id]/status` — changement de statut
- API POST `/api/devis/[id]/duplicate` — duplication d'un devis
- Type `QuoteForTable` ajouté à types/index.ts
- Tests Cypress : auth guard, navigation, filtres, actions

https://claude.ai/code/session_01Xff8dgJpRrBQdR6mB2ZSme