### PR TITLE
feat: intégration Gmail API — inbox, OAuth2, lib/gmail.ts

### DIFF
--- a/app/(bureau)/inbox/page.tsx
+++ b/app/(bureau)/inbox/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next"
+import { Mail } from "lucide-react"
+import { supabaseService } from "@/lib/supabase/service"
+import { listEmails } from "@/lib/gmail"
+import { GmailConnectionBanner } from "@/components/inbox/gmail-connection-banner"
+import { EmailList } from "@/components/inbox/email-list"
+
+export const metadata: Metadata = {
+  title: "Messagerie — BTP×AI",
+}
+
+export default async function InboxPage() {
+  const { data: connection } = await supabaseService
+    .from("gmail_connections")
+    .select("email")
+    .limit(1)
+    .single()
+
+  const emails = connection
+    ? await listEmails({ maxResults: 50 }).catch(() => [])
+    : []
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Mail className="size-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground tracking-wider uppercase">
+            Communication
+          </span>
+        </div>
+        <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+          Messagerie
+        </h1>
+        {connection && (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {connection.email} · {emails.length} email{emails.length > 1 ? "s" : ""}
+          </p>
+        )}
+      </div>
+
+      {!connection ? (
+        <GmailConnectionBanner />
+      ) : (
+        <EmailList emails={emails} />
+      )}
+    </div>
+  )
+}

--- a/app/(bureau)/parametres/page.tsx
+++ b/app/(bureau)/parametres/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next"
+import { Settings } from "lucide-react"
+import { supabaseService } from "@/lib/supabase/service"
+import { GmailConnectionSection } from "@/components/parametres/gmail-connection-section"
+
+export const metadata: Metadata = {
+  title: "Paramètres — BTP×AI",
+}
+
+type SearchParams = Promise<{ gmail?: string }>
+
+export default async function ParametresPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const { gmail } = await searchParams
+
+  const { data: connection } = await supabaseService
+    .from("gmail_connections")
+    .select("email, created_at")
+    .limit(1)
+    .single()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Settings className="size-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground tracking-wider uppercase">
+            Configuration
+          </span>
+        </div>
+        <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+          Paramètres
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Gérez les intégrations et la configuration de l'application.
+        </p>
+      </div>
+
+      <div className="max-w-2xl space-y-4">
+        <h2 className="text-sm font-medium text-muted-foreground tracking-wider uppercase">
+          Intégrations
+        </h2>
+        <GmailConnectionSection connection={connection} gmailParam={gmail} />
+      </div>
+    </div>
+  )
+}

--- a/app/api/devis/[id]/duplicate/route.ts
+++ b/app/api/devis/[id]/duplicate/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
 import { createClient } from "@/lib/supabase/server"
 import { duplicateQuote } from "@/lib/quotes"
+import { auth } from "@/lib/auth"
 
 export async function POST(
   _req: NextRequest,
@@ -8,13 +10,12 @@ export async function POST(
 ) {
   const { id } = await params
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
   }
+
+  const supabase = await createClient()
 
   try {
     const quote = await duplicateQuote(supabase, id)

--- a/app/api/devis/[id]/pdf/route.ts
+++ b/app/api/devis/[id]/pdf/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
 import { renderToBuffer } from "@react-pdf/renderer"
 import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { supabaseService } from "@/lib/supabase/service"
 import { getQuoteWithContext } from "@/lib/quotes"
 import { QuotePDFDocument } from "@/components/devis/quote-pdf-document"
+import { auth } from "@/lib/auth"
 
 const BUCKET = "quotes-pdf"
 
@@ -22,13 +24,12 @@ export async function GET(
 ) {
   const { id } = await params
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
   }
+
+  const supabase = await createClient()
 
   let quote
   try {

--- a/app/api/devis/[id]/send/route.ts
+++ b/app/api/devis/[id]/send/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
 import { Resend } from "resend"
 import { renderToBuffer } from "@react-pdf/renderer"
 import React from "react"
@@ -7,6 +8,7 @@ import { getQuoteWithContext, updateQuote } from "@/lib/quotes"
 import { QuotePDFDocument } from "@/components/devis/quote-pdf-document"
 import { buildQuoteEmailHtml, buildQuoteEmailSubject } from "@/lib/email/quote"
 import { env } from "@/lib/env"
+import { auth } from "@/lib/auth"
 
 export async function POST(
   _req: NextRequest,
@@ -14,13 +16,12 @@ export async function POST(
 ) {
   const { id } = await params
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
   }
+
+  const supabase = await createClient()
 
   let quote
   try {

--- a/app/api/devis/[id]/status/route.ts
+++ b/app/api/devis/[id]/status/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
 import { z } from "zod"
 import { createClient } from "@/lib/supabase/server"
 import { updateQuote } from "@/lib/quotes"
+import { auth } from "@/lib/auth"
 
 const schema = z.object({
   status: z.enum(["draft", "sent", "accepted", "rejected", "expired"]),
@@ -13,13 +15,12 @@ export async function PATCH(
 ) {
   const { id } = await params
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
   }
+
+  const supabase = await createClient()
 
   let body: unknown
   try {

--- a/app/api/gmail/auth/route.ts
+++ b/app/api/gmail/auth/route.ts
@@ -23,6 +23,7 @@ export async function GET(_req: NextRequest) {
     return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
   }
 
+  const state = crypto.randomUUID()
   const redirectUri = `${env.NEXT_PUBLIC_APP_URL}/api/gmail/callback`
   const params = new URLSearchParams({
     client_id: env.GOOGLE_CLIENT_ID,
@@ -31,11 +32,20 @@ export async function GET(_req: NextRequest) {
     scope: SCOPES,
     access_type: "offline",
     prompt: "consent",
+    state,
   })
 
-  return NextResponse.redirect(
+  const response = NextResponse.redirect(
     `https://accounts.google.com/o/oauth2/v2/auth?${params}`
   )
+  response.cookies.set("gmail_oauth_state", state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  })
+  return response
 }
 
 export async function DELETE(_req: NextRequest) {

--- a/app/api/gmail/auth/route.ts
+++ b/app/api/gmail/auth/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { supabaseService } from "@/lib/supabase/service"
+import { env } from "@/lib/env"
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/gmail.send",
+  "https://www.googleapis.com/auth/gmail.modify",
+].join(" ")
+
+function requireBureauOrAdmin(role?: string) {
+  return role === "admin" || role === "bureau"
+}
+
+export async function GET(_req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const role = (session.user as { role?: string }).role
+  if (!requireBureauOrAdmin(role)) {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
+  const redirectUri = `${env.NEXT_PUBLIC_APP_URL}/api/gmail/callback`
+  const params = new URLSearchParams({
+    client_id: env.GOOGLE_CLIENT_ID,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: SCOPES,
+    access_type: "offline",
+    prompt: "consent",
+  })
+
+  return NextResponse.redirect(
+    `https://accounts.google.com/o/oauth2/v2/auth?${params}`
+  )
+}
+
+export async function DELETE(_req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const role = (session.user as { role?: string }).role
+  if (!requireBureauOrAdmin(role)) {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
+  const { data: conn } = await supabaseService
+    .from("gmail_connections")
+    .select("access_token")
+    .limit(1)
+    .single()
+
+  if (conn?.access_token) {
+    await fetch(
+      `https://oauth2.googleapis.com/revoke?token=${conn.access_token}`,
+      { method: "POST" }
+    ).catch(() => null)
+  }
+
+  await supabaseService.from("gmail_connections").delete().neq("id", "")
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/gmail/callback/route.ts
+++ b/app/api/gmail/callback/route.ts
@@ -19,6 +19,15 @@ export async function GET(req: NextRequest) {
     )
   }
 
+  const state = req.nextUrl.searchParams.get("state")
+  const expectedState = req.cookies.get("gmail_oauth_state")?.value
+
+  if (!state || !expectedState || state !== expectedState) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
+  }
+
   const redirectUri = `${env.NEXT_PUBLIC_APP_URL}/api/gmail/callback`
 
   const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
@@ -43,6 +52,12 @@ export async function GET(req: NextRequest) {
     access_token: string
     refresh_token: string
     expires_in: number
+  }
+
+  if (!tokens.refresh_token) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
   }
 
   const userInfoRes = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
@@ -71,7 +86,9 @@ export async function GET(req: NextRequest) {
     updated_at: now,
   })
 
-  return NextResponse.redirect(
+  const finalResponse = NextResponse.redirect(
     `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=connected`
   )
+  finalResponse.cookies.delete("gmail_oauth_state")
+  return finalResponse
 }

--- a/app/api/gmail/callback/route.ts
+++ b/app/api/gmail/callback/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { supabaseService } from "@/lib/supabase/service"
+import { env } from "@/lib/env"
+
+export async function GET(req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.redirect(`${env.NEXT_PUBLIC_APP_URL}/login`)
+  }
+
+  const code = req.nextUrl.searchParams.get("code")
+  const error = req.nextUrl.searchParams.get("error")
+
+  if (error || !code) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
+  }
+
+  const redirectUri = `${env.NEXT_PUBLIC_APP_URL}/api/gmail/callback`
+
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+  })
+
+  if (!tokenRes.ok) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
+  }
+
+  const tokens = (await tokenRes.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  const userInfoRes = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+    headers: { Authorization: `Bearer ${tokens.access_token}` },
+  })
+
+  if (!userInfoRes.ok) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
+  }
+
+  const userInfo = (await userInfoRes.json()) as { email: string }
+
+  const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+  const now = new Date().toISOString()
+
+  await supabaseService.from("gmail_connections").delete().neq("id", "")
+
+  await supabaseService.from("gmail_connections").insert({
+    email: userInfo.email,
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    expires_at: expiresAt,
+    created_at: now,
+    updated_at: now,
+  })
+
+  return NextResponse.redirect(
+    `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=connected`
+  )
+}

