### PR TITLE
feat: persist email classification category to database

### DIFF
--- a/app/api/agents/email/classify/route.ts
+++ b/app/api/agents/email/classify/route.ts
@@ -2,12 +2,15 @@ import { NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
 import { getUser } from "@/lib/supabase/server"
 import { classifyEmail } from "@/lib/agents/email"
+import { saveEmailCategory } from "@/lib/email-statuses"
 
 export const maxDuration = 30
 
 const classifySchema = z.object({
   subject: z.string(),
   body: z.string().min(1, "Corps du message requis"),
+  messageId: z.string().optional(),
+  threadId: z.string().optional(),
 })
 
 export async function POST(req: NextRequest) {
@@ -33,6 +36,13 @@ export async function POST(req: NextRequest) {
 
   try {
     const result = await classifyEmail(parsed.data.subject, parsed.data.body, req.signal)
+
+    if (parsed.data.messageId && parsed.data.threadId) {
+      saveEmailCategory(parsed.data.messageId, parsed.data.threadId, result.category).catch(
+        (err) => console.error("Failed to persist email category:", err)
+      )
+    }
+
     return NextResponse.json(result)
   } catch (err) {
     const isTimeout =

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -162,7 +162,12 @@ export function EmailDetail({
     fetch("/api/agents/email/classify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ subject: detail.subject, body: plainBody }),
+      body: JSON.stringify({
+        subject: detail.subject,
+        body: plainBody,
+        messageId: detail.id,
+        threadId: detail.threadId,
+      }),
     })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: EmailClassification | null) => {

--- a/components/inbox/email-list.tsx
+++ b/components/inbox/email-list.tsx
@@ -113,7 +113,12 @@ function parseSenderName(from: string): { name: string; address: string } {
 export function EmailList({ emails, initialStatuses, clients }: Props) {
   const [statuses, setStatuses] =
     useState<Record<string, EmailStatusRecord>>(initialStatuses)
-  const [classifications, setClassifications] = useState<Record<string, EmailCategory>>({})
+  const [classifications, setClassifications] = useState<Record<string, EmailCategory>>(() =>
+    Object.entries(initialStatuses).reduce<Record<string, EmailCategory>>(
+      (acc, [id, r]) => (r.category ? { ...acc, [id]: r.category } : acc),
+      {}
+    )
+  )
   const [selectedId, setSelectedId] = useState<string | null>(
     emails[0]?.id ?? null
   )
@@ -148,6 +153,7 @@ export function EmailList({ emails, initialStatuses, clients }: Props) {
         message_id: email.id,
         thread_id: email.threadId,
         status,
+        category: statuses[email.id]?.category ?? null,
         client_id: clientId !== undefined ? clientId : (statuses[email.id]?.client_id ?? null),
         created_at: statuses[email.id]?.created_at ?? new Date().toISOString(),
         updated_at: new Date().toISOString(),

--- a/lib/email-statuses.ts
+++ b/lib/email-statuses.ts
@@ -1,5 +1,5 @@
 import { supabaseService } from "@/lib/supabase/service"
-import type { EmailStatus, EmailStatusRecord, LinkedClient } from "@/types"
+import type { EmailCategory, EmailStatus, EmailStatusRecord, LinkedClient } from "@/types"
 
 export async function getEmailStatuses(
   messageIds: string[]
@@ -39,6 +39,18 @@ export async function upsertEmailStatus(
 
   if (error) throw error
   return data as EmailStatusRecord
+}
+
+export async function saveEmailCategory(
+  messageId: string,
+  threadId: string,
+  category: EmailCategory
+): Promise<void> {
+  const { error } = await supabaseService
+    .from("email_statuses")
+    .upsert({ message_id: messageId, thread_id: threadId, category }, { onConflict: "message_id" })
+
+  if (error) throw error
 }
 
 export async function findClientByEmailAddress(

--- a/supabase/migrations/20260430000010_add_category_to_email_statuses.sql
+++ b/supabase/migrations/20260430000010_add_category_to_email_statuses.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.email_statuses
+  ADD COLUMN IF NOT EXISTS category TEXT
+    CHECK (category IN ('demande_devis', 'suivi_commande', 'question', 'autre'));

--- a/types/index.ts
+++ b/types/index.ts
@@ -96,6 +96,7 @@ export type EmailStatusRecord = {
   message_id: string
   thread_id: string
   status: EmailStatus
+  category: EmailCategory | null
   client_id: string | null
   created_at: string
   updated_at: string

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -123,6 +123,7 @@ export type Database = {
           message_id: string
           thread_id: string
           status: "a_traiter" | "en_cours" | "repondu" | "archive"
+          category: "demande_devis" | "suivi_commande" | "question" | "autre" | null
           client_id: string | null
           created_at: string
           updated_at: string
@@ -132,6 +133,7 @@ export type Database = {
           message_id: string
           thread_id: string
           status?: "a_traiter" | "en_cours" | "repondu" | "archive"
+          category?: "demande_devis" | "suivi_commande" | "question" | "autre" | null
           client_id?: string | null
           created_at?: string
           updated_at?: string
@@ -141,6 +143,7 @@ export type Database = {
           message_id?: string
           thread_id?: string
           status?: "a_traiter" | "en_cours" | "repondu" | "archive"
+          category?: "demande_devis" | "suivi_commande" | "question" | "autre" | null
           client_id?: string | null
           created_at?: string
           updated_at?: string


### PR DESCRIPTION
After the AI classifies an email, save the category to the
email_statuses table so classification badges survive page reloads.

- Add migration: category column on email_statuses (nullable)
- Add saveEmailCategory() to lib/email-statuses.ts
- Classify route accepts optional messageId/threadId and fire-and-forgets
  a DB save after a successful classification
- EmailDetail passes messageId/threadId to the classify endpoint
- EmailList initialises classifications state from saved statuses so
  badges render immediately on load without re-classifying

https://claude.ai/code/session_01SJLxfQMDExqAfxAFeV7oz3