### PR TITLE
feat: auto email acknowledgment with dedup and settings toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ RESEND_API_KEY=
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Cron (Vercel Cron authentication secret)
+CRON_SECRET=

--- a/app/(bureau)/parametres/page.tsx
+++ b/app/(bureau)/parametres/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next"
 import { Settings } from "lucide-react"
 import { supabaseService } from "@/lib/supabase/service"
 import { GmailConnectionSection } from "@/components/parametres/gmail-connection-section"
+import { AutoAcknowledgmentSection } from "@/components/parametres/auto-acknowledgment-section"
+import { getAutoAcknowledgmentEnabled } from "@/lib/acknowledgments"
 
 export const metadata: Metadata = {
   title: "Paramètres — BTP×AI",
@@ -16,11 +18,10 @@ export default async function ParametresPage({
 }) {
   const { gmail } = await searchParams
 
-  const { data: connection } = await supabaseService
-    .from("gmail_connections")
-    .select("email, created_at")
-    .limit(1)
-    .single()
+  const [{ data: connection }, autoAckEnabled] = await Promise.all([
+    supabaseService.from("gmail_connections").select("email, created_at").limit(1).single(),
+    getAutoAcknowledgmentEnabled(),
+  ])
 
   return (
     <div className="space-y-6">
@@ -44,6 +45,13 @@ export default async function ParametresPage({
           Intégrations
         </h2>
         <GmailConnectionSection connection={connection} gmailParam={gmail} />
+      </div>
+
+      <div className="max-w-2xl space-y-4">
+        <h2 className="text-sm font-medium text-muted-foreground tracking-wider uppercase">
+          Automatisations
+        </h2>
+        <AutoAcknowledgmentSection initialEnabled={autoAckEnabled} />
       </div>
     </div>
   )

--- a/app/api/cron/email-acknowledgment/route.ts
+++ b/app/api/cron/email-acknowledgment/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server"
+import { listEmails, sendEmail } from "@/lib/gmail"
+import { findClientByEmailAddress } from "@/lib/email-statuses"
+import {
+  getAutoAcknowledgmentEnabled,
+  hasRecentAcknowledgment,
+  logAcknowledgment,
+  getLastPollAt,
+  setLastPollAt,
+} from "@/lib/acknowledgments"
+import {
+  buildAcknowledgmentSubject,
+  buildAcknowledgmentBody,
+} from "@/lib/email/acknowledgment"
+
+// Accepted by Vercel cron (Authorization: Bearer CRON_SECRET)
+function isCronAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return false
+  const auth = request.headers.get("authorization")
+  return auth === `Bearer ${secret}`
+}
+
+function extractEmailAddress(from: string): string {
+  const match = from.match(/<(.+)>/)
+  return (match ? match[1] : from).trim().toLowerCase()
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const enabled = await getAutoAcknowledgmentEnabled()
+  if (!enabled) {
+    return NextResponse.json({ skipped: true, reason: "auto_acknowledgment_disabled" })
+  }
+
+  const now = new Date()
+
+  // Use last_poll_at with a 2-minute overlap to avoid missed emails between runs
+  const lastPollAt = await getLastPollAt()
+  const windowStart = lastPollAt
+    ? new Date(lastPollAt.getTime() - 2 * 60 * 1000)
+    : new Date(now.getTime() - 10 * 60 * 1000) // fallback: last 10 min on first run
+
+  const epochSeconds = Math.floor(windowStart.getTime() / 1000)
+
+  let emails
+  try {
+    emails = await listEmails({ maxResults: 20, query: `after:${epochSeconds}` })
+  } catch {
+    // No Gmail connection configured — skip silently
+    await setLastPollAt(now)
+    return NextResponse.json({ skipped: true, reason: "gmail_unavailable" })
+  }
+
+  await setLastPollAt(now)
+
+  const results: { messageId: string; status: "sent" | "skipped"; reason?: string }[] = []
+
+  for (const email of emails) {
+    const emailDate = new Date(email.date)
+
+    // Skip emails older than the window (overlap may include already-processed ones)
+    if (emailDate <= windowStart) {
+      results.push({ messageId: email.id, status: "skipped", reason: "before_window" })
+      continue
+    }
+
+    const senderEmail = extractEmailAddress(email.from)
+
+    const alreadySent = await hasRecentAcknowledgment(senderEmail)
+    if (alreadySent) {
+      results.push({ messageId: email.id, status: "skipped", reason: "recent_ack_exists" })
+      continue
+    }
+
+    const client = await findClientByEmailAddress(email.from)
+
+    try {
+      const subject = buildAcknowledgmentSubject(email.subject)
+      const body = buildAcknowledgmentBody(client?.name, email.subject)
+
+      await sendEmail(email.from, subject, body, email.id)
+      await logAcknowledgment(email.id, email.threadId, senderEmail, client?.name)
+
+      results.push({ messageId: email.id, status: "sent" })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      results.push({ messageId: email.id, status: "skipped", reason: `send_error: ${message}` })
+    }
+  }
+
+  const sent = results.filter((r) => r.status === "sent").length
+  return NextResponse.json({ processed: results.length, sent, results })
+}

--- a/app/api/parametres/acknowledgment/route.ts
+++ b/app/api/parametres/acknowledgment/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient } from "@/lib/supabase/server"
+import {
+  getAutoAcknowledgmentEnabled,
+  setAutoAcknowledgmentEnabled,
+} from "@/lib/acknowledgments"
+
+const bodySchema = z.object({ enabled: z.boolean() })
+
+export async function GET(): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const enabled = await getAutoAcknowledgmentEnabled()
+  return NextResponse.json({ enabled })
+}
+
+export async function PATCH(request: Request): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const role = user.user_metadata?.role as string | undefined
+  if (!role || !["bureau", "admin"].includes(role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
+
+  await setAutoAcknowledgmentEnabled(parsed.data.enabled)
+  return NextResponse.json({ enabled: parsed.data.enabled })
+}

--- a/components/parametres/auto-acknowledgment-section.tsx
+++ b/components/parametres/auto-acknowledgment-section.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useTransition } from "react"
 import { MailCheck, Loader2 } from "lucide-react"
-import { Switch } from "@/components/ui/switch"
-import { Label } from "@/components/ui/label"
 
 type Props = {
   initialEnabled: boolean
@@ -13,14 +11,15 @@ export function AutoAcknowledgmentSection({ initialEnabled }: Props) {
   const [enabled, setEnabled] = useState(initialEnabled)
   const [isPending, startTransition] = useTransition()
 
-  function handleToggle(checked: boolean) {
+  function handleToggle() {
     startTransition(async () => {
+      const next = !enabled
       const res = await fetch("/api/parametres/acknowledgment", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled: checked }),
+        body: JSON.stringify({ enabled: next }),
       })
-      if (res.ok) setEnabled(checked)
+      if (res.ok) setEnabled(next)
     })
   }
 
@@ -31,7 +30,7 @@ export function AutoAcknowledgmentSection({ initialEnabled }: Props) {
         <div>
           <h3 className="font-medium text-foreground">Accusé de réception automatique</h3>
           <p className="text-sm text-muted-foreground">
-            Envoie une réponse automatique à chaque nouveau email reçu. Pas de doublon si
+            Envoie une réponse automatique à chaque nouvel email reçu. Pas de doublon si
             plusieurs emails du même expéditeur dans les 30 dernières minutes.
           </p>
         </div>
@@ -39,15 +38,28 @@ export function AutoAcknowledgmentSection({ initialEnabled }: Props) {
 
       <div className="flex items-center gap-3">
         {isPending && <Loader2 className="size-4 animate-spin text-muted-foreground" />}
-        <Switch
-          id="auto-ack-toggle"
-          checked={enabled}
-          onCheckedChange={handleToggle}
+        <button
+          role="switch"
+          aria-checked={enabled}
+          onClick={handleToggle}
           disabled={isPending}
-        />
-        <Label htmlFor="auto-ack-toggle" className="text-sm text-muted-foreground cursor-pointer">
+          className={[
+            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full",
+            "transition-colors focus-visible:outline-none focus-visible:ring-2",
+            "focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+            enabled ? "bg-primary" : "bg-input",
+          ].join(" ")}
+        >
+          <span
+            className={[
+              "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform",
+              enabled ? "translate-x-5" : "translate-x-0.5",
+            ].join(" ")}
+          />
+        </button>
+        <span className="text-sm text-muted-foreground">
           {enabled ? "Activé" : "Désactivé"}
-        </Label>
+        </span>
       </div>
     </div>
   )

--- a/components/parametres/auto-acknowledgment-section.tsx
+++ b/components/parametres/auto-acknowledgment-section.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { MailCheck, Loader2 } from "lucide-react"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+
+type Props = {
+  initialEnabled: boolean
+}
+
+export function AutoAcknowledgmentSection({ initialEnabled }: Props) {
+  const [enabled, setEnabled] = useState(initialEnabled)
+  const [isPending, startTransition] = useTransition()
+
+  function handleToggle(checked: boolean) {
+    startTransition(async () => {
+      const res = await fetch("/api/parametres/acknowledgment", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: checked }),
+      })
+      if (res.ok) setEnabled(checked)
+    })
+  }
+
+  return (
+    <div className="rounded-lg border border-border p-6 space-y-4">
+      <div className="flex items-center gap-3">
+        <MailCheck className="size-5 text-muted-foreground" />
+        <div>
+          <h3 className="font-medium text-foreground">Accusé de réception automatique</h3>
+          <p className="text-sm text-muted-foreground">
+            Envoie une réponse automatique à chaque nouveau email reçu. Pas de doublon si
+            plusieurs emails du même expéditeur dans les 30 dernières minutes.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        {isPending && <Loader2 className="size-4 animate-spin text-muted-foreground" />}
+        <Switch
+          id="auto-ack-toggle"
+          checked={enabled}
+          onCheckedChange={handleToggle}
+          disabled={isPending}
+        />
+        <Label htmlFor="auto-ack-toggle" className="text-sm text-muted-foreground cursor-pointer">
+          {enabled ? "Activé" : "Désactivé"}
+        </Label>
+      </div>
+    </div>
+  )
+}