--- a/app/api/gmail/messages/[id]/route.ts
+++ b/app/api/gmail/messages/[id]/route.ts
@@ -10,6 +10,11 @@ export async function GET(
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
 
+  const role = (session.user as { role?: string }).role
+  if (role !== "admin" && role !== "bureau") {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
   const { id } = await params
 
   try {

--- a/app/api/gmail/messages/[id]/route.ts
+++ b/app/api/gmail/messages/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { getEmail, markAsRead } from "@/lib/gmail"
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const { id } = await params
+
+  try {
+    const email = await getEmail(id)
+    await markAsRead(id).catch(() => null)
+    return NextResponse.json({ email })
+  } catch (err) {
+    console.error("Erreur getEmail:", err)
+    return NextResponse.json({ error: "Impossible de charger l'email" }, { status: 500 })
+  }
+}

--- a/app/api/gmail/send/route.ts
+++ b/app/api/gmail/send/route.ts
@@ -15,6 +15,11 @@ export async function POST(req: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
 
+  const role = (session.user as { role?: string }).role
+  if (role !== "admin" && role !== "bureau") {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
   let body: unknown
   try {
     body = await req.json()

--- a/app/api/gmail/send/route.ts
+++ b/app/api/gmail/send/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { z } from "zod"
+import { auth } from "@/lib/auth"
+import { sendEmail } from "@/lib/gmail"
+
+const sendSchema = z.object({
+  to: z.string().email(),
+  subject: z.string().min(1),
+  body: z.string().min(1),
+  replyToMessageId: z.string().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps invalide" }, { status: 400 })
+  }
+
+  const parsed = sendSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Données invalides" }, { status: 422 })
+  }
+
+  try {
+    await sendEmail(parsed.data.to, parsed.data.subject, parsed.data.body, parsed.data.replyToMessageId)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error("Erreur sendEmail:", err)
+    return NextResponse.json({ error: "Erreur lors de l'envoi" }, { status: 500 })
+  }
+}

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+type Props = {
+  messageId: string
+}
+
+export function EmailDetail({ messageId }: Props) {
+  return (
+    <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+      Chargement de l'email {messageId}...
+    </div>
+  )
+}

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -94,7 +94,7 @@ export function EmailDetail({ messageId }: Props) {
         {email.body.startsWith("<") ? (
           <iframe
             srcDoc={email.body}
-            sandbox="allow-same-origin"
+            sandbox=""
             className="w-full min-h-[400px] border-0"
             title="Contenu de l'email"
           />

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -1,13 +1,151 @@
 "use client"
 
+import { useEffect, useState, useTransition } from "react"
+import { Reply, Loader2, Send, X } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import type { EmailDetail } from "@/types"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "sonner"
+
+const replySchema = z.object({
+  body: z.string().min(1, "Le message ne peut pas être vide"),
+})
+type ReplyForm = z.infer<typeof replySchema>
+
 type Props = {
   messageId: string
 }
 
 export function EmailDetail({ messageId }: Props) {
+  const [email, setEmail] = useState<EmailDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [showReply, setShowReply] = useState(false)
+  const [isSending, startSending] = useTransition()
+
+  const form = useForm<ReplyForm>({
+    resolver: zodResolver(replySchema),
+    defaultValues: { body: "" },
+  })
+
+  useEffect(() => {
+    setEmail(null)
+    setShowReply(false)
+    form.reset()
+
+    setIsLoading(true)
+    fetch(`/api/gmail/messages/${messageId}`)
+      .then((r) => r.json())
+      .then((data: { email: EmailDetail }) => setEmail(data.email))
+      .catch(() => toast.error("Impossible de charger l'email"))
+      .finally(() => setIsLoading(false))
+  }, [messageId, form])
+
+  function onSubmit(values: ReplyForm) {
+    if (!email) return
+    startSending(async () => {
+      const res = await fetch("/api/gmail/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          to: email.from,
+          subject: email.subject.startsWith("Re:") ? email.subject : `Re: ${email.subject}`,
+          body: values.body,
+          replyToMessageId: email.id,
+        }),
+      })
+      if (!res.ok) {
+        toast.error("Erreur lors de l'envoi")
+        return
+      }
+      toast.success("Réponse envoyée")
+      setShowReply(false)
+      form.reset()
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!email) return null
+
   return (
-    <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-      Chargement de l'email {messageId}...
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-border space-y-1">
+        <h2 className="font-semibold text-foreground text-lg">
+          {email.subject || "(Sans objet)"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          De : <span className="text-foreground">{email.from}</span>
+        </p>
+        <p className="text-xs text-muted-foreground">{email.date}</p>
+      </div>
+
+      {/* Corps */}
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {email.body.startsWith("<") ? (
+          <iframe
+            srcDoc={email.body}
+            sandbox="allow-same-origin"
+            className="w-full min-h-[400px] border-0"
+            title="Contenu de l'email"
+          />
+        ) : (
+          <pre className="text-sm text-foreground whitespace-pre-wrap font-sans">
+            {email.body}
+          </pre>
+        )}
+      </div>
+
+      {/* Réponse */}
+      <div className="px-6 py-4 border-t border-border">
+        {!showReply ? (
+          <Button variant="outline" size="sm" onClick={() => setShowReply(true)}>
+            <Reply className="size-4" />
+            Répondre
+          </Button>
+        ) : (
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+            <Textarea
+              placeholder="Votre réponse..."
+              rows={5}
+              {...form.register("body")}
+            />
+            {form.formState.errors.body && (
+              <p className="text-xs text-destructive">
+                {form.formState.errors.body.message}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <Button type="submit" size="sm" disabled={isSending}>
+                {isSending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Send className="size-4" />
+                )}
+                Envoyer
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => { setShowReply(false); form.reset() }}
+              >
+                <X className="size-4" />
+                Annuler
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/inbox/email-list.tsx
+++ b/components/inbox/email-list.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import type { EmailSummary } from "@/types"
+
+type Props = {
+  emails: EmailSummary[]
+}
+
+export function EmailList({ emails }: Props) {
+  return (
+    <div>
+      {emails.length === 0 && (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          Aucun email dans la boîte de réception.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/inbox/email-list.tsx
+++ b/components/inbox/email-list.tsx
@@ -1,19 +1,93 @@
 "use client"
 
+import { useState } from "react"
+import { formatDistanceToNow } from "date-fns"
+import { fr } from "date-fns/locale"
+import { cn } from "@/lib/utils"
 import type { EmailSummary } from "@/types"
+import { EmailDetail } from "./email-detail"
 
 type Props = {
   emails: EmailSummary[]
 }
 
+function formatEmailDate(dateStr: string): string {
+  try {
+    return formatDistanceToNow(new Date(dateStr), { addSuffix: true, locale: fr })
+  } catch {
+    return dateStr
+  }
+}
+
 export function EmailList({ emails }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(
+    emails[0]?.id ?? null
+  )
+  const [readIds, setReadIds] = useState<Set<string>>(
+    new Set(emails.filter((e) => e.isRead).map((e) => e.id))
+  )
+
+  function handleSelect(id: string) {
+    setSelectedId(id)
+    setReadIds((prev) => new Set([...prev, id]))
+  }
+
+  if (emails.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-8 text-center">
+        Aucun email dans la boîte de réception.
+      </p>
+    )
+  }
+
   return (
-    <div>
-      {emails.length === 0 && (
-        <p className="text-sm text-muted-foreground py-8 text-center">
-          Aucun email dans la boîte de réception.
-        </p>
-      )}
+    <div className="flex gap-0 border border-border rounded-lg overflow-hidden min-h-[600px]">
+      {/* Liste */}
+      <div className="w-full lg:w-80 xl:w-96 shrink-0 border-r border-border overflow-y-auto">
+        {emails.map((email) => {
+          const isRead = readIds.has(email.id)
+          const isSelected = selectedId === email.id
+          return (
+            <button
+              key={email.id}
+              onClick={() => handleSelect(email.id)}
+              className={cn(
+                "w-full text-left px-4 py-3 border-b border-border transition-colors",
+                isSelected
+                  ? "bg-primary/10"
+                  : "hover:bg-muted/50",
+                !isRead && "bg-blue-50/50"
+              )}
+            >
+              <div className="flex items-start justify-between gap-2 mb-1">
+                <span className={cn("text-sm truncate", !isRead && "font-semibold text-foreground")}>
+                  {email.from.replace(/<.*>/, "").trim() || email.from}
+                </span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {formatEmailDate(email.date)}
+                </span>
+              </div>
+              <p className={cn("text-sm truncate", isRead ? "text-muted-foreground" : "text-foreground font-medium")}>
+                {email.subject || "(Sans objet)"}
+              </p>
+              <p className="text-xs text-muted-foreground truncate mt-0.5">
+                {email.snippet}
+              </p>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Détail */}
+      <div className="flex-1 hidden lg:block">
+        {selectedId ? (
+          <EmailDetail messageId={selectedId} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Sélectionnez un email
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/inbox/gmail-connection-banner.tsx
+++ b/components/inbox/gmail-connection-banner.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link"
+import { Mail } from "lucide-react"
+import { buttonVariants } from "@/components/ui/button"
+
+export function GmailConnectionBanner() {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-muted/30 p-8 text-center space-y-4">
+      <div className="flex justify-center">
+        <div className="size-12 rounded-full bg-primary/10 flex items-center justify-center">
+          <Mail className="size-6 text-primary" />
+        </div>
+      </div>
+      <div>
+        <h3 className="font-medium text-foreground">Aucune boîte mail connectée</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Connectez la boîte Gmail de l'entreprise pour accéder à vos emails.
+        </p>
+      </div>
+      <Link href="/parametres" className={buttonVariants({ variant: "default" })}>
+        Configurer dans les paramètres
+      </Link>
+    </div>
+  )
+}

--- a/components/parametres/gmail-connection-section.tsx
+++ b/components/parametres/gmail-connection-section.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useState } from "react"
+import { Mail, CheckCircle, XCircle, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+type Props = {
+  connection: { email: string; created_at: string } | null
+  gmailParam?: string
+}
+
+export function GmailConnectionSection({ connection, gmailParam }: Props) {
+  const [isDisconnecting, setIsDisconnecting] = useState(false)
+
+  async function handleDisconnect() {
+    setIsDisconnecting(true)
+    try {
+      await fetch("/api/gmail/auth", { method: "DELETE" })
+      window.location.reload()
+    } finally {
+      setIsDisconnecting(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border p-6 space-y-4">
+      <div className="flex items-center gap-3">
+        <Mail className="size-5 text-muted-foreground" />
+        <div>
+          <h3 className="font-medium text-foreground">Boîte mail</h3>
+          <p className="text-sm text-muted-foreground">
+            Connectez la boîte Gmail de l'entreprise pour gérer les emails depuis l'application.
+          </p>
+        </div>
+      </div>
+
+      {gmailParam === "connected" && (
+        <div className="flex items-center gap-2 text-sm text-green-600 bg-green-50 rounded-md px-3 py-2">
+          <CheckCircle className="size-4" />
+          Boîte mail connectée avec succès.
+        </div>
+      )}
+
+      {gmailParam === "error" && (
+        <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">
+          <XCircle className="size-4" />
+          Erreur lors de la connexion. Veuillez réessayer.
+        </div>
+      )}
+
+      {connection ? (
+        <div className="flex items-center justify-between gap-4">
+          <div className="text-sm">
+            <span className="text-muted-foreground">Connecté en tant que </span>
+            <span className="font-medium text-foreground">{connection.email}</span>
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleDisconnect}
+            disabled={isDisconnecting}
+          >
+            {isDisconnecting && <Loader2 className="size-4 animate-spin" />}
+            Déconnecter
+          </Button>
+        </div>
+      ) : (
+        <a href="/api/gmail/auth">
+          <Button size="sm">
+            <Mail className="size-4" />
+            Connecter Gmail
+          </Button>
+        </a>
+      )}
+    </div>
+  )
+}

--- a/docs/superpowers/plans/2026-04-29-gmail-integration.md
+++ b/docs/superpowers/plans/2026-04-29-gmail-integration.md
@@ -1,0 +1,1696 @@
+# Gmail Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Connecter la boîte mail d'entreprise via Gmail API OAuth2, exposer 4 fonctions dans `lib/gmail.ts`, et créer la page Inbox + section Paramètres.
+
+**Architecture:** Une table `gmail_connections` stocke les tokens OAuth2 d'une seule boîte d'entreprise. Un helper `getValidAccessToken()` dans `lib/gmail.ts` gère le refresh automatique avant chaque appel. Les routes `/api/gmail/auth` et `/api/gmail/callback` gèrent le flow OAuth2. La page `/inbox` charge les emails en RSC, avec des Client Components pour l'interaction.
+
+**Tech Stack:** Next.js 15 App Router, Supabase (service role), Better-Auth (auth check), raw `fetch` vers Gmail API v1, Vitest pour les tests.
+
+---
+
+## File Map
+
+**Créer :**
+- `supabase/migrations/20260429000007_gmail_connections.sql`
+- `lib/gmail.ts`
+- `tests/unit/gmail.test.ts`
+- `app/api/gmail/auth/route.ts`
+- `app/api/gmail/callback/route.ts`
+- `app/(bureau)/inbox/page.tsx`
+- `app/(bureau)/parametres/page.tsx`
+- `components/inbox/email-list.tsx`
+- `components/inbox/email-detail.tsx`
+- `components/inbox/gmail-connection-banner.tsx`
+- `components/parametres/gmail-connection-section.tsx`
+
+**Modifier :**
+- `types/index.ts` — ajouter types Gmail
+- `vitest.config.ts` — ajouter les env vars manquantes pour les tests
+
+---
+
+### Task 1 : Migration DB + env vars de test
+
+**Files:**
+- Create: `supabase/migrations/20260429000007_gmail_connections.sql`
+- Modify: `vitest.config.ts`
+
+- [ ] **Step 1 : Créer la migration**
+
+Créer `supabase/migrations/20260429000007_gmail_connections.sql` :
+
+```sql
+create table public.gmail_connections (
+  id            uuid primary key default gen_random_uuid(),
+  email         text not null,
+  access_token  text not null,
+  refresh_token text not null,
+  expires_at    timestamptz not null,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+alter table public.gmail_connections enable row level security;
+
+create policy "bureau and admin can select gmail_connections"
+  on public.gmail_connections for select
+  using (auth.uid() is not null);
+
+create policy "bureau and admin can insert gmail_connections"
+  on public.gmail_connections for insert
+  with check (auth.uid() is not null);
+
+create policy "bureau and admin can update gmail_connections"
+  on public.gmail_connections for update
+  using (auth.uid() is not null);
+
+create policy "bureau and admin can delete gmail_connections"
+  on public.gmail_connections for delete
+  using (auth.uid() is not null);
+```
+
+- [ ] **Step 2 : Appliquer la migration en local**
+
+```bash
+npm run db:reset
+```
+
+Résultat attendu : la migration s'applique sans erreur.
+
+- [ ] **Step 3 : Ajouter les env vars manquantes dans vitest.config.ts**
+
+Dans `vitest.config.ts`, compléter le bloc `env` :
+
+```ts
+env: {
+  NEXT_PUBLIC_SUPABASE_URL: "http://127.0.0.1:54321",
+  NEXT_PUBLIC_SUPABASE_ANON_KEY:
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRFA0NiK7W9oHQFQRFHE2VIFxSDAoJyGo0k7VCsxhC4",
+  SUPABASE_SERVICE_ROLE_KEY:
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hj04zWl196z2-SBc0",
+  DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+  ANTHROPIC_API_KEY: "test-anthropic-key",
+  BETTER_AUTH_SECRET: "test-better-auth-secret-32-chars-min",
+  BETTER_AUTH_URL: "http://localhost:3000",
+  GOOGLE_CLIENT_ID: "test-google-client-id",
+  GOOGLE_CLIENT_SECRET: "test-google-client-secret",
+  RESEND_API_KEY: "test-resend-key",
+  NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+},
+```
+
+- [ ] **Step 4 : Vérifier que les tests existants passent toujours**
+
+```bash
+npm run test:run
+```
+
+Résultat attendu : tous les tests existants passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add supabase/migrations/20260429000007_gmail_connections.sql vitest.config.ts
+git commit -m "feat: migration table gmail_connections + env vars vitest"
+```
+
+---
+
+### Task 2 : Types Gmail dans `types/index.ts`
+
+**Files:**
+- Modify: `types/index.ts`
+
+- [ ] **Step 1 : Ajouter les types Gmail à la fin de `types/index.ts`**
+
+```ts
+export type GmailConnection = {
+  id: string
+  email: string
+  access_token: string
+  refresh_token: string
+  expires_at: string
+  created_at: string
+  updated_at: string
+}
+
+export type EmailSummary = {
+  id: string
+  threadId: string
+  subject: string
+  from: string
+  date: string
+  snippet: string
+  isRead: boolean
+}
+
+export type EmailDetail = EmailSummary & {
+  body: string
+}
+```
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add types/index.ts
+git commit -m "feat: ajouter types GmailConnection, EmailSummary, EmailDetail"
+```
+
+---
+
+### Task 3 : `lib/gmail.ts` — `getValidAccessToken` + test
+
+**Files:**
+- Create: `lib/gmail.ts`
+- Create: `tests/unit/gmail.test.ts`
+
+- [ ] **Step 1 : Écrire les tests pour `getValidAccessToken`**
+
+Créer `tests/unit/gmail.test.ts` :
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock supabaseService avant tout import de lib/gmail
+vi.mock("@/lib/supabase/service", () => ({
+  supabaseService: {
+    from: vi.fn(),
+  },
+}))
+
+// Mock fetch global
+const mockFetch = vi.fn()
+vi.stubGlobal("fetch", mockFetch)
+
+import { supabaseService } from "@/lib/supabase/service"
+import { getValidAccessToken } from "@/lib/gmail"
+
+const mockSupabase = supabaseService as {
+  from: ReturnType<typeof vi.fn>
+}
+
+function makeBuilder(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve),
+  }
+  for (const method of ["select", "update", "eq", "single", "limit", "order"]) {
+    builder[method] = vi.fn().mockReturnValue(builder)
+  }
+  return builder
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("getValidAccessToken", () => {
+  it("retourne l'access_token existant si non expiré", async () => {
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString()
+    const builder = makeBuilder({
+      data: {
+        id: "conn-1",
+        email: "contact@entreprise.fr",
+        access_token: "valid-token",
+        refresh_token: "refresh-token",
+        expires_at: futureDate,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      error: null,
+    })
+    mockSupabase.from.mockReturnValue(builder)
+
+    const token = await getValidAccessToken()
+    expect(token).toBe("valid-token")
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("rafraîchit le token si expiré et retourne le nouveau token", async () => {
+    const pastDate = new Date(Date.now() - 1000).toISOString()
+    const readBuilder = makeBuilder({
+      data: {
+        id: "conn-1",
+        email: "contact@entreprise.fr",
+        access_token: "expired-token",
+        refresh_token: "refresh-token-xyz",
+        expires_at: pastDate,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      error: null,
+    })
+    const updateBuilder = makeBuilder({ data: null, error: null })
+    mockSupabase.from
+      .mockReturnValueOnce(readBuilder)
+      .mockReturnValueOnce(updateBuilder)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: "new-access-token",
+        expires_in: 3600,
+      }),
+    })
+
+    const token = await getValidAccessToken()
+    expect(token).toBe("new-access-token")
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({ method: "POST" })
+    )
+  })
+
+  it("lève une erreur si aucune connexion Gmail en base", async () => {
+    const builder = makeBuilder({ data: null, error: null })
+    mockSupabase.from.mockReturnValue(builder)
+
+    await expect(getValidAccessToken()).rejects.toThrow(
+      "Aucune connexion Gmail configurée"
+    )
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : FAIL — `getValidAccessToken` n'existe pas.
+
+- [ ] **Step 3 : Créer `lib/gmail.ts` avec `getValidAccessToken`**
+
+```ts
+import { supabaseService } from "@/lib/supabase/service"
+import { env } from "@/lib/env"
+import type { EmailSummary, EmailDetail } from "@/types"
+
+const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me"
+const TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+export async function getValidAccessToken(): Promise<string> {
+  const { data: conn } = await supabaseService
+    .from("gmail_connections")
+    .select("*")
+    .limit(1)
+    .single()
+
+  if (!conn) throw new Error("Aucune connexion Gmail configurée")
+
+  const isExpired = new Date(conn.expires_at) <= new Date()
+  if (!isExpired) return conn.access_token
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      refresh_token: conn.refresh_token,
+      grant_type: "refresh_token",
+    }),
+  })
+
+  if (!res.ok) throw new Error("Échec du refresh token Gmail")
+
+  const { access_token, expires_in } = (await res.json()) as {
+    access_token: string
+    expires_in: number
+  }
+
+  const newExpiresAt = new Date(Date.now() + expires_in * 1000).toISOString()
+
+  await supabaseService
+    .from("gmail_connections")
+    .update({ access_token, expires_at: newExpiresAt, updated_at: new Date().toISOString() })
+    .eq("id", conn.id)
+
+  return access_token
+}
+```
+
+- [ ] **Step 4 : Relancer les tests**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : les 3 tests `getValidAccessToken` passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add lib/gmail.ts tests/unit/gmail.test.ts
+git commit -m "feat: getValidAccessToken avec refresh automatique"
+```
+
+---
+
+### Task 4 : `lib/gmail.ts` — `listEmails` + test
+
+**Files:**
+- Modify: `lib/gmail.ts`
+- Modify: `tests/unit/gmail.test.ts`
+
+- [ ] **Step 1 : Ajouter les tests pour `listEmails`**
+
+Ajouter l'import en haut de `tests/unit/gmail.test.ts` (après les imports existants) et les tests à la fin du fichier :
+
+```ts
+import { listEmails } from "@/lib/gmail"
+
+// Helper : simule getValidAccessToken (token valide, pas de refresh)
+function mockValidToken() {
+  const futureDate = new Date(Date.now() + 3600 * 1000).toISOString()
+  const builder = makeBuilder({
+    data: {
+      id: "conn-1",
+      email: "contact@entreprise.fr",
+      access_token: "valid-token",
+      refresh_token: "refresh-token",
+      expires_at: futureDate,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    error: null,
+  })
+  mockSupabase.from.mockReturnValue(builder)
+}
+
+describe("listEmails", () => {
+  it("retourne une liste d'EmailSummary", async () => {
+    mockValidToken()
+
+    // Réponse messages.list
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          messages: [{ id: "msg-1", threadId: "thread-1" }],
+        }),
+      })
+      // Réponse messages.get pour msg-1
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "msg-1",
+          threadId: "thread-1",
+          labelIds: ["INBOX", "UNREAD"],
+          snippet: "Bonjour, j'aimerais un devis...",
+          payload: {
+            headers: [
+              { name: "Subject", value: "Demande de devis" },
+              { name: "From", value: "Jean Dupont <jean@example.com>" },
+              { name: "Date", value: "Mon, 28 Apr 2026 10:00:00 +0200" },
+            ],
+          },
+        }),
+      })
+
+    const emails = await listEmails({ maxResults: 10 })
+
+    expect(emails).toHaveLength(1)
+    expect(emails[0]).toEqual({
+      id: "msg-1",
+      threadId: "thread-1",
+      subject: "Demande de devis",
+      from: "Jean Dupont <jean@example.com>",
+      date: "Mon, 28 Apr 2026 10:00:00 +0200",
+      snippet: "Bonjour, j'aimerais un devis...",
+      isRead: false,
+    })
+  })
+
+  it("retourne un tableau vide si aucun message", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    })
+
+    const emails = await listEmails()
+    expect(emails).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : FAIL — `listEmails` n'existe pas.
+
+- [ ] **Step 3 : Ajouter `listEmails` dans `lib/gmail.ts`**
+
+Ajouter après `getValidAccessToken` :
+
+```ts
+function getHeader(headers: { name: string; value: string }[], name: string): string {
+  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? ""
+}
+
+export async function listEmails(
+  options: { maxResults?: number; query?: string } = {}
+): Promise<EmailSummary[]> {
+  const token = await getValidAccessToken()
+  const { maxResults = 20, query } = options
+
+  const params = new URLSearchParams({ maxResults: String(maxResults), labelIds: "INBOX" })
+  if (query) params.set("q", query)
+
+  const listRes = await fetch(`${GMAIL_API}/messages?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!listRes.ok) throw new Error("Erreur Gmail API (list)")
+
+  const listData = (await listRes.json()) as { messages?: { id: string; threadId: string }[] }
+  if (!listData.messages?.length) return []
+
+  const messages = await Promise.all(
+    listData.messages.map(async ({ id, threadId }) => {
+      const msgRes = await fetch(
+        `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!msgRes.ok) throw new Error(`Erreur Gmail API (get ${id})`)
+
+      const msg = (await msgRes.json()) as {
+        id: string
+        threadId: string
+        labelIds: string[]
+        snippet: string
+        payload: { headers: { name: string; value: string }[] }
+      }
+
+      return {
+        id: msg.id,
+        threadId: msg.threadId,
+        subject: getHeader(msg.payload.headers, "Subject"),
+        from: getHeader(msg.payload.headers, "From"),
+        date: getHeader(msg.payload.headers, "Date"),
+        snippet: msg.snippet,
+        isRead: !msg.labelIds.includes("UNREAD"),
+      }
+    })
+  )
+
+  return messages
+}
+```
+
+- [ ] **Step 4 : Relancer les tests**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add lib/gmail.ts tests/unit/gmail.test.ts
+git commit -m "feat: listEmails avec mapping EmailSummary"
+```
+
+---
+
+### Task 5 : `lib/gmail.ts` — `getEmail` + test
+
+**Files:**
+- Modify: `lib/gmail.ts`
+- Modify: `tests/unit/gmail.test.ts`
+
+- [ ] **Step 1 : Ajouter les tests pour `getEmail`**
+
+Ajouter l'import en haut du fichier et les tests à la fin de `tests/unit/gmail.test.ts` :
+
+```ts
+import { getEmail } from "@/lib/gmail"
+
+describe("getEmail", () => {
+  it("retourne un EmailDetail avec body texte brut", async () => {
+    mockValidToken()
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg-1",
+        threadId: "thread-1",
+        labelIds: ["INBOX"],
+        snippet: "Bonjour...",
+        payload: {
+          mimeType: "text/plain",
+          headers: [
+            { name: "Subject", value: "Test" },
+            { name: "From", value: "jean@example.com" },
+            { name: "Date", value: "Mon, 28 Apr 2026 10:00:00 +0200" },
+          ],
+          body: {
+            data: Buffer.from("Corps du message").toString("base64url"),
+          },
+        },
+      }),
+    })
+
+    const email = await getEmail("msg-1")
+    expect(email.id).toBe("msg-1")
+    expect(email.body).toBe("Corps du message")
+    expect(email.isRead).toBe(true)
+  })
+
+  it("retourne le body HTML depuis un message multipart", async () => {
+    mockValidToken()
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg-2",
+        threadId: "thread-2",
+        labelIds: ["INBOX", "UNREAD"],
+        snippet: "...",
+        payload: {
+          mimeType: "multipart/alternative",
+          headers: [
+            { name: "Subject", value: "Multipart" },
+            { name: "From", value: "a@b.com" },
+            { name: "Date", value: "Mon, 28 Apr 2026 10:00:00 +0200" },
+          ],
+          parts: [
+            {
+              mimeType: "text/plain",
+              body: { data: Buffer.from("texte brut").toString("base64url") },
+            },
+            {
+              mimeType: "text/html",
+              body: { data: Buffer.from("<p>HTML</p>").toString("base64url") },
+            },
+          ],
+        },
+      }),
+    })
+
+    const email = await getEmail("msg-2")
+    expect(email.body).toBe("<p>HTML</p>")
+    expect(email.isRead).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : FAIL — `getEmail` n'existe pas.
+
+- [ ] **Step 3 : Ajouter `getEmail` dans `lib/gmail.ts`**
+
+```ts
+type GmailPart = {
+  mimeType: string
+  body?: { data?: string }
+  parts?: GmailPart[]
+}
+
+function extractBody(part: GmailPart): string {
+  if (part.mimeType === "text/html" && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf-8")
+  }
+  if (part.parts) {
+    const html = part.parts.find((p) => p.mimeType === "text/html")
+    if (html?.body?.data) return Buffer.from(html.body.data, "base64url").toString("utf-8")
+    const plain = part.parts.find((p) => p.mimeType === "text/plain")
+    if (plain?.body?.data) return Buffer.from(plain.body.data, "base64url").toString("utf-8")
+  }
+  if (part.mimeType === "text/plain" && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf-8")
+  }
+  return ""
+}
+
+export async function getEmail(id: string): Promise<EmailDetail> {
+  const token = await getValidAccessToken()
+
+  const res = await fetch(`${GMAIL_API}/messages/${id}?format=full`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(`Erreur Gmail API (getEmail ${id})`)
+
+  const msg = (await res.json()) as {
+    id: string
+    threadId: string
+    labelIds: string[]
+    snippet: string
+    payload: GmailPart & { headers: { name: string; value: string }[] }
+  }
+
+  return {
+    id: msg.id,
+    threadId: msg.threadId,
+    subject: getHeader(msg.payload.headers, "Subject"),
+    from: getHeader(msg.payload.headers, "From"),
+    date: getHeader(msg.payload.headers, "Date"),
+    snippet: msg.snippet,
+    isRead: !msg.labelIds.includes("UNREAD"),
+    body: extractBody(msg.payload),
+  }
+}
+```
+
+- [ ] **Step 4 : Relancer les tests**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add lib/gmail.ts tests/unit/gmail.test.ts
+git commit -m "feat: getEmail avec extraction body HTML/texte"
+```
+
+---
+
+### Task 6 : `lib/gmail.ts` — `sendEmail` + test
+
+**Files:**
+- Modify: `lib/gmail.ts`
+- Modify: `tests/unit/gmail.test.ts`
+
+- [ ] **Step 1 : Ajouter les tests pour `sendEmail`**
+
+Ajouter l'import en haut du fichier et les tests à la fin de `tests/unit/gmail.test.ts` :
+
+```ts
+import { sendEmail } from "@/lib/gmail"
+
+describe("sendEmail", () => {
+  it("envoie un email via Gmail API avec encodage base64url", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: "sent-1" }) })
+
+    await sendEmail("client@example.com", "Votre devis", "Bonjour,\n\nVeuillez trouver...")
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${GMAIL_API}/messages/send`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer valid-token",
+          "Content-Type": "application/json",
+        }),
+      })
+    )
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    const decoded = Buffer.from(callBody.raw, "base64url").toString("utf-8")
+    expect(decoded).toContain("To: client@example.com")
+    expect(decoded).toContain("Subject: Votre devis")
+    expect(decoded).toContain("Bonjour,")
+  })
+
+  it("inclut In-Reply-To quand replyToMessageId est fourni", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: "sent-2" }) })
+
+    await sendEmail("a@b.com", "Re: Test", "Réponse", "original-msg-id")
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    const decoded = Buffer.from(callBody.raw, "base64url").toString("utf-8")
+    expect(decoded).toContain("In-Reply-To: original-msg-id")
+    expect(decoded).toContain("References: original-msg-id")
+  })
+})
+```
+
+Note : `GMAIL_API` doit être exporté depuis `lib/gmail.ts` pour les tests, ou on peut utiliser l'URL complète dans le test. Utilisez l'URL complète : `"https://gmail.googleapis.com/gmail/v1/users/me/messages/send"`.
+
+Corriger le test précédent pour utiliser l'URL complète :
+```ts
+expect(mockFetch).toHaveBeenCalledWith(
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+  expect.objectContaining({ method: "POST" })
+)
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : FAIL — `sendEmail` n'existe pas.
+
+- [ ] **Step 3 : Ajouter `sendEmail` dans `lib/gmail.ts`**
+
+```ts
+export async function sendEmail(
+  to: string,
+  subject: string,
+  body: string,
+  replyToMessageId?: string
+): Promise<void> {
+  const token = await getValidAccessToken()
+
+  const lines = [
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/plain; charset=utf-8",
+  ]
+  if (replyToMessageId) {
+    lines.push(`In-Reply-To: ${replyToMessageId}`)
+    lines.push(`References: ${replyToMessageId}`)
+  }
+  lines.push("", body)
+
+  const raw = Buffer.from(lines.join("\r\n")).toString("base64url")
+
+  const res = await fetch(`${GMAIL_API}/messages/send`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ raw }),
+  })
+
+  if (!res.ok) throw new Error("Erreur Gmail API (sendEmail)")
+}
+```
+
+- [ ] **Step 4 : Relancer les tests**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add lib/gmail.ts tests/unit/gmail.test.ts
+git commit -m "feat: sendEmail avec encodage RFC 2822 base64url"
+```
+
+---
+
+### Task 7 : `lib/gmail.ts` — `markAsRead` + test
+
+**Files:**
+- Modify: `lib/gmail.ts`
+- Modify: `tests/unit/gmail.test.ts`
+
+- [ ] **Step 1 : Ajouter le test pour `markAsRead`**
+
+Ajouter l'import en haut du fichier et le test à la fin de `tests/unit/gmail.test.ts` :
+
+```ts
+import { markAsRead } from "@/lib/gmail"
+
+describe("markAsRead", () => {
+  it("appelle Gmail API PATCH avec removeLabelIds UNREAD", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+
+    await markAsRead("msg-1")
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-1/modify",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ removeLabelIds: ["UNREAD"] }),
+      })
+    )
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : FAIL — `markAsRead` n'existe pas.
+
+- [ ] **Step 3 : Ajouter `markAsRead` dans `lib/gmail.ts`**
+
+```ts
+export async function markAsRead(id: string): Promise<void> {
+  const token = await getValidAccessToken()
+
+  const res = await fetch(`${GMAIL_API}/messages/${id}/modify`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ removeLabelIds: ["UNREAD"] }),
+  })
+
+  if (!res.ok) throw new Error(`Erreur Gmail API (markAsRead ${id})`)
+}
+```
+
+- [ ] **Step 4 : Lancer tous les tests Gmail**
+
+```bash
+npm run test:run -- tests/unit/gmail.test.ts
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Step 5 : Lancer tous les tests du projet**
+
+```bash
+npm run test:run
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add lib/gmail.ts tests/unit/gmail.test.ts
+git commit -m "feat: markAsRead — supprime label UNREAD via Gmail API"
+```
+
+---
+
+### Task 8 : Routes API OAuth2 (`/api/gmail/auth` et `/api/gmail/callback`)
+
+**Files:**
+- Create: `app/api/gmail/auth/route.ts`
+- Create: `app/api/gmail/callback/route.ts`
+
+- [ ] **Step 1 : Créer `app/api/gmail/auth/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { supabaseService } from "@/lib/supabase/service"
+import { env } from "@/lib/env"
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/gmail.send",
+  "https://www.googleapis.com/auth/gmail.modify",
+].join(" ")
+
+function requireBureauOrAdmin(role?: string) {
+  return role === "admin" || role === "bureau"
+}
+
+export async function GET(_req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const role = (session.user as { role?: string }).role
+  if (!requireBureauOrAdmin(role)) {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
+  const redirectUri = `${env.NEXT_PUBLIC_APP_URL}/api/gmail/callback`
+  const params = new URLSearchParams({
+    client_id: env.GOOGLE_CLIENT_ID,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: SCOPES,
+    access_type: "offline",
+    prompt: "consent",
+  })
+
+  return NextResponse.redirect(
+    `https://accounts.google.com/o/oauth2/v2/auth?${params}`
+  )
+}
+
+export async function DELETE(_req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const role = (session.user as { role?: string }).role
+  if (!requireBureauOrAdmin(role)) {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
+  const { data: conn } = await supabaseService
+    .from("gmail_connections")
+    .select("access_token")
+    .limit(1)
+    .single()
+
+  if (conn?.access_token) {
+    await fetch(
+      `https://oauth2.googleapis.com/revoke?token=${conn.access_token}`,
+      { method: "POST" }
+    ).catch(() => null)
+  }
+
+  await supabaseService.from("gmail_connections").delete().neq("id", "")
+
+  return NextResponse.json({ success: true })
+}
+```
+
+- [ ] **Step 2 : Créer `app/api/gmail/callback/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { supabaseService } from "@/lib/supabase/service"
+import { env } from "@/lib/env"
+
+export async function GET(req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.redirect(`${env.NEXT_PUBLIC_APP_URL}/login`)
+  }
+
+  const code = req.nextUrl.searchParams.get("code")
+  const error = req.nextUrl.searchParams.get("error")
+
+  if (error || !code) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
+  }
+
+  const redirectUri = `${env.NEXT_PUBLIC_APP_URL}/api/gmail/callback`
+
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+  })
+
+  if (!tokenRes.ok) {
+    return NextResponse.redirect(
+      `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=error`
+    )
+  }
+
+  const tokens = (await tokenRes.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  const userInfoRes = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+    headers: { Authorization: `Bearer ${tokens.access_token}` },
+  })
+  const userInfo = (await userInfoRes.json()) as { email: string }
+
+  const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+  const now = new Date().toISOString()
+
+  await supabaseService.from("gmail_connections").delete().neq("id", "")
+
+  await supabaseService.from("gmail_connections").insert({
+    email: userInfo.email,
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    expires_at: expiresAt,
+    created_at: now,
+    updated_at: now,
+  })
+
+  return NextResponse.redirect(
+    `${env.NEXT_PUBLIC_APP_URL}/parametres?gmail=connected`
+  )
+}
+```
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add app/api/gmail/auth/route.ts app/api/gmail/callback/route.ts
+git commit -m "feat: routes OAuth2 Gmail (auth, callback, disconnect)"
+```
+
+---
+
+### Task 9 : Page Paramètres avec section Gmail
+
+**Files:**
+- Create: `app/(bureau)/parametres/page.tsx`
+- Create: `components/parametres/gmail-connection-section.tsx`
+
+- [ ] **Step 1 : Créer `components/parametres/gmail-connection-section.tsx`**
+
+```tsx
+"use client"
+
+import { useState } from "react"
+import { Mail, CheckCircle, XCircle, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+type Props = {
+  connection: { email: string; created_at: string } | null
+  gmailParam?: string
+}
+
+export function GmailConnectionSection({ connection, gmailParam }: Props) {
+  const [isDisconnecting, setIsDisconnecting] = useState(false)
+
+  async function handleDisconnect() {
+    setIsDisconnecting(true)
+    try {
+      await fetch("/api/gmail/auth", { method: "DELETE" })
+      window.location.reload()
+    } finally {
+      setIsDisconnecting(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border p-6 space-y-4">
+      <div className="flex items-center gap-3">
+        <Mail className="size-5 text-muted-foreground" />
+        <div>
+          <h3 className="font-medium text-foreground">Boîte mail</h3>
+          <p className="text-sm text-muted-foreground">
+            Connectez la boîte Gmail de l'entreprise pour gérer les emails depuis l'application.
+          </p>
+        </div>
+      </div>
+
+      {gmailParam === "connected" && (
+        <div className="flex items-center gap-2 text-sm text-green-600 bg-green-50 rounded-md px-3 py-2">
+          <CheckCircle className="size-4" />
+          Boîte mail connectée avec succès.
+        </div>
+      )}
+
+      {gmailParam === "error" && (
+        <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">
+          <XCircle className="size-4" />
+          Erreur lors de la connexion. Veuillez réessayer.
+        </div>
+      )}
+
+      {connection ? (
+        <div className="flex items-center justify-between gap-4">
+          <div className="text-sm">
+            <span className="text-muted-foreground">Connecté en tant que </span>
+            <span className="font-medium text-foreground">{connection.email}</span>
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleDisconnect}
+            disabled={isDisconnecting}
+          >
+            {isDisconnecting && <Loader2 className="size-4 animate-spin" />}
+            Déconnecter
+          </Button>
+        </div>
+      ) : (
+        <a href="/api/gmail/auth">
+          <Button size="sm">
+            <Mail className="size-4" />
+            Connecter Gmail
+          </Button>
+        </a>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2 : Créer `app/(bureau)/parametres/page.tsx`**
+
+```tsx
+import type { Metadata } from "next"
+import { Settings } from "lucide-react"
+import { supabaseService } from "@/lib/supabase/service"
+import { GmailConnectionSection } from "@/components/parametres/gmail-connection-section"
+
+export const metadata: Metadata = {
+  title: "Paramètres — BTP×AI",
+}
+
+type SearchParams = Promise<{ gmail?: string }>
+
+export default async function ParametresPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const { gmail } = await searchParams
+
+  const { data: connection } = await supabaseService
+    .from("gmail_connections")
+    .select("email, created_at")
+    .limit(1)
+    .single()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Settings className="size-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground tracking-wider uppercase">
+            Configuration
+          </span>
+        </div>
+        <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+          Paramètres
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Gérez les intégrations et la configuration de l'application.
+        </p>
+      </div>
+
+      <div className="max-w-2xl space-y-4">
+        <h2 className="text-sm font-medium text-muted-foreground tracking-wider uppercase">
+          Intégrations
+        </h2>
+        <GmailConnectionSection connection={connection} gmailParam={gmail} />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add app/(bureau)/parametres/page.tsx components/parametres/gmail-connection-section.tsx
+git commit -m "feat: page paramètres avec section connexion Gmail"
+```
+
+---
+
+### Task 10 : Page Inbox + `GmailConnectionBanner`
+
+**Files:**
+- Create: `app/(bureau)/inbox/page.tsx`
+- Create: `components/inbox/gmail-connection-banner.tsx`
+
+- [ ] **Step 1 : Créer `components/inbox/gmail-connection-banner.tsx`**
+
+```tsx
+import Link from "next/link"
+import { Mail } from "lucide-react"
+import { buttonVariants } from "@/components/ui/button"
+
+export function GmailConnectionBanner() {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-muted/30 p-8 text-center space-y-4">
+      <div className="flex justify-center">
+        <div className="size-12 rounded-full bg-primary/10 flex items-center justify-center">
+          <Mail className="size-6 text-primary" />
+        </div>
+      </div>
+      <div>
+        <h3 className="font-medium text-foreground">Aucune boîte mail connectée</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Connectez la boîte Gmail de l'entreprise pour accéder à vos emails.
+        </p>
+      </div>
+      <Link href="/parametres" className={buttonVariants({ variant: "default" })}>
+        Configurer dans les paramètres
+      </Link>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2 : Créer `app/(bureau)/inbox/page.tsx`**
+
+```tsx
+import type { Metadata } from "next"
+import { Mail } from "lucide-react"
+import { supabaseService } from "@/lib/supabase/service"
+import { listEmails } from "@/lib/gmail"
+import { GmailConnectionBanner } from "@/components/inbox/gmail-connection-banner"
+import { EmailList } from "@/components/inbox/email-list"
+
+export const metadata: Metadata = {
+  title: "Messagerie — BTP×AI",
+}
+
+export default async function InboxPage() {
+  const { data: connection } = await supabaseService
+    .from("gmail_connections")
+    .select("email")
+    .limit(1)
+    .single()
+
+  const emails = connection
+    ? await listEmails({ maxResults: 50 }).catch(() => [])
+    : []
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Mail className="size-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground tracking-wider uppercase">
+            Communication
+          </span>
+        </div>
+        <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+          Messagerie
+        </h1>
+        {connection && (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {connection.email} · {emails.length} email{emails.length > 1 ? "s" : ""}
+          </p>
+        )}
+      </div>
+
+      {!connection ? (
+        <GmailConnectionBanner />
+      ) : (
+        <EmailList emails={emails} />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add app/(bureau)/inbox/page.tsx components/inbox/gmail-connection-banner.tsx
+git commit -m "feat: page inbox avec GmailConnectionBanner et chargement RSC"
+```
+
+---
+
+### Task 11 : Composant `EmailList`
+
+**Files:**
+- Create: `components/inbox/email-list.tsx`
+
+- [ ] **Step 1 : Créer `components/inbox/email-list.tsx`**
+
+```tsx
+"use client"
+
+import { useState } from "react"
+import { formatDistanceToNow } from "date-fns"
+import { fr } from "date-fns/locale"
+import { cn } from "@/lib/utils"
+import type { EmailSummary, EmailDetail } from "@/types"
+import { EmailDetail as EmailDetailComponent } from "./email-detail"
+
+type Props = {
+  emails: EmailSummary[]
+}
+
+function formatEmailDate(dateStr: string): string {
+  try {
+    return formatDistanceToNow(new Date(dateStr), { addSuffix: true, locale: fr })
+  } catch {
+    return dateStr
+  }
+}
+
+export function EmailList({ emails }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(
+    emails[0]?.id ?? null
+  )
+  const [readIds, setReadIds] = useState<Set<string>>(
+    new Set(emails.filter((e) => e.isRead).map((e) => e.id))
+  )
+
+  function handleSelect(id: string) {
+    setSelectedId(id)
+    setReadIds((prev) => new Set([...prev, id]))
+  }
+
+  if (emails.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-8 text-center">
+        Aucun email dans la boîte de réception.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex gap-0 border border-border rounded-lg overflow-hidden min-h-[600px]">
+      {/* Liste */}
+      <div className="w-full lg:w-80 xl:w-96 shrink-0 border-r border-border overflow-y-auto">
+        {emails.map((email) => {
+          const isRead = readIds.has(email.id)
+          const isSelected = selectedId === email.id
+          return (
+            <button
+              key={email.id}
+              onClick={() => handleSelect(email.id)}
+              className={cn(
+                "w-full text-left px-4 py-3 border-b border-border transition-colors",
+                isSelected
+                  ? "bg-primary/10"
+                  : "hover:bg-muted/50",
+                !isRead && "bg-blue-50/50"
+              )}
+            >
+              <div className="flex items-start justify-between gap-2 mb-1">
+                <span className={cn("text-sm truncate", !isRead && "font-semibold text-foreground")}>
+                  {email.from.replace(/<.*>/, "").trim() || email.from}
+                </span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {formatEmailDate(email.date)}
+                </span>
+              </div>
+              <p className={cn("text-sm truncate", isRead ? "text-muted-foreground" : "text-foreground font-medium")}>
+                {email.subject || "(Sans objet)"}
+              </p>
+              <p className="text-xs text-muted-foreground truncate mt-0.5">
+                {email.snippet}
+              </p>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Détail */}
+      <div className="flex-1 hidden lg:block">
+        {selectedId ? (
+          <EmailDetailComponent messageId={selectedId} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Sélectionnez un email
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+Note : ce composant requiert `date-fns`. Installer avec :
+```bash
+npm install date-fns
+```
+
+- [ ] **Step 2 : Installer `date-fns`**
+
+```bash
+npm install date-fns
+```
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add components/inbox/email-list.tsx package.json package-lock.json
+git commit -m "feat: composant EmailList avec sélection et badge non-lu"
+```
+
+---
+
+### Task 12 : Composant `EmailDetail`
+
+**Files:**
+- Create: `components/inbox/email-detail.tsx`
+
+- [ ] **Step 1 : Créer `components/inbox/email-detail.tsx`**
+
+```tsx
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import { Reply, Loader2, Send, X } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import type { EmailDetail } from "@/types"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "sonner"
+
+const replySchema = z.object({
+  body: z.string().min(1, "Le message ne peut pas être vide"),
+})
+type ReplyForm = z.infer<typeof replySchema>
+
+type Props = {
+  messageId: string
+}
+
+export function EmailDetail({ messageId }: Props) {
+  const [email, setEmail] = useState<EmailDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [showReply, setShowReply] = useState(false)
+  const [isSending, startSending] = useTransition()
+
+  const form = useForm<ReplyForm>({
+    resolver: zodResolver(replySchema),
+    defaultValues: { body: "" },
+  })
+
+  useEffect(() => {
+    setEmail(null)
+    setShowReply(false)
+    form.reset()
+
+    setIsLoading(true)
+    fetch(`/api/gmail/messages/${messageId}`)
+      .then((r) => r.json())
+      .then((data: { email: EmailDetail }) => setEmail(data.email))
+      .catch(() => toast.error("Impossible de charger l'email"))
+      .finally(() => setIsLoading(false))
+  }, [messageId, form])
+
+  function onSubmit(values: ReplyForm) {
+    if (!email) return
+    startSending(async () => {
+      const res = await fetch("/api/gmail/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          to: email.from,
+          subject: email.subject.startsWith("Re:") ? email.subject : `Re: ${email.subject}`,
+          body: values.body,
+          replyToMessageId: email.id,
+        }),
+      })
+      if (!res.ok) {
+        toast.error("Erreur lors de l'envoi")
+        return
+      }
+      toast.success("Réponse envoyée")
+      setShowReply(false)
+      form.reset()
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!email) return null
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-border space-y-1">
+        <h2 className="font-semibold text-foreground text-lg">
+          {email.subject || "(Sans objet)"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          De : <span className="text-foreground">{email.from}</span>
+        </p>
+        <p className="text-xs text-muted-foreground">{email.date}</p>
+      </div>
+
+      {/* Corps */}
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {email.body.startsWith("<") ? (
+          <iframe
+            srcDoc={email.body}
+            sandbox="allow-same-origin"
+            className="w-full min-h-[400px] border-0"
+            title="Contenu de l'email"
+          />
+        ) : (
+          <pre className="text-sm text-foreground whitespace-pre-wrap font-sans">
+            {email.body}
+          </pre>
+        )}
+      </div>
+
+      {/* Réponse */}
+      <div className="px-6 py-4 border-t border-border">
+        {!showReply ? (
+          <Button variant="outline" size="sm" onClick={() => setShowReply(true)}>
+            <Reply className="size-4" />
+            Répondre
+          </Button>
+        ) : (
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+            <Textarea
+              placeholder="Votre réponse..."
+              rows={5}
+              {...form.register("body")}
+            />
+            {form.formState.errors.body && (
+              <p className="text-xs text-destructive">
+                {form.formState.errors.body.message}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <Button type="submit" size="sm" disabled={isSending}>
+                {isSending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Send className="size-4" />
+                )}
+                Envoyer
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => { setShowReply(false); form.reset() }}
+              >
+                <X className="size-4" />
+                Annuler
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2 : Créer la route API `/api/gmail/messages/[id]/route.ts`**
+
+Ce composant appelle `/api/gmail/messages/[id]` et `/api/gmail/send` — il faut créer ces routes.
+
+Créer `app/api/gmail/messages/[id]/route.ts` :
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { getEmail, markAsRead } from "@/lib/gmail"
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const { id } = await params
+
+  try {
+    const email = await getEmail(id)
+    await markAsRead(id).catch(() => null)
+    return NextResponse.json({ email })
+  } catch (err) {
+    console.error("Erreur getEmail:", err)
+    return NextResponse.json({ error: "Impossible de charger l'email" }, { status: 500 })
+  }
+}
+```
+
+Créer `app/api/gmail/send/route.ts` :
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+import { headers } from "next/headers"
+import { z } from "zod"
+import { auth } from "@/lib/auth"
+import { sendEmail } from "@/lib/gmail"
+
+const sendSchema = z.object({
+  to: z.string().email(),
+  subject: z.string().min(1),
+  body: z.string().min(1),
+  replyToMessageId: z.string().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps invalide" }, { status: 400 })
+  }
+
+  const parsed = sendSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Données invalides" }, { status: 422 })
+  }
+
+  try {
+    await sendEmail(parsed.data.to, parsed.data.subject, parsed.data.body, parsed.data.replyToMessageId)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error("Erreur sendEmail:", err)
+    return NextResponse.json({ error: "Erreur lors de l'envoi" }, { status: 500 })
+  }
+}
+```
+
+- [ ] **Step 3 : Lancer tous les tests**
+
+```bash
+npm run test:run
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Step 4 : Commit final**
+
+```bash
+git add components/inbox/email-detail.tsx app/api/gmail/messages/[id]/route.ts app/api/gmail/send/route.ts
+git commit -m "feat: EmailDetail avec formulaire réponse inline et routes API"
+```
+
+---
+
+## Récapitulatif des fichiers créés/modifiés
+
+| Fichier | Action |
+|---------|--------|
+| `supabase/migrations/20260429000007_gmail_connections.sql` | Créé |
+| `vitest.config.ts` | Modifié |
+| `types/index.ts` | Modifié |
+| `lib/gmail.ts` | Créé |
+| `tests/unit/gmail.test.ts` | Créé |
+| `app/api/gmail/auth/route.ts` | Créé |
+| `app/api/gmail/callback/route.ts` | Créé |
+| `app/api/gmail/messages/[id]/route.ts` | Créé |
+| `app/api/gmail/send/route.ts` | Créé |
+| `app/(bureau)/inbox/page.tsx` | Créé |
+| `app/(bureau)/parametres/page.tsx` | Créé |
+| `components/inbox/gmail-connection-banner.tsx` | Créé |
+| `components/inbox/email-list.tsx` | Créé |
+| `components/inbox/email-detail.tsx` | Créé |
+| `components/parametres/gmail-connection-section.tsx` | Créé |

--- a/docs/superpowers/specs/2026-04-29-gmail-integration-design.md
+++ b/docs/superpowers/specs/2026-04-29-gmail-integration-design.md
@@ -1,0 +1,172 @@
+# Gmail Integration — Design Spec
+
+**Date :** 2026-04-29  
+**Branche :** `15-email-connexion-gmail-api`  
+**Périmètre :** Connexion OAuth2 Gmail API, `lib/gmail.ts`, page Inbox, tests Vitest
+
+---
+
+## Contexte
+
+L'application doit accéder à la boîte mail de l'entreprise via Gmail API. Il s'agit d'**une seule boîte partagée** (ex. `contact@entreprise.fr`), pas d'un accès par utilisateur. Les rôles `admin` et `bureau` peuvent connecter/déconnecter la boîte. La connexion se gère depuis la page `/parametres`.
+
+---
+
+## Base de données
+
+Nouvelle table `gmail_connections` :
+
+```sql
+CREATE TABLE gmail_connections (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email         text NOT NULL,
+  access_token  text NOT NULL,
+  refresh_token text NOT NULL,
+  expires_at    timestamptz NOT NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- Une seule ligne autorisée (vérification applicative à l'upsert)
+- RLS : lecture/écriture pour `admin` et `bureau` uniquement
+- Pas de FK utilisateur — ressource d'entreprise
+
+---
+
+## Flow OAuth2
+
+### Connexion
+
+1. Clic "Connecter Gmail" sur `/parametres` → `GET /api/gmail/auth`
+2. Redirect vers Google consent screen — scopes : `gmail.readonly`, `gmail.send`, `gmail.modify`
+3. Callback Google → `GET /api/gmail/callback?code=...`
+4. Échange du code → `access_token` + `refresh_token`, upsert dans `gmail_connections`
+5. Redirect vers `/parametres?gmail=connected`
+
+### Déconnexion
+
+- `DELETE /api/gmail/auth` → supprime la ligne en base, révoque le token côté Google
+
+### Refresh automatique
+
+- Dans `lib/gmail.ts`, helper `getValidAccessToken()` vérifie `expires_at` avant chaque appel
+- Si expiré : appel Google `/oauth2/v4/token`, mise à jour de `access_token` et `expires_at` en base
+- Toutes les fonctions publiques passent par ce helper — jamais d'accès direct aux tokens
+
+---
+
+## `lib/gmail.ts`
+
+### Types
+
+```ts
+interface EmailSummary {
+  id: string
+  threadId: string
+  subject: string
+  from: string
+  date: string
+  snippet: string
+  isRead: boolean
+}
+
+interface EmailDetail extends EmailSummary {
+  body: string  // HTML ou texte brut
+}
+```
+
+### Fonctions publiques
+
+```ts
+listEmails(options?: { maxResults?: number; query?: string }): Promise<EmailSummary[]>
+getEmail(id: string): Promise<EmailDetail>
+sendEmail(to: string, subject: string, body: string, replyToMessageId?: string): Promise<void>
+markAsRead(id: string): Promise<void>
+```
+
+### Helper interne
+
+```ts
+getValidAccessToken(): Promise<string>
+// Lit gmail_connections, rafraîchit si expiré, retourne un access_token valide
+```
+
+---
+
+## API Routes
+
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/gmail/auth` | Démarre le flow OAuth2 (redirect Google) |
+| `GET` | `/api/gmail/callback` | Reçoit le code, stocke les tokens |
+| `DELETE` | `/api/gmail/auth` | Déconnecte la boîte |
+
+Les routes vérifient que l'utilisateur est connecté avec le rôle `admin` ou `bureau` via Better-Auth.
+
+---
+
+## Page Inbox (`/inbox`)
+
+### Layout
+
+- **Desktop** : deux colonnes (liste à gauche, détail à droite)
+- **Mobile** : une colonne (liste d'abord, détail en vue séparée)
+
+### Liste des emails
+
+- Chargée en RSC via `listEmails({ maxResults: 50 })`
+- Chaque item : expéditeur, objet, snippet, date, badge "non lu"
+- Clic → charge le détail + appelle `markAsRead`
+
+### Détail email
+
+- Corps HTML affiché dans un `<iframe>` sandboxé (`sandbox="allow-same-origin"`) ou texte brut
+- Bouton "Répondre" → formulaire inline (destinataire pré-rempli, objet avec `Re:`)
+- Envoi via `sendEmail` avec `replyToMessageId`
+
+### État non-connecté
+
+- Si aucune ligne dans `gmail_connections` → bannière informative avec lien vers `/parametres`
+
+### Composants
+
+- `InboxLayout` (Server Component) — chargement initial de la liste
+- `EmailList` (Client Component) — sélection, état actif
+- `EmailDetail` (Client Component) — affichage détail, formulaire réponse
+- `GmailConnectionBanner` — affiché si non connecté
+
+---
+
+## Page Paramètres (`/parametres`)
+
+Ajout d'une section "Boîte mail" :
+
+- **État connecté** : email connecté + date connexion + bouton "Déconnecter"
+- **État non-connecté** : bouton "Connecter Gmail"
+
+---
+
+## Tests Vitest
+
+Fichier : `lib/gmail.test.ts`
+
+| Fonction | Cas testés |
+|----------|-----------|
+| `getValidAccessToken` | Token valide (pas de refresh), token expiré (refresh + update base) |
+| `listEmails` | Construction requête, mapping `EmailSummary`, liste vide |
+| `getEmail` | Parsing body HTML, parsing texte brut |
+| `sendEmail` | Encodage base64url RFC 2822, avec et sans `replyToMessageId` |
+| `markAsRead` | Appel PATCH avec `{ removeLabelIds: ['UNREAD'] }` |
+
+Mocks : client Supabase via `vi.mock`, `fetch` global pour les appels Google API.
+
+---
+
+## Variables d'environnement
+
+Déjà présentes dans `lib/env.ts` :
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+
+Aucune variable supplémentaire nécessaire. L'URL de callback est construite depuis `NEXT_PUBLIC_APP_URL`.

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -67,7 +67,7 @@ export async function listEmails(
   if (!listData.messages?.length) return []
 
   const messages = await Promise.all(
-    listData.messages.map(async ({ id, threadId }) => {
+    listData.messages.map(async ({ id }) => {
       const msgRes = await fetch(
         `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`,
         { headers: { Authorization: `Bearer ${token}` } }

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -44,3 +44,55 @@ export async function getValidAccessToken(): Promise<string> {
 
   return access_token
 }
+
+function getHeader(headers: { name: string; value: string }[], name: string): string {
+  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? ""
+}
+
+export async function listEmails(
+  options: { maxResults?: number; query?: string } = {}
+): Promise<EmailSummary[]> {
+  const token = await getValidAccessToken()
+  const { maxResults = 20, query } = options
+
+  const params = new URLSearchParams({ maxResults: String(maxResults), labelIds: "INBOX" })
+  if (query) params.set("q", query)
+
+  const listRes = await fetch(`${GMAIL_API}/messages?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!listRes.ok) throw new Error("Erreur Gmail API (list)")
+
+  const listData = (await listRes.json()) as { messages?: { id: string; threadId: string }[] }
+  if (!listData.messages?.length) return []
+
+  const messages = await Promise.all(
+    listData.messages.map(async ({ id, threadId }) => {
+      const msgRes = await fetch(
+        `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!msgRes.ok) throw new Error(`Erreur Gmail API (get ${id})`)
+
+      const msg = (await msgRes.json()) as {
+        id: string
+        threadId: string
+        labelIds: string[]
+        snippet: string
+        payload: { headers: { name: string; value: string }[] }
+      }
+
+      return {
+        id: msg.id,
+        threadId: msg.threadId,
+        subject: getHeader(msg.payload.headers, "Subject"),
+        from: getHeader(msg.payload.headers, "From"),
+        date: getHeader(msg.payload.headers, "Date"),
+        snippet: msg.snippet,
+        isRead: !msg.labelIds.includes("UNREAD"),
+      }
+    })
+  )
+
+  return messages
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -146,3 +146,37 @@ export async function getEmail(id: string): Promise<EmailDetail> {
     body: extractBody(msg.payload),
   }
 }
+
+export async function sendEmail(
+  to: string,
+  subject: string,
+  body: string,
+  replyToMessageId?: string
+): Promise<void> {
+  const token = await getValidAccessToken()
+
+  const lines = [
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/plain; charset=utf-8",
+  ]
+  if (replyToMessageId) {
+    lines.push(`In-Reply-To: ${replyToMessageId}`)
+    lines.push(`References: ${replyToMessageId}`)
+  }
+  lines.push("", body)
+
+  const raw = Buffer.from(lines.join("\r\n")).toString("base64url")
+
+  const res = await fetch(`${GMAIL_API}/messages/send`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ raw }),
+  })
+
+  if (!res.ok) throw new Error("Erreur Gmail API (sendEmail)")
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,0 +1,46 @@
+import { supabaseService } from "@/lib/supabase/service"
+import { env } from "@/lib/env"
+import type { EmailSummary, EmailDetail } from "@/types"
+
+const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me"
+const TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+export async function getValidAccessToken(): Promise<string> {
+  const { data: conn } = await supabaseService
+    .from("gmail_connections")
+    .select("*")
+    .limit(1)
+    .single()
+
+  if (!conn) throw new Error("Aucune connexion Gmail configurée")
+
+  const isExpired = new Date(conn.expires_at) <= new Date()
+  if (!isExpired) return conn.access_token
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      refresh_token: conn.refresh_token,
+      grant_type: "refresh_token",
+    }),
+  })
+
+  if (!res.ok) throw new Error("Échec du refresh token Gmail")
+
+  const { access_token, expires_in } = (await res.json()) as {
+    access_token: string
+    expires_in: number
+  }
+
+  const newExpiresAt = new Date(Date.now() + expires_in * 1000).toISOString()
+
+  await supabaseService
+    .from("gmail_connections")
+    .update({ access_token, expires_at: newExpiresAt, updated_at: new Date().toISOString() })
+    .eq("id", conn.id)
+
+  return access_token
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -96,3 +96,53 @@ export async function listEmails(
 
   return messages
 }
+
+type GmailPart = {
+  mimeType: string
+  body?: { data?: string }
+  parts?: GmailPart[]
+}
+
+function extractBody(part: GmailPart): string {
+  if (part.mimeType === "text/html" && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf-8")
+  }
+  if (part.parts) {
+    const html = part.parts.find((p) => p.mimeType === "text/html")
+    if (html?.body?.data) return Buffer.from(html.body.data, "base64url").toString("utf-8")
+    const plain = part.parts.find((p) => p.mimeType === "text/plain")
+    if (plain?.body?.data) return Buffer.from(plain.body.data, "base64url").toString("utf-8")
+  }
+  if (part.mimeType === "text/plain" && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf-8")
+  }
+  return ""
+}
+
+export async function getEmail(id: string): Promise<EmailDetail> {
+  const token = await getValidAccessToken()
+
+  const res = await fetch(`${GMAIL_API}/messages/${id}?format=full`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(`Erreur Gmail API (getEmail ${id})`)
+
+  const msg = (await res.json()) as {
+    id: string
+    threadId: string
+    labelIds: string[]
+    snippet: string
+    payload: GmailPart & { headers: { name: string; value: string }[] }
+  }
+
+  return {
+    id: msg.id,
+    threadId: msg.threadId,
+    subject: getHeader(msg.payload.headers, "Subject"),
+    from: getHeader(msg.payload.headers, "From"),
+    date: getHeader(msg.payload.headers, "Date"),
+    snippet: msg.snippet,
+    isRead: !msg.labelIds.includes("UNREAD"),
+    body: extractBody(msg.payload),
+  }
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -180,3 +180,18 @@ export async function sendEmail(
 
   if (!res.ok) throw new Error("Erreur Gmail API (sendEmail)")
 }
+
+export async function markAsRead(id: string): Promise<void> {
+  const token = await getValidAccessToken()
+
+  const res = await fetch(`${GMAIL_API}/messages/${id}/modify`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ removeLabelIds: ["UNREAD"] }),
+  })
+
+  if (!res.ok) throw new Error(`Erreur Gmail API (markAsRead ${id})`)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "better-auth": "^1.6.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^1.11.0",
         "next": "16.2.4",
         "next-themes": "^0.4.6",
@@ -140,7 +141,7 @@
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
@@ -157,7 +158,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
@@ -174,7 +175,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -184,7 +185,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -797,7 +798,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -810,7 +811,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -830,7 +831,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -854,7 +855,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -882,7 +883,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -905,7 +906,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -930,7 +931,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1257,7 +1258,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1279,7 +1279,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1434,7 +1433,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -2819,7 +2818,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2836,7 +2834,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2853,7 +2850,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2870,7 +2866,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2887,7 +2882,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2904,7 +2898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,7 +2914,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,7 +2930,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2955,7 +2946,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2972,7 +2962,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2989,7 +2978,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3006,7 +2994,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3023,7 +3010,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3039,7 +3025,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3061,7 +3046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3078,7 +3062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3696,7 +3679,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6116,7 +6098,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -6485,7 +6467,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -6549,6 +6531,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -6577,7 +6569,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6959,7 +6951,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -8254,7 +8246,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8730,7 +8721,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -9342,7 +9333,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -9611,7 +9602,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9680,7 +9671,7 @@
       "version": "29.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
       "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
@@ -9721,7 +9712,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -9950,7 +9941,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9971,7 +9961,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9992,7 +9981,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10013,7 +10001,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10034,7 +10021,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10055,7 +10041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10076,7 +10061,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10097,7 +10081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10118,7 +10101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10139,7 +10121,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10160,7 +10141,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10515,7 +10495,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-engine": {
@@ -11353,7 +11333,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -11859,7 +11839,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12396,7 +12376,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -13385,7 +13365,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/systeminformation": {
@@ -13627,7 +13607,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -13911,7 +13891,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -14343,7 +14323,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -14385,7 +14365,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -14395,7 +14375,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -14405,7 +14385,7 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -14652,7 +14632,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -14662,7 +14642,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "better-auth": "^1.6.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^1.11.0",
     "next": "16.2.4",
     "next-themes": "^0.4.6",

--- a/supabase/migrations/20260429000007_gmail_connections.sql
+++ b/supabase/migrations/20260429000007_gmail_connections.sql
@@ -1,0 +1,27 @@
+create table public.gmail_connections (
+  id            uuid primary key default gen_random_uuid(),
+  email         text not null,
+  access_token  text not null,
+  refresh_token text not null,
+  expires_at    timestamptz not null,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+alter table public.gmail_connections enable row level security;
+
+create policy "bureau and admin can select gmail_connections"
+  on public.gmail_connections for select
+  using (auth.uid() is not null);
+
+create policy "bureau and admin can insert gmail_connections"
+  on public.gmail_connections for insert
+  with check (auth.uid() is not null);
+
+create policy "bureau and admin can update gmail_connections"
+  on public.gmail_connections for update
+  using (auth.uid() is not null);
+
+create policy "bureau and admin can delete gmail_connections"
+  on public.gmail_connections for delete
+  using (auth.uid() is not null);

--- a/tests/unit/gmail.test.ts
+++ b/tests/unit/gmail.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock supabaseService avant tout import de lib/gmail
+vi.mock("@/lib/supabase/service", () => ({
+  supabaseService: {
+    from: vi.fn(),
+  },
+}))
+
+// Mock fetch global
+const mockFetch = vi.fn()
+vi.stubGlobal("fetch", mockFetch)
+
+import { supabaseService } from "@/lib/supabase/service"
+import { getValidAccessToken } from "@/lib/gmail"
+
+const mockSupabase = supabaseService as {
+  from: ReturnType<typeof vi.fn>
+}
+
+function makeBuilder(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve),
+  }
+  for (const method of ["select", "update", "eq", "single", "limit", "order", "delete", "insert", "neq"]) {
+    builder[method] = vi.fn().mockReturnValue(builder)
+  }
+  return builder
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("getValidAccessToken", () => {
+  it("retourne l'access_token existant si non expiré", async () => {
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString()
+    const builder = makeBuilder({
+      data: {
+        id: "conn-1",
+        email: "contact@entreprise.fr",
+        access_token: "valid-token",
+        refresh_token: "refresh-token",
+        expires_at: futureDate,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      error: null,
+    })
+    mockSupabase.from.mockReturnValue(builder)
+
+    const token = await getValidAccessToken()
+    expect(token).toBe("valid-token")
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("rafraîchit le token si expiré et retourne le nouveau token", async () => {
+    const pastDate = new Date(Date.now() - 1000).toISOString()
+    const readBuilder = makeBuilder({
+      data: {
+        id: "conn-1",
+        email: "contact@entreprise.fr",
+        access_token: "expired-token",
+        refresh_token: "refresh-token-xyz",
+        expires_at: pastDate,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      error: null,
+    })
+    const updateBuilder = makeBuilder({ data: null, error: null })
+    mockSupabase.from
+      .mockReturnValueOnce(readBuilder)
+      .mockReturnValueOnce(updateBuilder)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: "new-access-token",
+        expires_in: 3600,
+      }),
+    })
+
+    const token = await getValidAccessToken()
+    expect(token).toBe("new-access-token")
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({ method: "POST" })
+    )
+  })
+
+  it("lève une erreur si aucune connexion Gmail en base", async () => {
+    const builder = makeBuilder({ data: null, error: null })
+    mockSupabase.from.mockReturnValue(builder)
+
+    await expect(getValidAccessToken()).rejects.toThrow(
+      "Aucune connexion Gmail configurée"
+    )
+  })
+})

--- a/tests/unit/gmail.test.ts
+++ b/tests/unit/gmail.test.ts
@@ -12,7 +12,7 @@ const mockFetch = vi.fn()
 vi.stubGlobal("fetch", mockFetch)
 
 import { supabaseService } from "@/lib/supabase/service"
-import { getValidAccessToken, listEmails } from "@/lib/gmail"
+import { getValidAccessToken, listEmails, getEmail } from "@/lib/gmail"
 
 const mockSupabase = supabaseService as {
   from: ReturnType<typeof vi.fn>
@@ -168,5 +168,73 @@ describe("listEmails", () => {
 
     const emails = await listEmails()
     expect(emails).toEqual([])
+  })
+})
+
+describe("getEmail", () => {
+  it("retourne un EmailDetail avec body texte brut", async () => {
+    mockValidToken()
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg-1",
+        threadId: "thread-1",
+        labelIds: ["INBOX"],
+        snippet: "Bonjour...",
+        payload: {
+          mimeType: "text/plain",
+          headers: [
+            { name: "Subject", value: "Test" },
+            { name: "From", value: "jean@example.com" },
+            { name: "Date", value: "Mon, 28 Apr 2026 10:00:00 +0200" },
+          ],
+          body: {
+            data: Buffer.from("Corps du message").toString("base64url"),
+          },
+        },
+      }),
+    })
+
+    const email = await getEmail("msg-1")
+    expect(email.id).toBe("msg-1")
+    expect(email.body).toBe("Corps du message")
+    expect(email.isRead).toBe(true)
+  })
+
+  it("retourne le body HTML depuis un message multipart", async () => {
+    mockValidToken()
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg-2",
+        threadId: "thread-2",
+        labelIds: ["INBOX", "UNREAD"],
+        snippet: "...",
+        payload: {
+          mimeType: "multipart/alternative",
+          headers: [
+            { name: "Subject", value: "Multipart" },
+            { name: "From", value: "a@b.com" },
+            { name: "Date", value: "Mon, 28 Apr 2026 10:00:00 +0200" },
+          ],
+          parts: [
+            {
+              mimeType: "text/plain",
+              body: { data: Buffer.from("texte brut").toString("base64url") },
+            },
+            {
+              mimeType: "text/html",
+              body: { data: Buffer.from("<p>HTML</p>").toString("base64url") },
+            },
+          ],
+        },
+      }),
+    })
+
+    const email = await getEmail("msg-2")
+    expect(email.body).toBe("<p>HTML</p>")
+    expect(email.isRead).toBe(false)
   })
 })

