### PR TITLE
feat: email inbox management with status tracking and client linking

### DIFF
--- a/app/(bureau)/inbox/page.tsx
+++ b/app/(bureau)/inbox/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next"
 import { Mail } from "lucide-react"
 import { supabaseService } from "@/lib/supabase/service"
 import { listEmails } from "@/lib/gmail"
+import { getEmailStatuses } from "@/lib/email-statuses"
 import { GmailConnectionBanner } from "@/components/inbox/gmail-connection-banner"
 import { EmailList } from "@/components/inbox/email-list"
+import type { EmailStatusRecord } from "@/types"
 
 export const metadata: Metadata = {
   title: "Messagerie — BTP×AI",
@@ -16,25 +18,44 @@ export default async function InboxPage() {
     .limit(1)
     .single()
 
-  const emails = connection
-    ? await listEmails({ maxResults: 50 }).catch(() => [])
-    : []
+  const [emails, clientsResult] = await Promise.all([
+    connection
+      ? listEmails({ maxResults: 50 }).catch(() => [])
+      : Promise.resolve([]),
+    supabaseService
+      .from("clients")
+      .select("id, name, email")
+      .order("name", { ascending: true }),
+  ])
+
+  const initialStatuses: Record<string, EmailStatusRecord> =
+    connection && emails.length
+      ? await getEmailStatuses(emails.map((e) => e.id)).catch(() => ({}))
+      : {}
+
+  const clients = (clientsResult.data ?? []) as {
+    id: string
+    name: string
+    email: string | null
+  }[]
 
   return (
     <div className="space-y-6">
       <div>
         <div className="flex items-center gap-2 mb-1">
           <Mail className="size-3.5 text-muted-foreground" />
-          <span className="text-xs text-muted-foreground tracking-wider uppercase">
+          <span className="text-xs text-muted-foreground tracking-widest uppercase font-mono">
             Communication
           </span>
         </div>
-        <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+        <h1 className="font-heading text-3xl font-bold tracking-wide uppercase text-foreground">
           Messagerie
         </h1>
         {connection && (
-          <p className="mt-1 text-sm text-muted-foreground">
-            {connection.email} · {emails.length} email{emails.length > 1 ? "s" : ""}
+          <p className="mt-1 text-sm text-muted-foreground font-mono">
+            {connection.email}
+            <span className="mx-2 text-border">·</span>
+            {emails.length} message{emails.length !== 1 ? "s" : ""}
           </p>
         )}
       </div>
@@ -42,7 +63,11 @@ export default async function InboxPage() {
       {!connection ? (
         <GmailConnectionBanner />
       ) : (
-        <EmailList emails={emails} />
+        <EmailList
+          emails={emails}
+          initialStatuses={initialStatuses}
+          clients={clients}
+        />
       )}
     </div>
   )

--- a/app/api/inbox/[id]/archive/route.ts
+++ b/app/api/inbox/[id]/archive/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser, getUserRole } from "@/lib/supabase/server"
+import { archiveEmail } from "@/lib/gmail"
+import { upsertEmailStatus } from "@/lib/email-statuses"
+
+const archiveSchema = z.object({
+  threadId: z.string().min(1),
+})
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser()
+  if (!user) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin" && role !== "bureau") {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps invalide" }, { status: 400 })
+  }
+
+  const parsed = archiveSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Données invalides" }, { status: 422 })
+  }
+
+  try {
+    await Promise.all([
+      archiveEmail(id),
+      upsertEmailStatus(id, parsed.data.threadId, "archive"),
+    ])
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error("Erreur archiveEmail:", err)
+    return NextResponse.json({ error: "Erreur lors de l'archivage" }, { status: 500 })
+  }
+}