--- a/lib/acknowledgments.ts
+++ b/lib/acknowledgments.ts
@@ -1,0 +1,72 @@
+import { supabaseService } from "@/lib/supabase/service"
+import type { EmailAcknowledgment } from "@/types"
+
+const DEDUP_WINDOW_MINUTES = 30
+
+export async function getAutoAcknowledgmentEnabled(): Promise<boolean> {
+  const { data } = await supabaseService
+    .from("app_settings")
+    .select("value")
+    .eq("key", "auto_acknowledgment_enabled")
+    .single()
+
+  return data?.value === "true"
+}
+
+export async function setAutoAcknowledgmentEnabled(enabled: boolean): Promise<void> {
+  await supabaseService.from("app_settings").upsert(
+    { key: "auto_acknowledgment_enabled", value: String(enabled), updated_at: new Date().toISOString() },
+    { onConflict: "key" }
+  )
+}
+
+export async function hasRecentAcknowledgment(senderEmail: string): Promise<boolean> {
+  const since = new Date(Date.now() - DEDUP_WINDOW_MINUTES * 60 * 1000).toISOString()
+
+  const { data } = await supabaseService
+    .from("email_acknowledgments")
+    .select("id")
+    .eq("sender_email", senderEmail.toLowerCase())
+    .gte("sent_at", since)
+    .limit(1)
+
+  return Boolean(data?.length)
+}
+
+export async function logAcknowledgment(
+  messageId: string,
+  threadId: string,
+  senderEmail: string,
+  clientName?: string | null
+): Promise<EmailAcknowledgment> {
+  const { data, error } = await supabaseService
+    .from("email_acknowledgments")
+    .insert({
+      message_id: messageId,
+      thread_id: threadId,
+      sender_email: senderEmail.toLowerCase(),
+      client_name: clientName ?? null,
+    })
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as EmailAcknowledgment
+}
+
+export async function getLastPollAt(): Promise<Date | null> {
+  const { data } = await supabaseService
+    .from("app_settings")
+    .select("value")
+    .eq("key", "acknowledgment_last_poll_at")
+    .single()
+
+  return data?.value ? new Date(data.value) : null
+}
+
+export async function setLastPollAt(date: Date): Promise<void> {
+  await supabaseService.from("app_settings").upsert(
+    { key: "acknowledgment_last_poll_at", value: date.toISOString(), updated_at: new Date().toISOString() },
+    { onConflict: "key" }
+  )
+}