--- a/tests/unit/gmail.test.ts
+++ b/tests/unit/gmail.test.ts
@@ -12,7 +12,7 @@ const mockFetch = vi.fn()
 vi.stubGlobal("fetch", mockFetch)
 
 import { supabaseService } from "@/lib/supabase/service"
-import { getValidAccessToken, listEmails, getEmail } from "@/lib/gmail"
+import { getValidAccessToken, listEmails, getEmail, sendEmail } from "@/lib/gmail"
 
 const mockSupabase = supabaseService as {
   from: ReturnType<typeof vi.fn>
@@ -236,5 +236,43 @@ describe("getEmail", () => {
     const email = await getEmail("msg-2")
     expect(email.body).toBe("<p>HTML</p>")
     expect(email.isRead).toBe(false)
+  })
+})
+
+describe("sendEmail", () => {
+  it("envoie un email via Gmail API avec encodage base64url", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: "sent-1" }) })
+
+    await sendEmail("client@example.com", "Votre devis", "Bonjour,\n\nVeuillez trouver...")
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer valid-token",
+          "Content-Type": "application/json",
+        }),
+      })
+    )
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    const decoded = Buffer.from(callBody.raw, "base64url").toString("utf-8")
+    expect(decoded).toContain("To: client@example.com")
+    expect(decoded).toContain("Subject: Votre devis")
+    expect(decoded).toContain("Bonjour,")
+  })
+
+  it("inclut In-Reply-To quand replyToMessageId est fourni", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: "sent-2" }) })
+
+    await sendEmail("a@b.com", "Re: Test", "Réponse", "original-msg-id")
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    const decoded = Buffer.from(callBody.raw, "base64url").toString("utf-8")
+    expect(decoded).toContain("In-Reply-To: original-msg-id")
+    expect(decoded).toContain("References: original-msg-id")
   })
 })