--- a/app/api/inbox/[id]/status/route.ts
+++ b/app/api/inbox/[id]/status/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser, getUserRole } from "@/lib/supabase/server"
+import { upsertEmailStatus } from "@/lib/email-statuses"
+
+const statusSchema = z.object({
+  threadId: z.string().min(1),
+  status: z.enum(["a_traiter", "en_cours", "repondu", "archive"]),
+  clientId: z.string().uuid().nullable().optional(),
+})
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser()
+  if (!user) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin" && role !== "bureau") {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps invalide" }, { status: 400 })
+  }
+
+  const parsed = statusSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Données invalides" }, { status: 422 })
+  }
+
+  try {
+    const record = await upsertEmailStatus(
+      id,
+      parsed.data.threadId,
+      parsed.data.status,
+      parsed.data.clientId
+    )
+    return NextResponse.json({ record })
+  } catch (err) {
+    console.error("Erreur upsertEmailStatus:", err)
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -1,29 +1,86 @@
 "use client"
 
 import { useEffect, useState, useTransition } from "react"
-import { Reply, Loader2, Send, X } from "lucide-react"
+import {
+  Reply,
+  Loader2,
+  Send,
+  X,
+  Archive,
+  Link2,
+  Link2Off,
+  User,
+} from "lucide-react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
-import type { EmailDetail } from "@/types"
+import { cn } from "@/lib/utils"
+import type { EmailDetail as EmailDetailType, EmailStatus, EmailStatusRecord } from "@/types"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "sonner"
+
+type Client = { id: string; name: string; email: string | null }
+
+type Props = {
+  messageId: string
+  email: { id: string; threadId: string; subject: string; from: string }
+  statusRecord: EmailStatusRecord | null
+  clients: Client[]
+  onStatusChange: (status: EmailStatus, clientId?: string | null) => void
+}
+
+const STATUS_LABELS: Record<EmailStatus, string> = {
+  a_traiter: "À traiter",
+  en_cours: "En cours",
+  repondu: "Répondu",
+  archive: "Archivé",
+}
+
+const STATUS_STYLES: Record<EmailStatus, string> = {
+  a_traiter: "text-amber-400 bg-amber-400/10 border-amber-400/30 hover:bg-amber-400/20",
+  en_cours: "text-blue-400 bg-blue-400/10 border-blue-400/30 hover:bg-blue-400/20",
+  repondu: "text-emerald-400 bg-emerald-400/10 border-emerald-400/30 hover:bg-emerald-400/20",
+  archive: "text-muted-foreground bg-muted/30 border-border hover:bg-muted/50",
+}
+
+const ACTIVE_STATUS_STYLES: Record<EmailStatus, string> = {
+  a_traiter: "text-amber-400 bg-amber-400/20 border-amber-400/60 ring-1 ring-amber-400/30",
+  en_cours: "text-blue-400 bg-blue-400/20 border-blue-400/60 ring-1 ring-blue-400/30",
+  repondu: "text-emerald-400 bg-emerald-400/20 border-emerald-400/60 ring-1 ring-emerald-400/30",
+  archive: "text-muted-foreground bg-muted/50 border-border ring-1 ring-border",
+}
 
 const replySchema = z.object({
   body: z.string().min(1, "Le message ne peut pas être vide"),
 })
 type ReplyForm = z.infer<typeof replySchema>
 
-type Props = {
-  messageId: string
+function parseSenderName(from: string): { name: string; address: string } {
+  const match = from.match(/^(.+?)\s*<(.+)>$/)
+  if (match) return { name: match[1].replace(/^["']|["']$/g, ""), address: match[2] }
+  return { name: from, address: from }
 }
 
-export function EmailDetail({ messageId }: Props) {
-  const [email, setEmail] = useState<EmailDetail | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
+function parseEmailFromString(from: string): string {
+  const match = from.match(/<(.+)>/)
+  return match ? match[1] : from
+}
+
+export function EmailDetail({
+  messageId,
+  email: emailSummary,
+  statusRecord,
+  clients,
+  onStatusChange,
+}: Props) {
+  const [detail, setDetail] = useState<EmailDetailType | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
   const [showReply, setShowReply] = useState(false)
+  const [showClientPicker, setShowClientPicker] = useState(false)
+  const [clientSearch, setClientSearch] = useState("")
   const [isSending, startSending] = useTransition()
+  const [isArchiving, startArchiving] = useTransition()
 
   const form = useForm<ReplyForm>({
     resolver: zodResolver(replySchema),
@@ -31,29 +88,34 @@ export function EmailDetail({ messageId }: Props) {
   })
 
   useEffect(() => {
-    setEmail(null)
+    setDetail(null)
     setShowReply(false)
+    setShowClientPicker(false)
+    setClientSearch("")
     form.reset()
-
     setIsLoading(true)
+
     fetch(`/api/gmail/messages/${messageId}`)
       .then((r) => r.json())
-      .then((data: { email: EmailDetail }) => setEmail(data.email))
+      .then((data: { email: EmailDetailType }) => setDetail(data.email))
       .catch(() => toast.error("Impossible de charger l'email"))
       .finally(() => setIsLoading(false))
   }, [messageId, form])
 
   function onSubmit(values: ReplyForm) {
-    if (!email) return
+    if (!detail) return
     startSending(async () => {
+      const subject = detail.subject.startsWith("Re:")
+        ? detail.subject
+        : `Re: ${detail.subject}`
       const res = await fetch("/api/gmail/send", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          to: email.from,
-          subject: email.subject.startsWith("Re:") ? email.subject : `Re: ${email.subject}`,
+          to: detail.from,
+          subject,
           body: values.body,
-          replyToMessageId: email.id,
+          replyToMessageId: detail.id,
         }),
       })
       if (!res.ok) {
@@ -61,62 +123,262 @@ export function EmailDetail({ messageId }: Props) {
         return
       }
       toast.success("Réponse envoyée")
+      onStatusChange("repondu")
       setShowReply(false)
       form.reset()
     })
   }
 
+  function handleArchive() {
+    startArchiving(async () => {
+      const res = await fetch(`/api/inbox/${messageId}/archive`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ threadId: emailSummary.threadId }),
+      })
+      if (!res.ok) {
+        toast.error("Erreur lors de l'archivage")
+        return
+      }
+      toast.success("Email archivé")
+    })
+  }
+
+  function handleLinkClient(client: Client) {
+    onStatusChange(
+      statusRecord?.status ?? "a_traiter",
+      client.id
+    )
+    setShowClientPicker(false)
+    setClientSearch("")
+    toast.success(`Lié à ${client.name}`)
+  }
+
+  function handleUnlinkClient() {
+    onStatusChange(statusRecord?.status ?? "a_traiter", null)
+    toast.success("Lien client retiré")
+  }
+
+  const currentStatus: EmailStatus = statusRecord?.status ?? "a_traiter"
+  const linkedClient = statusRecord?.client_id
+    ? clients.find((c) => c.id === statusRecord.client_id)
+    : null
+
+  const senderAddress = parseEmailFromString(emailSummary.from)
+  const autoMatchClient = !linkedClient
+    ? clients.find(
+        (c) => c.email?.toLowerCase() === senderAddress.toLowerCase()
+      )
+    : null
+
+  const { name: senderName, address: senderAddr } = parseSenderName(
+    emailSummary.from
+  )
+
+  const filteredClients = clients.filter(
+    (c) =>
+      c.name.toLowerCase().includes(clientSearch.toLowerCase()) ||
+      c.email?.toLowerCase().includes(clientSearch.toLowerCase())
+  )
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
       </div>
     )
   }
 
-  if (!email) return null
-
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full max-h-[calc(100vh-280px)]">
       {/* Header */}
-      <div className="px-6 py-4 border-b border-border space-y-1">
-        <h2 className="font-semibold text-foreground text-lg">
-          {email.subject || "(Sans objet)"}
+      <div className="px-6 py-4 border-b border-border space-y-3">
+        <h2
+          data-testid="email-subject"
+          className="font-heading text-lg font-bold uppercase tracking-wide text-foreground leading-tight"
+        >
+          {emailSummary.subject || "(Sans objet)"}
         </h2>
-        <p className="text-sm text-muted-foreground">
-          De : <span className="text-foreground">{email.from}</span>
-        </p>
-        <p className="text-xs text-muted-foreground">{email.date}</p>
+
+        <div className="flex items-start gap-3">
+          <div className="size-8 rounded-sm bg-muted/60 border border-border flex items-center justify-center shrink-0 mt-0.5">
+            <User className="size-4 text-muted-foreground" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">{senderName}</p>
+            <p className="text-[11px] text-muted-foreground font-mono">
+              {senderAddr}
+            </p>
+          </div>
+        </div>
+
+        {/* Status selector */}
+        <div>
+          <p className="text-[10px] text-muted-foreground font-mono tracking-widest uppercase mb-2">
+            Statut
+          </p>
+          <div
+            data-testid="status-selector"
+            className="flex gap-1.5 flex-wrap"
+          >
+            {(
+              ["a_traiter", "en_cours", "repondu", "archive"] as EmailStatus[]
+            ).map((s) => (
+              <button
+                key={s}
+                data-testid={`status-btn-${s}`}
+                onClick={() => onStatusChange(s)}
+                className={cn(
+                  "text-[10px] font-mono tracking-wider uppercase px-2.5 py-1 border transition-all",
+                  currentStatus === s
+                    ? ACTIVE_STATUS_STYLES[s]
+                    : STATUS_STYLES[s]
+                )}
+              >
+                {STATUS_LABELS[s]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Client link */}
+        <div>
+          <p className="text-[10px] text-muted-foreground font-mono tracking-widest uppercase mb-2">
+            Client lié
+          </p>
+
+          {linkedClient ? (
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 text-xs font-mono px-2.5 py-1 border border-primary/30 bg-primary/8 text-primary">
+                <Link2 className="size-3" />
+                {linkedClient.name}
+              </span>
+              <button
+                onClick={handleUnlinkClient}
+                className="text-muted-foreground hover:text-destructive transition-colors"
+                title="Retirer le lien"
+              >
+                <Link2Off className="size-3.5" />
+              </button>
+            </div>
+          ) : autoMatchClient ? (
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] text-muted-foreground">
+                Correspondance :{" "}
+                <span className="text-foreground">{autoMatchClient.name}</span>
+              </span>
+              <button
+                onClick={() => handleLinkClient(autoMatchClient)}
+                className="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 border border-primary/30 text-primary hover:bg-primary/10 transition-colors"
+              >
+                Lier
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowClientPicker((v) => !v)}
+              className="text-[10px] font-mono uppercase tracking-wider px-2.5 py-1 border border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors inline-flex items-center gap-1.5"
+            >
+              <Link2 className="size-3" />
+              Associer un client
+            </button>
+          )}
+
+          {showClientPicker && (
+            <div className="mt-2 border border-border bg-card shadow-lg max-h-40 overflow-y-auto">
+              <div className="sticky top-0 border-b border-border bg-card">
+                <input
+                  autoFocus
+                  value={clientSearch}
+                  onChange={(e) => setClientSearch(e.target.value)}
+                  placeholder="Rechercher…"
+                  className="w-full bg-transparent px-3 py-2 text-xs focus:outline-none placeholder:text-muted-foreground"
+                />
+              </div>
+              {filteredClients.length === 0 ? (
+                <p className="px-3 py-2 text-xs text-muted-foreground">
+                  Aucun client trouvé
+                </p>
+              ) : (
+                filteredClients.map((c) => (
+                  <button
+                    key={c.id}
+                    onClick={() => handleLinkClient(c)}
+                    className="w-full text-left px-3 py-2 text-xs hover:bg-muted/40 transition-colors border-b border-border/50 last:border-0"
+                  >
+                    <span className="font-medium text-foreground">{c.name}</span>
+                    {c.email && (
+                      <span className="ml-2 text-muted-foreground font-mono text-[10px]">
+                        {c.email}
+                      </span>
+                    )}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
-      {/* Corps */}
+      {/* Body */}
       <div className="flex-1 overflow-y-auto px-6 py-4">
-        {email.body.startsWith("<") ? (
-          <iframe
-            srcDoc={email.body}
-            sandbox=""
-            className="w-full min-h-[400px] border-0"
-            title="Contenu de l'email"
-          />
+        {detail ? (
+          detail.body.trimStart().startsWith("<") ? (
+            <iframe
+              srcDoc={detail.body}
+              sandbox=""
+              className="w-full min-h-[300px] border-0 bg-white"
+              title="Contenu de l'email"
+            />
+          ) : (
+            <pre className="text-sm text-foreground whitespace-pre-wrap font-sans leading-relaxed">
+              {detail.body}
+            </pre>
+          )
         ) : (
-          <pre className="text-sm text-foreground whitespace-pre-wrap font-sans">
-            {email.body}
-          </pre>
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
         )}
       </div>
 
-      {/* Réponse */}
-      <div className="px-6 py-4 border-t border-border">
+      {/* Actions */}
+      <div className="px-6 py-4 border-t border-border space-y-3">
         {!showReply ? (
-          <Button variant="outline" size="sm" onClick={() => setShowReply(true)}>
-            <Reply className="size-4" />
-            Répondre
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowReply(true)}
+              className="font-mono text-xs tracking-wider uppercase"
+            >
+              <Reply className="size-3.5" />
+              Répondre
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleArchive}
+              disabled={isArchiving || currentStatus === "archive"}
+              className="font-mono text-xs tracking-wider uppercase text-muted-foreground hover:text-foreground"
+            >
+              {isArchiving ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Archive className="size-3.5" />
+              )}
+              Archiver
+            </Button>
+          </div>
         ) : (
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-2"
+          >
             <Textarea
-              placeholder="Votre réponse..."
-              rows={5}
+              placeholder="Votre réponse…"
+              rows={4}
+              className="text-sm resize-none"
               {...form.register("body")}
             />
             {form.formState.errors.body && (
@@ -125,11 +387,16 @@ export function EmailDetail({ messageId }: Props) {
               </p>
             )}
             <div className="flex gap-2">
-              <Button type="submit" size="sm" disabled={isSending}>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={isSending}
+                className="font-mono text-xs tracking-wider uppercase"
+              >
                 {isSending ? (
-                  <Loader2 className="size-4 animate-spin" />
+                  <Loader2 className="size-3.5 animate-spin" />
                 ) : (
-                  <Send className="size-4" />
+                  <Send className="size-3.5" />
                 )}
                 Envoyer
               </Button>
@@ -137,9 +404,13 @@ export function EmailDetail({ messageId }: Props) {
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={() => { setShowReply(false); form.reset() }}
+                onClick={() => {
+                  setShowReply(false)
+                  form.reset()
+                }}
+                className="font-mono text-xs tracking-wider uppercase"
               >
-                <X className="size-4" />
+                <X className="size-3.5" />
                 Annuler
               </Button>
             </div>

--- a/components/inbox/email-list.tsx
+++ b/components/inbox/email-list.tsx
@@ -1,17 +1,76 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useCallback, useTransition } from "react"
 import { formatDistanceToNow } from "date-fns"
 import { fr } from "date-fns/locale"
+import {
+  Search,
+  X,
+  Circle,
+  Loader2,
+  AlertCircle,
+  Clock,
+  CheckCircle2,
+  Archive,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { EmailSummary } from "@/types"
+import { createClient } from "@/lib/supabase/client"
+import { toast } from "sonner"
+import type { EmailSummary, EmailStatusRecord, EmailStatus } from "@/types"
 import { EmailDetail } from "./email-detail"
+
+type Client = { id: string; name: string; email: string | null }
 
 type Props = {
   emails: EmailSummary[]
+  initialStatuses: Record<string, EmailStatusRecord>
+  clients: Client[]
 }
 
-function formatEmailDate(dateStr: string): string {
+type StatusFilter = EmailStatus | "all"
+
+const STATUS_CONFIG: Record<
+  EmailStatus,
+  { label: string; color: string; bg: string; dot: string; icon: React.ElementType }
+> = {
+  a_traiter: {
+    label: "À traiter",
+    color: "text-amber-400",
+    bg: "bg-amber-400/10 border-amber-400/30",
+    dot: "bg-amber-400",
+    icon: AlertCircle,
+  },
+  en_cours: {
+    label: "En cours",
+    color: "text-blue-400",
+    bg: "bg-blue-400/10 border-blue-400/30",
+    dot: "bg-blue-400",
+    icon: Clock,
+  },
+  repondu: {
+    label: "Répondu",
+    color: "text-emerald-400",
+    bg: "bg-emerald-400/10 border-emerald-400/30",
+    dot: "bg-emerald-400",
+    icon: CheckCircle2,
+  },
+  archive: {
+    label: "Archivé",
+    color: "text-muted-foreground",
+    bg: "bg-muted/30 border-border",
+    dot: "bg-muted-foreground",
+    icon: Archive,
+  },
+}
+
+function getEffectiveStatus(
+  email: EmailSummary,
+  statuses: Record<string, EmailStatusRecord>
+): EmailStatus {
+  return statuses[email.id]?.status ?? (email.isRead ? "en_cours" : "a_traiter")
+}
+
+function formatDate(dateStr: string): string {
   try {
     return formatDistanceToNow(new Date(dateStr), { addSuffix: true, locale: fr })
   } catch {
@@ -19,74 +78,304 @@ function formatEmailDate(dateStr: string): string {
   }
 }
 
-export function EmailList({ emails }: Props) {
+function parseSenderName(from: string): { name: string; address: string } {
+  const match = from.match(/^(.+?)\s*<(.+)>$/)
+  if (match) return { name: match[1].replace(/^["']|["']$/g, ""), address: match[2] }
+  return { name: from, address: from }
+}
+
+export function EmailList({ emails, initialStatuses, clients }: Props) {
+  const [statuses, setStatuses] =
+    useState<Record<string, EmailStatusRecord>>(initialStatuses)
   const [selectedId, setSelectedId] = useState<string | null>(
     emails[0]?.id ?? null
   )
-  const [readIds, setReadIds] = useState<Set<string>>(
-    new Set(emails.filter((e) => e.isRead).map((e) => e.id))
+  const [search, setSearch] = useState("")
+  const [activeFilter, setActiveFilter] = useState<StatusFilter>("all")
+  const [, startTransition] = useTransition()
+
+  useEffect(() => {
+    const supabase = createClient()
+    const channel = supabase
+      .channel("email_statuses_realtime")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "email_statuses" },
+        (payload) => {
+          const record = payload.new as EmailStatusRecord
+          if (!record?.message_id) return
+          setStatuses((prev) => ({ ...prev, [record.message_id]: record }))
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [])
+
+  const updateStatus = useCallback(
+    (email: EmailSummary, status: EmailStatus, clientId?: string | null) => {
+      const optimistic: EmailStatusRecord = {
+        id: statuses[email.id]?.id ?? "",
+        message_id: email.id,
+        thread_id: email.threadId,
+        status,
+        client_id: clientId !== undefined ? clientId : (statuses[email.id]?.client_id ?? null),
+        created_at: statuses[email.id]?.created_at ?? new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+      setStatuses((prev) => ({ ...prev, [email.id]: optimistic }))
+
+      startTransition(async () => {
+        try {
+          const res = await fetch(`/api/inbox/${email.id}/status`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              threadId: email.threadId,
+              status,
+              clientId: clientId !== undefined ? clientId : (statuses[email.id]?.client_id ?? undefined),
+            }),
+          })
+          if (!res.ok) throw new Error()
+          const { record } = (await res.json()) as { record: EmailStatusRecord }
+          setStatuses((prev) => ({ ...prev, [email.id]: record }))
+        } catch {
+          setStatuses((prev) => ({ ...prev }))
+          toast.error("Impossible de mettre à jour le statut")
+        }
+      })
+    },
+    [statuses]
   )
 
-  function handleSelect(id: string) {
-    setSelectedId(id)
-    setReadIds((prev) => new Set([...prev, id]))
-  }
+  const counts = emails.reduce<Record<string, number>>(
+    (acc, e) => {
+      const s = getEffectiveStatus(e, statuses)
+      acc[s] = (acc[s] ?? 0) + 1
+      return acc
+    },
+    {}
+  )
 
-  if (emails.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground py-8 text-center">
-        Aucun email dans la boîte de réception.
-      </p>
-    )
-  }
+  const filtered = emails.filter((e) => {
+    if (activeFilter !== "all" && getEffectiveStatus(e, statuses) !== activeFilter)
+      return false
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      return (
+        e.subject.toLowerCase().includes(q) ||
+        e.from.toLowerCase().includes(q) ||
+        e.snippet.toLowerCase().includes(q)
+      )
+    }
+    return true
+  })
+
+  const selectedEmail = emails.find((e) => e.id === selectedId) ?? null
+  const selectedStatus = selectedId ? statuses[selectedId] : null
 
   return (
-    <div className="flex gap-0 border border-border rounded-lg overflow-hidden min-h-[600px]">
-      {/* Liste */}
-      <div className="w-full lg:w-80 xl:w-96 shrink-0 border-r border-border overflow-y-auto">
-        {emails.map((email) => {
-          const isRead = readIds.has(email.id)
-          const isSelected = selectedId === email.id
-          return (
+    <div className="flex flex-col gap-0 min-h-[600px]">
+      {/* Status tabs */}
+      <div
+        data-testid="status-filters"
+        className="flex items-center gap-px border border-border bg-card overflow-x-auto"
+      >
+        <button
+          onClick={() => setActiveFilter("all")}
+          data-testid="status-filter-all"
+          className={cn(
+            "flex items-center gap-2 px-4 py-2.5 text-xs font-mono tracking-wider uppercase transition-colors shrink-0",
+            activeFilter === "all"
+              ? "bg-primary/10 text-primary border-r border-primary/20"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/40 border-r border-border"
+          )}
+        >
+          <Circle className="size-2 fill-current" />
+          Tous
+          <span className="text-[10px] opacity-60">{emails.length}</span>
+        </button>
+
+        {(["a_traiter", "en_cours", "repondu", "archive"] as EmailStatus[]).map(
+          (s) => {
+            const cfg = STATUS_CONFIG[s]
+            const Icon = cfg.icon
+            const count = counts[s] ?? 0
+            return (
+              <button
+                key={s}
+                onClick={() =>
+                  setActiveFilter((prev) => (prev === s ? "all" : s))
+                }
+                data-testid={`status-filter-${s}`}
+                className={cn(
+                  "flex items-center gap-2 px-4 py-2.5 text-xs font-mono tracking-wider uppercase transition-colors shrink-0 border-r border-border",
+                  activeFilter === s
+                    ? cn(cfg.color, "bg-muted/60")
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/40"
+                )}
+              >
+                <Icon className="size-3" />
+                {cfg.label}
+                {count > 0 && (
+                  <span
+                    className={cn(
+                      "text-[10px]",
+                      activeFilter === s ? cfg.color : "opacity-50"
+                    )}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            )
+          }
+        )}
+
+        <div className="flex-1" />
+
+        {/* Search */}
+        <div className="relative flex items-center shrink-0 border-l border-border">
+          <Search className="absolute left-3 size-3.5 text-muted-foreground pointer-events-none" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Rechercher…"
+            data-testid="inbox-search"
+            className="h-full bg-transparent pl-9 pr-8 py-2.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none w-44"
+          />
+          {search && (
             <button
-              key={email.id}
-              onClick={() => handleSelect(email.id)}
-              className={cn(
-                "w-full text-left px-4 py-3 border-b border-border transition-colors",
-                isSelected
-                  ? "bg-primary/10"
-                  : "hover:bg-muted/50",
-                !isRead && "bg-blue-50/50"
-              )}
+              onClick={() => setSearch("")}
+              className="absolute right-2 text-muted-foreground hover:text-foreground"
             >
-              <div className="flex items-start justify-between gap-2 mb-1">
-                <span className={cn("text-sm truncate", !isRead && "font-semibold text-foreground")}>
-                  {email.from.replace(/<.*>/, "").trim() || email.from}
-                </span>
-                <span className="text-xs text-muted-foreground shrink-0">
-                  {formatEmailDate(email.date)}
-                </span>
-              </div>
-              <p className={cn("text-sm truncate", isRead ? "text-muted-foreground" : "text-foreground font-medium")}>
-                {email.subject || "(Sans objet)"}
-              </p>
-              <p className="text-xs text-muted-foreground truncate mt-0.5">
-                {email.snippet}
-              </p>
+              <X className="size-3.5" />
             </button>
-          )
-        })}
+          )}
+        </div>
       </div>
 
-      {/* Détail */}
-      <div className="flex-1 hidden lg:block">
-        {selectedId ? (
-          <EmailDetail messageId={selectedId} />
-        ) : (
-          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            Sélectionnez un email
-          </div>
-        )}
+      {/* Main panel */}
+      <div className="flex border border-t-0 border-border overflow-hidden flex-1">
+        {/* Email list */}
+        <div className="w-full lg:w-80 xl:w-96 shrink-0 border-r border-border overflow-y-auto max-h-[calc(100vh-280px)]">
+          {filtered.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 px-6 gap-3">
+              <div className="size-10 rounded-sm border border-dashed border-border flex items-center justify-center">
+                <Search className="size-4 text-muted-foreground" />
+              </div>
+              <p className="text-xs text-muted-foreground text-center">
+                Aucun email{search ? " pour cette recherche" : " dans cette catégorie"}
+              </p>
+            </div>
+          ) : (
+            filtered.map((email) => {
+              const isSelected = selectedId === email.id
+              const status = getEffectiveStatus(email, statuses)
+              const cfg = STATUS_CONFIG[status]
+              const { name: senderName } = parseSenderName(email.from)
+              const linkedClientId = statuses[email.id]?.client_id
+              const linkedClient = linkedClientId
+                ? clients.find((c) => c.id === linkedClientId)
+                : null
+
+              return (
+                <button
+                  key={email.id}
+                  data-testid="inbox-email-row"
+                  onClick={() => setSelectedId(email.id)}
+                  className={cn(
+                    "w-full text-left px-4 py-3 border-b border-border transition-all relative group",
+                    isSelected
+                      ? "bg-primary/8 before:absolute before:left-0 before:top-0 before:bottom-0 before:w-0.5 before:bg-primary"
+                      : "hover:bg-muted/30"
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-2 mb-0.5">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span
+                        className={cn(
+                          "size-1.5 rounded-full shrink-0 transition-colors",
+                          cfg.dot
+                        )}
+                      />
+                      <span
+                        className={cn(
+                          "text-sm truncate font-medium",
+                          !email.isRead
+                            ? "text-foreground"
+                            : "text-muted-foreground"
+                        )}
+                      >
+                        {senderName}
+                      </span>
+                    </div>
+                    <span className="text-[10px] text-muted-foreground font-mono shrink-0">
+                      {formatDate(email.date)}
+                    </span>
+                  </div>
+
+                  <p
+                    className={cn(
+                      "text-xs truncate mb-1",
+                      !email.isRead ? "text-foreground font-medium" : "text-muted-foreground"
+                    )}
+                  >
+                    {email.subject || "(Sans objet)"}
+                  </p>
+
+                  <p className="text-[11px] text-muted-foreground truncate mb-2">
+                    {email.snippet}
+                  </p>
+
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1 text-[10px] font-mono tracking-wider uppercase px-1.5 py-0.5 border",
+                        cfg.color,
+                        cfg.bg
+                      )}
+                    >
+                      {cfg.label}
+                    </span>
+                    {linkedClient && (
+                      <span className="inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 border border-border text-muted-foreground bg-muted/20">
+                        {linkedClient.name}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        {/* Detail panel */}
+        <div className="flex-1 hidden lg:block overflow-hidden">
+          {selectedId && selectedEmail ? (
+            <EmailDetail
+              key={selectedId}
+              messageId={selectedId}
+              email={selectedEmail}
+              statusRecord={selectedStatus ?? null}
+              clients={clients}
+              onStatusChange={(status, clientId) =>
+                updateStatus(selectedEmail, status, clientId)
+              }
+            />
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full gap-4">
+              <div className="size-12 rounded-sm border border-dashed border-border flex items-center justify-center">
+                <Loader2 className="size-5 text-muted-foreground" />
+              </div>
+              <p className="text-xs text-muted-foreground font-mono tracking-wider uppercase">
+                Sélectionnez un message
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/cypress/e2e/inbox.cy.ts
+++ b/cypress/e2e/inbox.cy.ts
@@ -1,0 +1,133 @@
+// Tests for /inbox — email list, status management, client linking.
+// Auth tests run unconditionally. Feature tests require
+// CYPRESS_BUREAU_EMAIL + CYPRESS_BUREAU_PASSWORD env vars.
+
+describe("Messagerie — /inbox", () => {
+  describe("Auth guard", () => {
+    it("redirige les utilisateurs non authentifiés vers /login", () => {
+      cy.visit("/inbox", { failOnStatusCode: false })
+      cy.url().should("include", "/login")
+    })
+  })
+
+  describe("Navigation et interface", () => {
+    before(function () {
+      if (!Cypress.env("BUREAU_EMAIL") || !Cypress.env("BUREAU_PASSWORD")) {
+        this.skip()
+      }
+    })
+
+    beforeEach(() => {
+      cy.session(
+        "bureau-inbox",
+        () => {
+          cy.visit("/login")
+          cy.get('input[type="email"]').type(
+            Cypress.env("BUREAU_EMAIL") as string
+          )
+          cy.get('input[type="password"]').type(
+            Cypress.env("BUREAU_PASSWORD") as string
+          )
+          cy.get('button[type="submit"]').click()
+          cy.url().should("include", "/dashboard")
+        },
+        { cacheAcrossSpecs: true }
+      )
+
+      cy.visit("/inbox")
+    })
+
+    it("affiche le titre de la page", () => {
+      cy.get("h1").should("contain.text", "Messagerie")
+    })
+
+    it("affiche les filtres de statut", () => {
+      cy.get('[data-testid="status-filters"]').should("be.visible")
+      cy.get('[data-testid="status-filter-all"]').should("exist")
+      cy.get('[data-testid="status-filter-a_traiter"]').should("exist")
+      cy.get('[data-testid="status-filter-en_cours"]').should("exist")
+      cy.get('[data-testid="status-filter-repondu"]').should("exist")
+      cy.get('[data-testid="status-filter-archive"]').should("exist")
+    })
+
+    it("affiche la bannière de connexion Gmail si aucune boîte n'est connectée ou la liste des emails", () => {
+      cy.get("body").then(($body) => {
+        if ($body.find('[data-testid="inbox-email-row"]').length > 0) {
+          cy.get('[data-testid="inbox-email-row"]').should("exist")
+        } else {
+          cy.contains("Aucune boîte mail connectée").should("exist")
+        }
+      })
+    })
+
+    describe("Avec emails", () => {
+      before(function () {
+        cy.visit("/inbox")
+        cy.get("body").then(($body) => {
+          if ($body.find('[data-testid="inbox-email-row"]').length === 0) {
+            this.skip()
+          }
+        })
+      })
+
+      it("sélectionne un email au clic et affiche le détail", () => {
+        cy.get('[data-testid="inbox-email-row"]').first().click()
+        cy.get('[data-testid="email-subject"]').should("exist")
+        cy.get('[data-testid="status-selector"]').should("be.visible")
+      })
+
+      it("filtre les emails par statut À traiter", () => {
+        cy.get('[data-testid="status-filter-a_traiter"]').click()
+        cy.get('[data-testid="inbox-email-row"]').each(($row) => {
+          cy.wrap($row).should("contain.text", "À traiter")
+        })
+      })
+
+      it("réinitialise le filtre au second clic sur le même statut", () => {
+        cy.get('[data-testid="inbox-email-row"]').then(($all) => {
+          const total = $all.length
+
+          cy.get('[data-testid="status-filter-en_cours"]').click()
+          cy.get('[data-testid="status-filter-en_cours"]').click()
+
+          cy.get('[data-testid="inbox-email-row"]').should(
+            "have.length",
+            total
+          )
+        })
+      })
+
+      it("filtre les emails via la recherche", () => {
+        cy.get('[data-testid="inbox-search"]').type("aaazzzxxx-inexistant")
+        cy.get('[data-testid="inbox-email-row"]').should("have.length", 0)
+      })
+
+      it("change le statut d'un email depuis le panneau détail", () => {
+        cy.get('[data-testid="inbox-email-row"]').first().click()
+        cy.get('[data-testid="status-selector"]').should("be.visible")
+
+        cy.get('[data-testid="status-btn-en_cours"]').click()
+
+        cy.get('[data-testid="status-btn-en_cours"]').should(
+          "have.class",
+          "ring-1"
+        )
+
+        cy.get('[data-testid="inbox-email-row"]').first().should(
+          "contain.text",
+          "En cours"
+        )
+      })
+
+      it("peut archiver un email depuis le panneau détail", () => {
+        cy.get('[data-testid="inbox-email-row"]').first().click()
+        cy.get('[data-testid="status-btn-archive"]').click()
+
+        cy.get('[data-testid="inbox-email-row"]').first().should(
+          "contain.text",
+          "Archivé"
+        )
+      })
+    })
+  })
+})

--- a/lib/email-statuses.ts
+++ b/lib/email-statuses.ts
@@ -1,0 +1,59 @@
+import { supabaseService } from "@/lib/supabase/service"
+import type { EmailStatus, EmailStatusRecord, LinkedClient } from "@/types"
+
+export async function getEmailStatuses(
+  messageIds: string[]
+): Promise<Record<string, EmailStatusRecord>> {
+  if (!messageIds.length) return {}
+
+  const { data } = await supabaseService
+    .from("email_statuses")
+    .select("*")
+    .in("message_id", messageIds)
+
+  if (!data) return {}
+
+  return Object.fromEntries(data.map((r) => [r.message_id, r as EmailStatusRecord]))
+}
+
+export async function upsertEmailStatus(
+  messageId: string,
+  threadId: string,
+  status: EmailStatus,
+  clientId?: string | null
+): Promise<EmailStatusRecord> {
+  const payload: {
+    message_id: string
+    thread_id: string
+    status: EmailStatus
+    client_id?: string | null
+  } = { message_id: messageId, thread_id: threadId, status }
+
+  if (clientId !== undefined) payload.client_id = clientId
+
+  const { data, error } = await supabaseService
+    .from("email_statuses")
+    .upsert(payload, { onConflict: "message_id" })
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as EmailStatusRecord
+}
+
+export async function findClientByEmailAddress(
+  emailAddress: string
+): Promise<LinkedClient | null> {
+  const cleanEmail = emailAddress
+    .replace(/^.*<(.+)>.*$/, "$1")
+    .trim()
+    .toLowerCase()
+
+  const { data } = await supabaseService
+    .from("clients")
+    .select("id, name, email")
+    .ilike("email", cleanEmail)
+    .maybeSingle()
+
+  return data as LinkedClient | null
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -195,3 +195,18 @@ export async function markAsRead(id: string): Promise<void> {
 
   if (!res.ok) throw new Error(`Erreur Gmail API (markAsRead ${id})`)
 }
+
+export async function archiveEmail(id: string): Promise<void> {
+  const token = await getValidAccessToken()
+
+  const res = await fetch(`${GMAIL_API}/messages/${id}/modify`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ removeLabelIds: ["INBOX", "UNREAD"] }),
+  })
+
+  if (!res.ok) throw new Error(`Erreur Gmail API (archiveEmail ${id})`)
+}

--- a/scripts/seed-admin.ts
+++ b/scripts/seed-admin.ts
@@ -4,7 +4,6 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 // Charge .env.local avant toute évaluation de lib/env (qui valide au chargement).
-// fs et path sont safe — ils ne lisent pas process.env.
 try {
   const content = readFileSync(resolve(process.cwd(), ".env.local"), "utf-8");
   for (const line of content.split("\n")) {
@@ -19,17 +18,17 @@ try {
 
 async function main() {
   // Import dynamique APRÈS que les vars sont en place
-  const { auth } = await import("../lib/auth");
+  const { supabaseService } = await import("../lib/supabase/service");
 
-  const result = await auth.api.createUser({
-    body: {
-      email: "admin@btpxai.fr",
-      password: "123qweASD!!!",
-      name: "Admin",
-      role: "admin",
-    },
+  const { data, error } = await supabaseService.auth.admin.createUser({
+    email: "admin@btpxai.fr",
+    password: "123qweASD!!!",
+    email_confirm: true,
+    user_metadata: { name: "Admin", role: "admin" },
   });
-  console.log("Utilisateur admin créé :", result);
+
+  if (error) throw error;
+  console.log("Utilisateur admin créé :", data.user?.id);
   process.exit(0);
 }
 

--- a/supabase/migrations/20260429000008_email_statuses.sql
+++ b/supabase/migrations/20260429000008_email_statuses.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS public.email_statuses (
+  id          UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id  TEXT    UNIQUE NOT NULL,
+  thread_id   TEXT    NOT NULL,
+  status      TEXT    NOT NULL DEFAULT 'a_traiter'
+                CHECK (status IN ('a_traiter', 'en_cours', 'repondu', 'archive')),
+  client_id   UUID    REFERENCES public.clients(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.email_statuses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "bureau_admin_full_access" ON public.email_statuses
+  FOR ALL TO authenticated
+  USING  ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'))
+  WITH CHECK ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'));
+
+CREATE OR REPLACE FUNCTION public.update_email_statuses_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER email_statuses_updated_at
+  BEFORE UPDATE ON public.email_statuses
+  FOR EACH ROW EXECUTE FUNCTION public.update_email_statuses_updated_at();
+
+CREATE INDEX IF NOT EXISTS email_statuses_message_id_idx ON public.email_statuses(message_id);
+CREATE INDEX IF NOT EXISTS email_statuses_status_idx     ON public.email_statuses(status);
+CREATE INDEX IF NOT EXISTS email_statuses_client_id_idx  ON public.email_statuses(client_id);

--- a/types/index.ts
+++ b/types/index.ts
@@ -81,6 +81,29 @@ export type UpdateQuoteItemInput = Partial<{
   unit: string | null
 }>
 
+export type EmailStatus = "a_traiter" | "en_cours" | "repondu" | "archive"
+
+export type EmailStatusRecord = {
+  id: string
+  message_id: string
+  thread_id: string
+  status: EmailStatus
+  client_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type LinkedClient = {
+  id: string
+  name: string
+  email: string | null
+}
+
+export type EmailSummaryWithStatus = EmailSummary & {
+  statusRecord: EmailStatusRecord | null
+  linkedClient: LinkedClient | null
+}
+
 export type GmailConnection = {
   id: string
   email: string

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -90,6 +90,44 @@ export type Database = {
           },
         ]
       }
+      email_statuses: {
+        Row: {
+          id: string
+          message_id: string
+          thread_id: string
+          status: "a_traiter" | "en_cours" | "repondu" | "archive"
+          client_id: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          message_id: string
+          thread_id: string
+          status?: "a_traiter" | "en_cours" | "repondu" | "archive"
+          client_id?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          message_id?: string
+          thread_id?: string
+          status?: "a_traiter" | "en_cours" | "repondu" | "archive"
+          client_id?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "email_statuses_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "clients"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       clients: {
         Row: {
           address: string | null


### PR DESCRIPTION
- Add email_statuses Supabase table (migration + types) to persist status
  and client associations per email message
- New statuses: à traiter, en cours, répondu, archivé with real-time sync
  via Supabase Realtime channel subscription
- Auto-detect linked client by matching sender email against clients table;
  manual client picker as fallback
- EmailList redesigned as industrial dispatch terminal: filter tabs per
  status with counts, inline search, status badges, client chips
- EmailDetail redesigned: segmented status selector, client link controls,
  archive button that removes Gmail INBOX label + sets status
- New API routes: PATCH /api/inbox/[id]/status, POST /api/inbox/[id]/archive
- archiveEmail() added to lib/gmail.ts (removes INBOX + UNREAD labels)
- Cypress E2E tests: auth guard, navigation, status filter tabs, status
  change from detail panel

https://claude.ai/code/session_01MsQRAE98wPmHzku8dihsMY