--- a/lib/email/acknowledgment.ts
+++ b/lib/email/acknowledgment.ts
@@ -1,0 +1,21 @@
+export function buildAcknowledgmentSubject(originalSubject: string): string {
+  const prefix = "Re: "
+  return originalSubject.startsWith(prefix) ? originalSubject : `${prefix}${originalSubject}`
+}
+
+export function buildAcknowledgmentBody(clientName?: string | null, originalSubject?: string): string {
+  const greeting = clientName ? `Bonjour ${clientName},` : "Bonjour,"
+
+  return [
+    greeting,
+    "",
+    "Nous avons bien reçu votre message" +
+      (originalSubject ? ` concernant "${originalSubject}"` : "") +
+      " et nous vous en remercions.",
+    "",
+    "Notre équipe prendra connaissance de votre demande dans les meilleurs délais et vous répondra sous 24 à 48 heures ouvrées.",
+    "",
+    "Cordialement,",
+    "L'équipe BTP×AI",
+  ].join("\n")
+}

--- a/supabase/migrations/20260429000009_email_acknowledgments_and_settings.sql
+++ b/supabase/migrations/20260429000009_email_acknowledgments_and_settings.sql
@@ -1,0 +1,37 @@
+-- email_acknowledgments: tracks auto-acknowledgment emails sent per message
+CREATE TABLE IF NOT EXISTS public.email_acknowledgments (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id   TEXT        UNIQUE NOT NULL,
+  thread_id    TEXT        NOT NULL,
+  sender_email TEXT        NOT NULL,
+  client_name  TEXT,
+  sent_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.email_acknowledgments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "bureau_admin_full_access" ON public.email_acknowledgments
+  FOR ALL TO authenticated
+  USING  ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'))
+  WITH CHECK ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'));
+
+CREATE INDEX IF NOT EXISTS email_acknowledgments_sender_email_idx ON public.email_acknowledgments(sender_email);
+CREATE INDEX IF NOT EXISTS email_acknowledgments_sent_at_idx       ON public.email_acknowledgments(sent_at);
+
+-- app_settings: generic key/value store for application configuration
+CREATE TABLE IF NOT EXISTS public.app_settings (
+  key        TEXT        PRIMARY KEY,
+  value      TEXT        NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.app_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "bureau_admin_full_access" ON public.app_settings
+  FOR ALL TO authenticated
+  USING  ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'))
+  WITH CHECK ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'));
+
+INSERT INTO public.app_settings (key, value)
+  VALUES ('auto_acknowledgment_enabled', 'false')
+  ON CONFLICT (key) DO NOTHING;

--- a/types/index.ts
+++ b/types/index.ts
@@ -135,3 +135,18 @@ export type EmailSummary = {
 export type EmailDetail = EmailSummary & {
   body: string
 }
+
+export type EmailAcknowledgment = {
+  id: string
+  message_id: string
+  thread_id: string
+  sender_email: string
+  client_name: string | null
+  sent_at: string
+}
+
+export type AppSetting = {
+  key: string
+  value: string
+  updated_at: string
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -90,6 +90,33 @@ export type Database = {
           },
         ]
       }
+      email_acknowledgments: {
+        Row: {
+          id: string
+          message_id: string
+          thread_id: string
+          sender_email: string
+          client_name: string | null
+          sent_at: string
+        }
+        Insert: {
+          id?: string
+          message_id: string
+          thread_id: string
+          sender_email: string
+          client_name?: string | null
+          sent_at?: string
+        }
+        Update: {
+          id?: string
+          message_id?: string
+          thread_id?: string
+          sender_email?: string
+          client_name?: string | null
+          sent_at?: string
+        }
+        Relationships: []
+      }
       email_statuses: {
         Row: {
           id: string
@@ -127,6 +154,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      app_settings: {
+        Row: {
+          key: string
+          value: string
+          updated_at: string
+        }
+        Insert: {
+          key: string
+          value: string
+          updated_at?: string
+        }
+        Update: {
+          key?: string
+          value?: string
+          updated_at?: string
+        }
+        Relationships: []
       }
       clients: {
         Row: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/email-acknowledgment",
+      "schedule": "*/2 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
- Migration: email_acknowledgments (log) + app_settings (toggle) tables
- lib/acknowledgments.ts: enabled check, 30-min dedup, log, poll-window tracking
- lib/email/acknowledgment.ts: personalized French ack template
- GET /api/cron/email-acknowledgment: Vercel cron (every 2 min) — fetches new
  Gmail messages, skips if already acked from same sender in last 30 min, sends
  and logs ack; secured with CRON_SECRET
- PATCH /api/parametres/acknowledgment: bureau/admin toggle endpoint
- AutoAcknowledgmentSection component: Switch UI with optimistic state
- Parametres page: new "Automatisations" section with the toggle
- vercel.json: cron schedule */2 * * * *
- .env.example: CRON_SECRET variable

https://claude.ai/code/session_0113J3w6SVx53U5he4wTnPYy