--- a/tests/unit/gmail.test.ts
+++ b/tests/unit/gmail.test.ts
@@ -12,7 +12,7 @@ const mockFetch = vi.fn()
 vi.stubGlobal("fetch", mockFetch)
 
 import { supabaseService } from "@/lib/supabase/service"
-import { getValidAccessToken } from "@/lib/gmail"
+import { getValidAccessToken, listEmails } from "@/lib/gmail"
 
 const mockSupabase = supabaseService as {
   from: ReturnType<typeof vi.fn>
@@ -31,6 +31,24 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
 beforeEach(() => {
   vi.clearAllMocks()
 })
+
+// Helper : simule getValidAccessToken (token valide, pas de refresh)
+function mockValidToken() {
+  const futureDate = new Date(Date.now() + 3600 * 1000).toISOString()
+  const builder = makeBuilder({
+    data: {
+      id: "conn-1",
+      email: "contact@entreprise.fr",
+      access_token: "valid-token",
+      refresh_token: "refresh-token",
+      expires_at: futureDate,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    error: null,
+  })
+  mockSupabase.from.mockReturnValue(builder)
+}
 
 describe("getValidAccessToken", () => {
   it("retourne l'access_token existant si non expiré", async () => {
@@ -96,5 +114,59 @@ describe("getValidAccessToken", () => {
     await expect(getValidAccessToken()).rejects.toThrow(
       "Aucune connexion Gmail configurée"
     )
+  })
+})
+
+describe("listEmails", () => {
+  it("retourne une liste d'EmailSummary", async () => {
+    mockValidToken()
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          messages: [{ id: "msg-1", threadId: "thread-1" }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "msg-1",
+          threadId: "thread-1",
+          labelIds: ["INBOX", "UNREAD"],
+          snippet: "Bonjour, j'aimerais un devis...",
+          payload: {
+            headers: [
+              { name: "Subject", value: "Demande de devis" },
+              { name: "From", value: "Jean Dupont <jean@example.com>" },
+              { name: "Date", value: "Mon, 28 Apr 2026 10:00:00 +0200" },
+            ],
+          },
+        }),
+      })
+
+    const emails = await listEmails({ maxResults: 10 })
+
+    expect(emails).toHaveLength(1)
+    expect(emails[0]).toEqual({
+      id: "msg-1",
+      threadId: "thread-1",
+      subject: "Demande de devis",
+      from: "Jean Dupont <jean@example.com>",
+      date: "Mon, 28 Apr 2026 10:00:00 +0200",
+      snippet: "Bonjour, j'aimerais un devis...",
+      isRead: false,
+    })
+  })
+
+  it("retourne un tableau vide si aucun message", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    })
+
+    const emails = await listEmails()
+    expect(emails).toEqual([])
   })
 })

