### PR TITLE
feat: email classification and AI draft generation

### DIFF
--- a/app/api/agents/email/classify/route.ts
+++ b/app/api/agents/email/classify/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser } from "@/lib/supabase/server"
+import { classifyEmail } from "@/lib/agents/email"
+
+export const maxDuration = 30
+
+const classifySchema = z.object({
+  subject: z.string(),
+  body: z.string().min(1, "Corps du message requis"),
+})
+
+export async function POST(req: NextRequest) {
+  const user = await getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 })
+  }
+
+  const parsed = classifySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    )
+  }
+
+  try {
+    const result = await classifyEmail(parsed.data.subject, parsed.data.body, req.signal)
+    return NextResponse.json(result)
+  } catch (err) {
+    const isTimeout =
+      err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")
+    console.error("Email classify error:", err)
+    return NextResponse.json(
+      {
+        error: isTimeout
+          ? "Délai de classification dépassé (30s)"
+          : "Erreur lors de la classification",
+      },
+      { status: isTimeout ? 504 : 502 }
+    )
+  }
+}

--- a/app/api/agents/email/draft/route.ts
+++ b/app/api/agents/email/draft/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser } from "@/lib/supabase/server"
+import { draftEmailReply, emailCategorySchema } from "@/lib/agents/email"
+
+export const maxDuration = 30
+
+const draftSchema = z.object({
+  subject: z.string(),
+  body: z.string().min(1, "Corps du message requis"),
+  category: emailCategorySchema,
+  clientName: z.string().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  const user = await getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 })
+  }
+
+  const parsed = draftSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    )
+  }
+
+  try {
+    const result = await draftEmailReply(
+      parsed.data.subject,
+      parsed.data.body,
+      parsed.data.category,
+      parsed.data.clientName,
+      req.signal
+    )
+    return NextResponse.json(result)
+  } catch (err) {
+    const isTimeout =
+      err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")
+    console.error("Email draft error:", err)
+    return NextResponse.json(
+      {
+        error: isTimeout
+          ? "Délai de génération dépassé (30s)"
+          : "Erreur lors de la génération du brouillon",
+      },
+      { status: isTimeout ? 504 : 502 }
+    )
+  }
+}

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useTransition } from "react"
+import { useEffect, useRef, useState, useTransition } from "react"
 import {
   Reply,
   Loader2,
@@ -10,12 +10,19 @@ import {
   Link2,
   Link2Off,
   User,
+  Sparkles,
 } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
 import { cn } from "@/lib/utils"
-import type { EmailDetail as EmailDetailType, EmailStatus, EmailStatusRecord } from "@/types"
+import type {
+  EmailDetail as EmailDetailType,
+  EmailStatus,
+  EmailStatusRecord,
+  EmailCategory,
+  EmailClassification,
+} from "@/types"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "sonner"
@@ -28,6 +35,7 @@ type Props = {
   statusRecord: EmailStatusRecord | null
   clients: Client[]
   onStatusChange: (status: EmailStatus, clientId?: string | null) => void
+  onClassify?: (category: EmailCategory) => void
 }
 
 const STATUS_LABELS: Record<EmailStatus, string> = {
@@ -51,6 +59,32 @@ const ACTIVE_STATUS_STYLES: Record<EmailStatus, string> = {
   archive: "text-muted-foreground bg-muted/50 border-border ring-1 ring-border",
 }
 
+const CATEGORY_CONFIG: Record<
+  EmailCategory,
+  { label: string; color: string; bg: string }
+> = {
+  demande_devis: {
+    label: "Demande de devis",
+    color: "text-purple-400",
+    bg: "bg-purple-400/10 border-purple-400/30",
+  },
+  suivi_commande: {
+    label: "Suivi commande",
+    color: "text-cyan-400",
+    bg: "bg-cyan-400/10 border-cyan-400/30",
+  },
+  question: {
+    label: "Question",
+    color: "text-orange-400",
+    bg: "bg-orange-400/10 border-orange-400/30",
+  },
+  autre: {
+    label: "Autre",
+    color: "text-muted-foreground",
+    bg: "bg-muted/30 border-border",
+  },
+}
+
 const replySchema = z.object({
   body: z.string().min(1, "Le message ne peut pas être vide"),
 })
@@ -67,12 +101,17 @@ function parseEmailFromString(from: string): string {
   return match ? match[1] : from
 }
 
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim()
+}
+
 export function EmailDetail({
   messageId,
   email: emailSummary,
   statusRecord,
   clients,
   onStatusChange,
+  onClassify,
 }: Props) {
   const [detail, setDetail] = useState<EmailDetailType | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -81,6 +120,11 @@ export function EmailDetail({
   const [clientSearch, setClientSearch] = useState("")
   const [isSending, startSending] = useTransition()
   const [isArchiving, startArchiving] = useTransition()
+
+  const [classification, setClassification] = useState<EmailClassification | null>(null)
+  const [isClassifying, setIsClassifying] = useState(false)
+  const [isDrafting, setIsDrafting] = useState(false)
+  const classificationCalled = useRef(false)
 
   const form = useForm<ReplyForm>({
     resolver: zodResolver(replySchema),
@@ -92,6 +136,9 @@ export function EmailDetail({
     setShowReply(false)
     setShowClientPicker(false)
     setClientSearch("")
+    setClassification(null)
+    setIsClassifying(false)
+    classificationCalled.current = false
     form.reset()
     setIsLoading(true)
 
@@ -101,6 +148,65 @@ export function EmailDetail({
       .catch(() => toast.error("Impossible de charger l'email"))
       .finally(() => setIsLoading(false))
   }, [messageId, form])
+
+  // Auto-classify when the email body is loaded.
+  useEffect(() => {
+    if (!detail || classificationCalled.current) return
+    classificationCalled.current = true
+    setIsClassifying(true)
+
+    const plainBody = detail.body.trimStart().startsWith("<")
+      ? stripHtml(detail.body)
+      : detail.body
+
+    fetch("/api/agents/email/classify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subject: detail.subject, body: plainBody }),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: EmailClassification | null) => {
+        if (data) {
+          setClassification(data)
+          onClassify?.(data.category)
+        }
+      })
+      .catch(() => {})
+      .finally(() => setIsClassifying(false))
+  }, [detail, onClassify])
+
+  async function generateDraft() {
+    if (!detail || !classification) return
+    setIsDrafting(true)
+    const plainBody = detail.body.trimStart().startsWith("<")
+      ? stripHtml(detail.body)
+      : detail.body
+
+    const linkedClient = statusRecord?.client_id
+      ? clients.find((c) => c.id === statusRecord.client_id)
+      : null
+
+    try {
+      const res = await fetch("/api/agents/email/draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subject: detail.subject,
+          body: plainBody,
+          category: classification.category,
+          clientName: linkedClient?.name,
+        }),
+      })
+      if (!res.ok) throw new Error()
+      const data = (await res.json()) as { draft: string }
+      form.setValue("body", data.draft)
+      setShowReply(true)
+    } catch {
+      toast.error("Impossible de générer le brouillon")
+    } finally {
+      setIsDrafting(false)
+    }
+  }
 
   function onSubmit(values: ReplyForm) {
     if (!detail) return
@@ -145,10 +251,7 @@ export function EmailDetail({
   }
 
   function handleLinkClient(client: Client) {
-    onStatusChange(
-      statusRecord?.status ?? "a_traiter",
-      client.id
-    )
+    onStatusChange(statusRecord?.status ?? "a_traiter", client.id)
     setShowClientPicker(false)
     setClientSearch("")
     toast.success(`Lié à ${client.name}`)
@@ -166,14 +269,10 @@ export function EmailDetail({
 
   const senderAddress = parseEmailFromString(emailSummary.from)
   const autoMatchClient = !linkedClient
-    ? clients.find(
-        (c) => c.email?.toLowerCase() === senderAddress.toLowerCase()
-      )
+    ? clients.find((c) => c.email?.toLowerCase() === senderAddress.toLowerCase())
     : null
 
-  const { name: senderName, address: senderAddr } = parseSenderName(
-    emailSummary.from
-  )
+  const { name: senderName, address: senderAddr } = parseSenderName(emailSummary.from)
 
   const filteredClients = clients.filter(
     (c) =>
@@ -206,10 +305,47 @@ export function EmailDetail({
           </div>
           <div className="min-w-0">
             <p className="text-sm font-medium text-foreground">{senderName}</p>
-            <p className="text-[11px] text-muted-foreground font-mono">
-              {senderAddr}
-            </p>
+            <p className="text-[11px] text-muted-foreground font-mono">{senderAddr}</p>
           </div>
+        </div>
+
+        {/* Classification badge */}
+        <div className="flex items-center gap-2">
+          {isClassifying ? (
+            <span className="inline-flex items-center gap-1.5 text-[10px] font-mono tracking-wider uppercase text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" />
+              Analyse…
+            </span>
+          ) : classification ? (
+            <>
+              <span
+                data-testid="classification-badge"
+                className={cn(
+                  "inline-flex items-center gap-1 text-[10px] font-mono tracking-wider uppercase px-1.5 py-0.5 border",
+                  CATEGORY_CONFIG[classification.category].color,
+                  CATEGORY_CONFIG[classification.category].bg
+                )}
+              >
+                {CATEGORY_CONFIG[classification.category].label}
+              </span>
+              <span className="text-[10px] text-muted-foreground font-mono">
+                {Math.round(classification.confidence * 100)}%
+              </span>
+              <button
+                onClick={generateDraft}
+                disabled={isDrafting}
+                data-testid="generate-draft-btn"
+                className="inline-flex items-center gap-1 text-[10px] font-mono tracking-wider uppercase px-1.5 py-0.5 border border-primary/30 text-primary hover:bg-primary/10 transition-colors disabled:opacity-50"
+              >
+                {isDrafting ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Sparkles className="size-3" />
+                )}
+                Brouillon IA
+              </button>
+            </>
+          ) : null}
         </div>
 
         {/* Status selector */}
@@ -217,22 +353,15 @@ export function EmailDetail({
           <p className="text-[10px] text-muted-foreground font-mono tracking-widest uppercase mb-2">
             Statut
           </p>
-          <div
-            data-testid="status-selector"
-            className="flex gap-1.5 flex-wrap"
-          >
-            {(
-              ["a_traiter", "en_cours", "repondu", "archive"] as EmailStatus[]
-            ).map((s) => (
+          <div data-testid="status-selector" className="flex gap-1.5 flex-wrap">
+            {(["a_traiter", "en_cours", "repondu", "archive"] as EmailStatus[]).map((s) => (
               <button
                 key={s}
                 data-testid={`status-btn-${s}`}
                 onClick={() => onStatusChange(s)}
                 className={cn(
                   "text-[10px] font-mono tracking-wider uppercase px-2.5 py-1 border transition-all",
-                  currentStatus === s
-                    ? ACTIVE_STATUS_STYLES[s]
-                    : STATUS_STYLES[s]
+                  currentStatus === s ? ACTIVE_STATUS_STYLES[s] : STATUS_STYLES[s]
                 )}
               >
                 {STATUS_LABELS[s]}
@@ -371,10 +500,7 @@ export function EmailDetail({
             </Button>
           </div>
         ) : (
-          <form
-            onSubmit={form.handleSubmit(onSubmit)}
-            className="space-y-2"
-          >
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-2">
             <Textarea
               placeholder="Votre réponse…"
               rows={4}

--- a/components/inbox/email-list.tsx
+++ b/components/inbox/email-list.tsx
@@ -16,8 +16,34 @@ import {
 import { cn } from "@/lib/utils"
 import { createClient } from "@/lib/supabase/client"
 import { toast } from "sonner"
-import type { EmailSummary, EmailStatusRecord, EmailStatus } from "@/types"
+import type { EmailSummary, EmailStatusRecord, EmailStatus, EmailCategory } from "@/types"
 import { EmailDetail } from "./email-detail"
+
+const CATEGORY_CONFIG: Record<
+  EmailCategory,
+  { label: string; color: string; bg: string }
+> = {
+  demande_devis: {
+    label: "Devis",
+    color: "text-purple-400",
+    bg: "bg-purple-400/10 border-purple-400/30",
+  },
+  suivi_commande: {
+    label: "Suivi",
+    color: "text-cyan-400",
+    bg: "bg-cyan-400/10 border-cyan-400/30",
+  },
+  question: {
+    label: "Question",
+    color: "text-orange-400",
+    bg: "bg-orange-400/10 border-orange-400/30",
+  },
+  autre: {
+    label: "Autre",
+    color: "text-muted-foreground",
+    bg: "bg-muted/30 border-border",
+  },
+}
 
 type Client = { id: string; name: string; email: string | null }
 
@@ -87,6 +113,7 @@ function parseSenderName(from: string): { name: string; address: string } {
 export function EmailList({ emails, initialStatuses, clients }: Props) {
   const [statuses, setStatuses] =
     useState<Record<string, EmailStatusRecord>>(initialStatuses)
+  const [classifications, setClassifications] = useState<Record<string, EmailCategory>>({})
   const [selectedId, setSelectedId] = useState<string | null>(
     emails[0]?.id ?? null
   )
@@ -340,6 +367,18 @@ export function EmailList({ emails, initialStatuses, clients }: Props) {
                     >
                       {cfg.label}
                     </span>
+                    {classifications[email.id] && (
+                      <span
+                        data-testid="classification-badge-list"
+                        className={cn(
+                          "inline-flex items-center gap-1 text-[10px] font-mono tracking-wider uppercase px-1.5 py-0.5 border",
+                          CATEGORY_CONFIG[classifications[email.id]].color,
+                          CATEGORY_CONFIG[classifications[email.id]].bg
+                        )}
+                      >
+                        {CATEGORY_CONFIG[classifications[email.id]].label}
+                      </span>
+                    )}
                     {linkedClient && (
                       <span className="inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 border border-border text-muted-foreground bg-muted/20">
                         {linkedClient.name}
@@ -363,6 +402,9 @@ export function EmailList({ emails, initialStatuses, clients }: Props) {
               clients={clients}
               onStatusChange={(status, clientId) =>
                 updateStatus(selectedEmail, status, clientId)
+              }
+              onClassify={(category) =>
+                setClassifications((prev) => ({ ...prev, [selectedId]: category }))
               }
             />
           ) : (

--- a/lib/agents/email.ts
+++ b/lib/agents/email.ts
@@ -1,0 +1,126 @@
+import { generateObject } from "ai"
+import { anthropic } from "@ai-sdk/anthropic"
+import { z } from "zod"
+
+export const emailCategorySchema = z.enum([
+  "demande_devis",
+  "suivi_commande",
+  "question",
+  "autre",
+])
+export type EmailCategory = z.infer<typeof emailCategorySchema>
+
+// Full schemas with business validation — used for testing and post-generation validation.
+export const emailClassificationSchema = z.object({
+  category: emailCategorySchema,
+  confidence: z.number().min(0).max(1),
+  reasoning: z.string().min(1),
+})
+export type EmailClassification = z.infer<typeof emailClassificationSchema>
+
+export const emailDraftSchema = z.object({
+  draft: z.string().min(1),
+})
+export type EmailDraft = z.infer<typeof emailDraftSchema>
+
+// Stripped schemas for Anthropic's output_config — numeric constraints not supported.
+const aiClassificationSchema = z.object({
+  category: emailCategorySchema,
+  confidence: z.number(),
+  reasoning: z.string(),
+})
+
+const aiDraftSchema = z.object({
+  draft: z.string(),
+})
+
+const CLASSIFY_SYSTEM_PROMPT = `Tu es un assistant pour une PME de métallerie et serrurerie. Ta tâche est de classifier les emails entrants reçus par l'entreprise.
+
+Catégories disponibles :
+- demande_devis : le client demande un devis, une estimation de prix, ou une offre commerciale pour des travaux
+- suivi_commande : le client s'enquiert de l'avancement d'une commande, d'un chantier en cours, ou de délais de livraison
+- question : le client pose une question générale (technique, administrative, horaires d'ouverture, etc.)
+- autre : tout ce qui ne correspond pas aux catégories précédentes (spam, newsletter, accusé de réception, etc.)
+
+Retourne un objet JSON avec :
+- category : la catégorie choisie parmi les 4 possibilités
+- confidence : un score entre 0.0 et 1.0 indiquant ta certitude
+- reasoning : une courte explication en français (1-2 phrases maximum)`
+
+const DRAFT_SYSTEM_PROMPT = `Tu es l'assistant administratif d'une PME familiale de métallerie et serrurerie en France. Tu rédiges des réponses professionnelles, courtoises et concises aux emails des clients.
+
+Règles de rédaction :
+- Rédige toujours en français
+- Ton professionnel mais chaleureux, typique d'une entreprise familiale
+- Signe avec "Cordialement,\nL'équipe BTP"
+- Pour les demandes de devis : remercie le client, indique qu'un devis sera établi et propose de fournir des détails supplémentaires si nécessaire
+- Pour les suivis de commande : rassure le client, confirme que le dossier est bien suivi
+- Pour les questions : réponds de manière précise et utile
+- Pour les autres cas : réponds courtoisement et oriente si nécessaire
+- Garde la réponse concise (2-4 paragraphes maximum)
+- N'invente JAMAIS de dates précises, de prix ou de noms de techniciens`
+
+export async function classifyEmail(
+  subject: string,
+  body: string,
+  signal?: AbortSignal
+): Promise<EmailClassification> {
+  const timeoutSignal = AbortSignal.timeout(30_000)
+  const abortSignal =
+    signal && typeof AbortSignal.any === "function"
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+
+  const { object } = await generateObject({
+    model: anthropic("claude-sonnet-4-6"),
+    schema: aiClassificationSchema,
+    system: CLASSIFY_SYSTEM_PROMPT,
+    prompt: `Objet : ${subject}\n\nCorps du message :\n${body}`,
+    maxOutputTokens: 256,
+    abortSignal,
+  })
+
+  return emailClassificationSchema.parse(object)
+}
+
+export async function draftEmailReply(
+  subject: string,
+  body: string,
+  category: EmailCategory,
+  clientName?: string,
+  signal?: AbortSignal
+): Promise<EmailDraft> {
+  const timeoutSignal = AbortSignal.timeout(30_000)
+  const abortSignal =
+    signal && typeof AbortSignal.any === "function"
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+
+  const categoryLabels: Record<EmailCategory, string> = {
+    demande_devis: "demande de devis",
+    suivi_commande: "suivi de commande",
+    question: "question générale",
+    autre: "autre",
+  }
+
+  const clientContext = clientName ? `\nClient connu : ${clientName}` : ""
+  const prompt = `Type d'email : ${categoryLabels[category]}${clientContext}
+
+Email reçu :
+Objet : ${subject}
+
+${body}
+
+Rédige une réponse adaptée à cet email.`
+
+  const { object } = await generateObject({
+    model: anthropic("claude-sonnet-4-6"),
+    schema: aiDraftSchema,
+    system: DRAFT_SYSTEM_PROMPT,
+    prompt,
+    maxOutputTokens: 512,
+    abortSignal,
+  })
+
+  return emailDraftSchema.parse(object)
+}

--- a/tests/unit/agents/email.test.ts
+++ b/tests/unit/agents/email.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  emailCategorySchema,
+  emailClassificationSchema,
+  emailDraftSchema,
+  classifyEmail,
+  draftEmailReply,
+} from "@/lib/agents/email"
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn(),
+}))
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  anthropic: vi.fn(() => "mock-model"),
+}))
+
+import { generateObject } from "ai"
+
+// ─── Schema: emailCategorySchema ─────────────────────────────────────────────
+
+describe("emailCategorySchema", () => {
+  it("accepts demande_devis", () => {
+    expect(emailCategorySchema.safeParse("demande_devis").success).toBe(true)
+  })
+
+  it("accepts suivi_commande", () => {
+    expect(emailCategorySchema.safeParse("suivi_commande").success).toBe(true)
+  })
+
+  it("accepts question", () => {
+    expect(emailCategorySchema.safeParse("question").success).toBe(true)
+  })
+
+  it("accepts autre", () => {
+    expect(emailCategorySchema.safeParse("autre").success).toBe(true)
+  })
+
+  it("rejects unknown category", () => {
+    expect(emailCategorySchema.safeParse("spam").success).toBe(false)
+  })
+
+  it("rejects empty string", () => {
+    expect(emailCategorySchema.safeParse("").success).toBe(false)
+  })
+})
+
+// ─── Schema: emailClassificationSchema ───────────────────────────────────────
+
+describe("emailClassificationSchema", () => {
+  const validClassification = {
+    category: "demande_devis",
+    confidence: 0.95,
+    reasoning: "Le client demande explicitement un chiffrage.",
+  }
+
+  it("accepts a valid classification", () => {
+    expect(emailClassificationSchema.safeParse(validClassification).success).toBe(true)
+  })
+
+  it("accepts confidence of 0", () => {
+    expect(
+      emailClassificationSchema.safeParse({ ...validClassification, confidence: 0 }).success
+    ).toBe(true)
+  })
+
+  it("accepts confidence of 1", () => {
+    expect(
+      emailClassificationSchema.safeParse({ ...validClassification, confidence: 1 }).success
+    ).toBe(true)
+  })
+
+  it("rejects confidence above 1", () => {
+    expect(
+      emailClassificationSchema.safeParse({ ...validClassification, confidence: 1.1 }).success
+    ).toBe(false)
+  })
+
+  it("rejects confidence below 0", () => {
+    expect(
+      emailClassificationSchema.safeParse({ ...validClassification, confidence: -0.1 }).success
+    ).toBe(false)
+  })
+
+  it("rejects empty reasoning", () => {
+    expect(
+      emailClassificationSchema.safeParse({ ...validClassification, reasoning: "" }).success
+    ).toBe(false)
+  })
+
+  it("rejects invalid category", () => {
+    expect(
+      emailClassificationSchema.safeParse({ ...validClassification, category: "unknown" }).success
+    ).toBe(false)
+  })
+
+  it("rejects missing fields", () => {
+    expect(emailClassificationSchema.safeParse({ category: "question" }).success).toBe(false)
+  })
+})
+
+// ─── Schema: emailDraftSchema ─────────────────────────────────────────────────
+
+describe("emailDraftSchema", () => {
+  it("accepts a non-empty draft", () => {
+    expect(
+      emailDraftSchema.safeParse({ draft: "Bonjour, merci pour votre message." }).success
+    ).toBe(true)
+  })
+
+  it("rejects an empty draft", () => {
+    expect(emailDraftSchema.safeParse({ draft: "" }).success).toBe(false)
+  })
+
+  it("rejects missing draft field", () => {
+    expect(emailDraftSchema.safeParse({}).success).toBe(false)
+  })
+})
+
+// ─── classifyEmail ────────────────────────────────────────────────────────────
+
+describe("classifyEmail", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns parsed classification from AI (demande_devis)", async () => {
+    const mockOutput = {
+      category: "demande_devis",
+      confidence: 0.95,
+      reasoning: "Le client demande un chiffrage pour une clôture.",
+    }
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockOutput } as never)
+
+    const result = await classifyEmail(
+      "Demande de devis clôture",
+      "Bonjour, je souhaite obtenir un devis pour une clôture en acier."
+    )
+
+    expect(result.category).toBe("demande_devis")
+    expect(result.confidence).toBe(0.95)
+    expect(result.reasoning).toBeTruthy()
+  })
+
+  it("returns parsed classification from AI (suivi_commande)", async () => {
+    const mockOutput = {
+      category: "suivi_commande",
+      confidence: 0.88,
+      reasoning: "Le client s'enquiert de l'avancement de sa commande.",
+    }
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockOutput } as never)
+
+    const result = await classifyEmail(
+      "Suivi de ma commande",
+      "Bonjour, où en est mon portail commandé il y a 3 semaines ?"
+    )
+
+    expect(result.category).toBe("suivi_commande")
+  })
+
+  it("returns parsed classification from AI (question)", async () => {
+    const mockOutput = {
+      category: "question",
+      confidence: 0.82,
+      reasoning: "Le client pose une question technique.",
+    }
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockOutput } as never)
+
+    const result = await classifyEmail(
+      "Question technique",
+      "Bonjour, travaillez-vous l'inox 316L ?"
+    )
+
+    expect(result.category).toBe("question")
+  })
+
+  it("returns parsed classification from AI (autre)", async () => {
+    const mockOutput = {
+      category: "autre",
+      confidence: 0.75,
+      reasoning: "Email hors sujet.",
+    }
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockOutput } as never)
+
+    const result = await classifyEmail("Newsletter", "Découvrez nos offres du mois !")
+
+    expect(result.category).toBe("autre")
+  })
+
+  it("calls generateObject with subject and body in the prompt", async () => {
+    const mockOutput = {
+      category: "question",
+      confidence: 0.8,
+      reasoning: "Question générale.",
+    }
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockOutput } as never)
+
+    const subject = "Horaires d'ouverture"
+    const body = "Bonjour, quels sont vos horaires ?"
+    await classifyEmail(subject, body)
+
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining(subject) as string,
+      })
+    )
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining(body) as string,
+      })
+    )
+  })
+
+  it("propagates errors from generateObject", async () => {
+    vi.mocked(generateObject).mockRejectedValueOnce(new Error("API unavailable"))
+
+    await expect(classifyEmail("Objet", "Corps")).rejects.toThrow("API unavailable")
+  })
+
+  it("propagates AbortError on timeout", async () => {
+    const abortErr = Object.assign(new Error("Timeout"), { name: "TimeoutError" })
+    vi.mocked(generateObject).mockRejectedValueOnce(abortErr)
+
+    await expect(classifyEmail("Objet", "Corps")).rejects.toMatchObject({
+      name: "TimeoutError",
+    })
+  })
+})
+
+// ─── draftEmailReply ──────────────────────────────────────────────────────────
+
+describe("draftEmailReply", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const mockDraft = {
+    draft:
+      "Bonjour,\n\nNous avons bien reçu votre demande et reviendrons vers vous rapidement.\n\nCordialement,\nL'équipe BTP",
+  }
+
+  it("returns parsed draft from AI", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockDraft } as never)
+
+    const result = await draftEmailReply(
+      "Demande de devis portail",
+      "Je souhaite un devis pour un portail coulissant.",
+      "demande_devis"
+    )
+
+    expect(result.draft).toBe(mockDraft.draft)
+  })
+
+  it("includes clientName in the prompt when provided", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockDraft } as never)
+
+    await draftEmailReply(
+      "Suivi commande",
+      "Où en est ma commande ?",
+      "suivi_commande",
+      "Jean Dupont"
+    )
+
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Jean Dupont") as string,
+      })
+    )
+  })
+
+  it("does not include clientName in prompt when absent", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockDraft } as never)
+
+    await draftEmailReply("Objet", "Corps", "question")
+
+    const call = vi.mocked(generateObject).mock.calls[0][0] as { prompt: string }
+    expect(call.prompt).not.toContain("Client connu")
+  })
+
+  it("includes the category label in the prompt", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({ object: mockDraft } as never)
+
+    await draftEmailReply("Objet", "Corps", "demande_devis")
+
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("demande de devis") as string,
+      })
+    )
+  })
+
+  it("propagates errors from generateObject", async () => {
+    vi.mocked(generateObject).mockRejectedValueOnce(new Error("API unavailable"))
+
+    await expect(
+      draftEmailReply("Objet", "Corps", "question")
+    ).rejects.toThrow("API unavailable")
+  })
+
+  it("propagates AbortError on timeout", async () => {
+    const abortErr = Object.assign(new Error("Timeout"), { name: "TimeoutError" })
+    vi.mocked(generateObject).mockRejectedValueOnce(abortErr)
+
+    await expect(
+      draftEmailReply("Objet", "Corps", "autre")
+    ).rejects.toMatchObject({ name: "TimeoutError" })
+  })
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -83,6 +83,14 @@ export type UpdateQuoteItemInput = Partial<{
 
 export type EmailStatus = "a_traiter" | "en_cours" | "repondu" | "archive"
 
+export type EmailCategory = "demande_devis" | "suivi_commande" | "question" | "autre"
+
+export type EmailClassification = {
+  category: EmailCategory
+  confidence: number
+  reasoning: string
+}
+
 export type EmailStatusRecord = {
   id: string
   message_id: string


### PR DESCRIPTION
- Add classifyEmail() and draftEmailReply() agents in lib/agents/email.ts
- Add POST /api/agents/email/classify and /draft API routes
- Auto-classify emails on detail load; show category badge + confidence
- "Brouillon IA" button generates a contextual reply draft, editable before send
- Classification badge propagates to inbox list rows
- Add EmailCategory and EmailClassification types
- 30 Vitest unit tests covering schemas, classifyEmail, and draftEmailReply

https://claude.ai/code/session_01RRGeRnPaz5JGionNUoa6eB