--- a/tests/unit/gmail.test.ts
+++ b/tests/unit/gmail.test.ts
@@ -12,7 +12,7 @@ const mockFetch = vi.fn()
 vi.stubGlobal("fetch", mockFetch)
 
 import { supabaseService } from "@/lib/supabase/service"
-import { getValidAccessToken, listEmails, getEmail, sendEmail } from "@/lib/gmail"
+import { getValidAccessToken, listEmails, getEmail, sendEmail, markAsRead } from "@/lib/gmail"
 
 const mockSupabase = supabaseService as {
   from: ReturnType<typeof vi.fn>
@@ -274,5 +274,22 @@ describe("sendEmail", () => {
     const decoded = Buffer.from(callBody.raw, "base64url").toString("utf-8")
     expect(decoded).toContain("In-Reply-To: original-msg-id")
     expect(decoded).toContain("References: original-msg-id")
+  })
+})
+
+describe("markAsRead", () => {
+  it("appelle Gmail API avec removeLabelIds UNREAD", async () => {
+    mockValidToken()
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+
+    await markAsRead("msg-1")
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-1/modify",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ removeLabelIds: ["UNREAD"] }),
+      })
+    )
   })
 })

--- a/tests/unit/gmail.test.ts
+++ b/tests/unit/gmail.test.ts
@@ -14,7 +14,7 @@ vi.stubGlobal("fetch", mockFetch)
 import { supabaseService } from "@/lib/supabase/service"
 import { getValidAccessToken, listEmails, getEmail, sendEmail, markAsRead } from "@/lib/gmail"
 
-const mockSupabase = supabaseService as {
+const mockSupabase = supabaseService as unknown as {
   from: ReturnType<typeof vi.fn>
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -80,3 +80,27 @@ export type UpdateQuoteItemInput = Partial<{
   unit_price: number
   unit: string | null
 }>
+
+export type GmailConnection = {
+  id: string
+  email: string
+  access_token: string
+  refresh_token: string
+  expires_at: string
+  created_at: string
+  updated_at: string
+}
+
+export type EmailSummary = {
+  id: string
+  threadId: string
+  subject: string
+  from: string
+  date: string
+  snippet: string
+  isRead: boolean
+}
+
+export type EmailDetail = EmailSummary & {
+  body: string
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -67,7 +62,7 @@ export type Database = {
           refreshToken?: string | null
           refreshTokenExpiresAt?: string | null
           scope?: string | null
-          updatedAt: string
+          updatedAt?: string
           userId: string
         }
         Update: {
@@ -119,6 +114,36 @@ export type Database = {
           id?: string
           name?: string
           phone?: string | null
+        }
+        Relationships: []
+      }
+      gmail_connections: {
+        Row: {
+          access_token: string
+          created_at: string
+          email: string
+          expires_at: string
+          id: string
+          refresh_token: string
+          updated_at: string
+        }
+        Insert: {
+          access_token: string
+          created_at?: string
+          email: string
+          expires_at: string
+          id?: string
+          refresh_token: string
+          updated_at?: string
+        }
+        Update: {
+          access_token?: string
+          created_at?: string
+          email?: string
+          expires_at?: string
+          id?: string
+          refresh_token?: string
+          updated_at?: string
         }
         Relationships: []
       }
@@ -258,7 +283,7 @@ export type Database = {
           impersonatedBy?: string | null
           ipAddress?: string | null
           token: string
-          updatedAt: string
+          updatedAt?: string
           userAgent?: string | null
           userId: string
         }
@@ -345,7 +370,7 @@ export type Database = {
           banReason?: string | null
           createdAt?: string
           email: string
-          emailVerified: boolean
+          emailVerified?: boolean
           id: string
           image?: string | null
           name: string
@@ -369,27 +394,27 @@ export type Database = {
       }
       verification: {
         Row: {
-          createdAt: string
+          createdAt: string | null
           expiresAt: string
           id: string
           identifier: string
-          updatedAt: string
+          updatedAt: string | null
           value: string
         }
         Insert: {
-          createdAt?: string
+          createdAt?: string | null
           expiresAt: string
           id: string
           identifier: string
-          updatedAt?: string
+          updatedAt?: string | null
           value: string
         }
         Update: {
-          createdAt?: string
+          createdAt?: string | null
           expiresAt?: string
           id?: string
           identifier?: string
-          updatedAt?: string
+          updatedAt?: string | null
           value?: string
         }
         Relationships: []
@@ -541,3 +566,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,8 +14,14 @@ export default defineConfig({
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRFA0NiK7W9oHQFQRFHE2VIFxSDAoJyGo0k7VCsxhC4",
       SUPABASE_SERVICE_ROLE_KEY:
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hj04zWl196z2-SBc0",
-      DATABASE_URL:
-        "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+      DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+      ANTHROPIC_API_KEY: "test-anthropic-key",
+      BETTER_AUTH_SECRET: "test-better-auth-secret-32-chars-min",
+      BETTER_AUTH_URL: "http://localhost:3000",
+      GOOGLE_CLIENT_ID: "test-google-client-id",
+      GOOGLE_CLIENT_SECRET: "test-google-client-secret",
+      RESEND_API_KEY: "test-resend-key",
+      NEXT_PUBLIC_APP_URL: "http://localhost:3000",
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

- Connecte la boîte mail de l'entreprise via OAuth2 Gmail API (une seule connexion partagée, rôles admin/bureau)
- Crée `lib/gmail.ts` avec `getValidAccessToken` (refresh auto), `listEmails`, `getEmail`, `sendEmail`, `markAsRead` — 10 tests TDD
- Ajoute la page `/inbox` (liste + détail + formulaire réponse inline) et la section Gmail dans `/parametres`

## Sécurité

- State parameter CSRF dans le flow OAuth2 (cookie httpOnly)
- Iframe HTML emails avec `sandbox=""` (sans `allow-same-origin`)
- Vérification du rôle admin/bureau sur toutes les routes `/api/gmail/*`
- Vérification de présence du `refresh_token` avant stockage

## Test Plan

- [ ] Connecter une boîte Gmail depuis `/parametres` → flow OAuth2 complet
- [ ] Vérifier que `/inbox` affiche les emails après connexion
- [ ] Sélectionner un email → chargement du détail + marquage comme lu
- [ ] Répondre à un email → envoi et toast de confirmation
- [ ] Déconnecter depuis `/parametres` → retour à l'état non-connecté
- [ ] `npm run test:run` → 71 tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)