### PR TITLE
feat: automatic reminders for quotes and payments

### DIFF
--- a/app/api/cron/quote-reminders/route.ts
+++ b/app/api/cron/quote-reminders/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server"
+import { Resend } from "resend"
+import { getQuotesDueForReminder, logReminder } from "@/lib/reminders"
+import { buildReminderSubject, buildReminderHtml } from "@/lib/email/reminder"
+import { env } from "@/lib/env"
+import type { ReminderType } from "@/types"
+
+function isCronAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return false
+  const auth = request.headers.get("authorization")
+  return auth === `Bearer ${secret}`
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const resend = new Resend(env.RESEND_API_KEY)
+  const types: ReminderType[] = ["quote_j7", "quote_j14", "payment"]
+  const results: {
+    type: ReminderType
+    quoteId: string
+    status: "sent" | "skipped"
+    reason?: string
+  }[] = []
+
+  for (const type of types) {
+    let quotes
+    try {
+      quotes = await getQuotesDueForReminder(type)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      results.push({
+        type,
+        quoteId: "*",
+        status: "skipped",
+        reason: `fetch_error: ${message}`,
+      })
+      continue
+    }
+
+    for (const quote of quotes) {
+      const clientEmail = quote.project.client.email
+      if (!clientEmail) {
+        results.push({
+          type,
+          quoteId: quote.id,
+          status: "skipped",
+          reason: "no_client_email",
+        })
+        continue
+      }
+
+      try {
+        await resend.emails.send({
+          from: "BTP × AI Métallerie <devis@btpxai.fr>",
+          to: [clientEmail],
+          subject: buildReminderSubject(quote, type),
+          html: buildReminderHtml(quote, type),
+        })
+
+        await logReminder(quote.id, type, clientEmail)
+        results.push({ type, quoteId: quote.id, status: "sent" })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        results.push({
+          type,
+          quoteId: quote.id,
+          status: "skipped",
+          reason: `send_error: ${message}`,
+        })
+      }
+    }
+  }
+
+  const sent = results.filter((r) => r.status === "sent").length
+  return NextResponse.json({ processed: results.length, sent, results })
+}

--- a/app/api/devis/[id]/reminders/route.ts
+++ b/app/api/devis/[id]/reminders/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+
+const updateSchema = z.object({
+  enabled: z.boolean(),
+})
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const user = await getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("quotes")
+    .select("reminders_enabled")
+    .eq("id", id)
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: "Devis introuvable" }, { status: 404 })
+  }
+
+  return NextResponse.json({ reminders_enabled: data.reminders_enabled })
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const user = await getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 })
+  }
+
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Paramètre 'enabled' (boolean) requis" }, { status: 422 })
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("quotes")
+    .update({ reminders_enabled: parsed.data.enabled })
+    .eq("id", id)
+    .select("reminders_enabled")
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: "Impossible de mettre à jour" }, { status: 500 })
+  }
+
+  return NextResponse.json({ reminders_enabled: data.reminders_enabled })
+}

--- a/components/devis/quotes-table.tsx
+++ b/components/devis/quotes-table.tsx
@@ -16,6 +16,8 @@ import {
   FileText,
   ChevronDown,
   Calendar,
+  Bell,
+  BellOff,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -193,6 +195,25 @@ export function QuotesTable({ quotes }: Props) {
     [router]
   )
 
+  const handleToggleReminders = useCallback(
+    async (id: string, currentlyEnabled: boolean) => {
+      const res = await fetch(`/api/devis/${id}/reminders`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !currentlyEnabled }),
+      })
+      if (res.ok) {
+        toast.success(
+          currentlyEnabled ? "Relances désactivées" : "Relances activées"
+        )
+        startTransition(() => router.refresh())
+      } else {
+        toast.error("Impossible de modifier les relances")
+      }
+    },
+    [router]
+  )
+
   return (
     <div className="space-y-4">
       {/* Status stat pills */}
@@ -355,6 +376,7 @@ export function QuotesTable({ quotes }: Props) {
                   onSend={handleSend}
                   onDuplicate={handleDuplicate}
                   onArchive={handleArchive}
+                  onToggleReminders={handleToggleReminders}
                 />
               ))
             )}
@@ -423,6 +445,7 @@ type RowProps = {
   onSend: (id: string) => Promise<void>
   onDuplicate: (id: string) => Promise<void>
   onArchive: (id: string) => Promise<void>
+  onToggleReminders: (id: string, currentlyEnabled: boolean) => Promise<void>
 }
 
 function QuoteRow({
@@ -431,7 +454,9 @@ function QuoteRow({
   onSend,
   onDuplicate,
   onArchive,
+  onToggleReminders,
 }: RowProps) {
+  const remindersEnabled = quote.reminders_enabled ?? true
   const reference =
     quote.reference ?? `DEV-${quote.id.slice(0, 8).toUpperCase()}`
   const config = STATUS_CONFIG[quote.status]
@@ -558,6 +583,24 @@ function QuoteRow({
             data-testid="action-archive"
           >
             <Archive className="size-3.5" />
+          </button>
+
+          <button
+            onClick={() => onToggleReminders(quote.id, remindersEnabled)}
+            title={remindersEnabled ? "Désactiver les relances" : "Activer les relances"}
+            data-testid="action-toggle-reminders"
+            className={cn(
+              "size-7 flex items-center justify-center rounded-sm transition-colors",
+              remindersEnabled
+                ? "text-sky-400 hover:text-sky-300 hover:bg-sky-400/10"
+                : "text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted"
+            )}
+          >
+            {remindersEnabled ? (
+              <Bell className="size-3.5" />
+            ) : (
+              <BellOff className="size-3.5" />
+            )}
           </button>
         </div>
       </td>

--- a/lib/email/reminder.ts
+++ b/lib/email/reminder.ts
@@ -1,0 +1,157 @@
+import type { QuoteWithContext } from "@/types"
+import type { ReminderType } from "@/types"
+
+function fmtEur(n: number) {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(n)
+}
+
+function getRef(quote: QuoteWithContext): string {
+  return quote.reference ?? `DEV-${quote.id.slice(0, 8).toUpperCase()}`
+}
+
+export function buildReminderSubject(
+  quote: QuoteWithContext,
+  type: ReminderType
+): string {
+  const ref = getRef(quote)
+  if (type === "quote_j7") return `Relance — Votre devis ${ref} est en attente`
+  if (type === "quote_j14")
+    return `Rappel urgent — Devis ${ref} : validité bientôt expirée`
+  return `Rappel paiement — Devis ${ref} accepté`
+}
+
+export function buildReminderHtml(
+  quote: QuoteWithContext,
+  type: ReminderType
+): string {
+  const ref = getRef(quote)
+  const clientName = quote.project.client.name
+  const totalHT = quote.total_ht ?? 0
+  const tvaRate = quote.tva_rate ?? 20
+  const totalTTC = Math.round(totalHT * (1 + tvaRate / 100) * 100) / 100
+  const validityDays = quote.validity_days ?? 30
+  const projectTitle = quote.project.title || "vos travaux"
+
+  const intro = buildIntro(type, clientName, projectTitle, ref, validityDays)
+  const badgeColor = type === "payment" ? "#10b981" : "#f59e0b"
+  const badgeText =
+    type === "quote_j7"
+      ? "Relance J+7"
+      : type === "quote_j14"
+        ? "Relance J+14"
+        : "Rappel paiement"
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${buildReminderSubject(quote, type)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:system-ui,-apple-system,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;border:1px solid #e4e4e7;">
+          <tr>
+            <td style="background:#18181b;padding:32px 40px;">
+              <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">BTP × AI Métallerie</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#a1a1aa;">12 rue de la Forge, 75001 Paris · 01 23 45 67 89</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px;">
+              <p style="margin:0 0 20px;display:inline-block;padding:4px 12px;background:${badgeColor}1a;color:${badgeColor};font-size:11px;font-weight:600;border-radius:4px;border:1px solid ${badgeColor}33;text-transform:uppercase;letter-spacing:0.08em;">${badgeText}</p>
+              <p style="margin:0 0 24px;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.1em;font-weight:600;">DEVIS N° ${ref}</p>
+              ${intro}
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#fafafa;border:1px solid #e4e4e7;border-radius:6px;margin-bottom:24px;">
+                <tr>
+                  <td style="padding:20px 24px;border-bottom:1px solid #e4e4e7;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Référence</p>
+                    <p style="margin:0;font-size:15px;font-weight:600;color:#18181b;">${ref}</p>
+                  </td>
+                  <td style="padding:20px 24px;border-bottom:1px solid #e4e4e7;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Validité</p>
+                    <p style="margin:0;font-size:15px;font-weight:600;color:#18181b;">${validityDays} jours</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:20px 24px;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Total H.T.</p>
+                    <p style="margin:0;font-size:15px;font-weight:600;color:#18181b;">${fmtEur(totalHT)}</p>
+                  </td>
+                  <td style="padding:20px 24px;">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;">Total T.T.C. (TVA ${tvaRate} %)</p>
+                    <p style="margin:0;font-size:18px;font-weight:700;color:#18181b;">${fmtEur(totalTTC)}</p>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 32px;font-size:14px;color:#3f3f46;line-height:1.6;">
+                Pour toute question, n'hésitez pas à nous contacter en répondant à cet email.
+              </p>
+              <p style="margin:0;font-size:14px;color:#3f3f46;line-height:1.6;">Cordialement,</p>
+              <p style="margin:4px 0 0;font-size:14px;font-weight:600;color:#18181b;">L'équipe BTP × AI Métallerie</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:#fafafa;padding:20px 40px;border-top:1px solid #e4e4e7;">
+              <p style="margin:0;font-size:12px;color:#a1a1aa;text-align:center;">
+                BTP × AI Métallerie · SIRET 123 456 789 00010 · contact@btpxai.fr
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}
+
+function buildIntro(
+  type: ReminderType,
+  clientName: string,
+  projectTitle: string,
+  ref: string,
+  validityDays: number
+): string {
+  if (type === "quote_j7") {
+    return `
+      <p style="margin:0 0 16px;font-size:16px;color:#18181b;">Bonjour ${clientName},</p>
+      <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+        Nous revenons vers vous au sujet de notre devis pour <strong>${projectTitle}</strong>.
+        Il y a 7 jours, nous vous avons transmis le devis <strong>${ref}</strong> et nous n'avons pas encore eu de retour de votre part.
+      </p>
+      <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+        Souhaitez-vous donner suite à ce devis, ou avez-vous des questions ou des modifications à demander ?
+        Nous sommes à votre disposition.
+      </p>`
+  }
+
+  if (type === "quote_j14") {
+    return `
+      <p style="margin:0 0 16px;font-size:16px;color:#18181b;">Bonjour ${clientName},</p>
+      <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+        Nous vous contactons une dernière fois au sujet de votre devis <strong>${ref}</strong> pour <strong>${projectTitle}</strong>.
+        La période de validité de <strong>${validityDays} jours</strong> arrive à son terme.
+      </p>
+      <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+        Si vous souhaitez toujours bénéficier de ce devis, merci de nous faire part de votre décision rapidement.
+        Passé ce délai, le tarif indiqué ne pourra plus être garanti.
+      </p>`
+  }
+
+  return `
+    <p style="margin:0 0 16px;font-size:16px;color:#18181b;">Bonjour ${clientName},</p>
+    <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+      Nous vous remercions d'avoir accepté notre devis <strong>${ref}</strong> pour <strong>${projectTitle}</strong>.
+    </p>
+    <p style="margin:0 0 24px;font-size:15px;color:#3f3f46;line-height:1.6;">
+      Dans le cadre du suivi de votre dossier, nous vous adressons ce rappel concernant le règlement.
+      N'hésitez pas à nous contacter si vous avez des questions relatives au paiement.
+    </p>`
+}

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -1,0 +1,87 @@
+import { supabaseService } from "@/lib/supabase/service"
+import type { ReminderType, QuoteReminder, QuoteWithContext } from "@/types"
+
+const REMINDER_DAYS: Record<ReminderType, number> = {
+  quote_j7: 7,
+  quote_j14: 14,
+  payment: 7,
+}
+
+const REMINDER_STATUS: Record<ReminderType, string> = {
+  quote_j7: "sent",
+  quote_j14: "sent",
+  payment: "accepted",
+}
+
+export async function getQuotesDueForReminder(
+  type: ReminderType
+): Promise<QuoteWithContext[]> {
+  const days = REMINDER_DAYS[type]
+  const status = REMINDER_STATUS[type]
+  const threshold = new Date(
+    Date.now() - days * 24 * 60 * 60 * 1000
+  ).toISOString()
+
+  // Collect quote IDs that already have this reminder type
+  const { data: existing } = await supabaseService
+    .from("quote_reminders")
+    .select("quote_id")
+    .eq("type", type)
+
+  const alreadySentIds = new Set((existing ?? []).map((r) => r.quote_id))
+
+  const { data: quotes, error } = await supabaseService
+    .from("quotes")
+    .select("*, items:quote_items(*), project:projects(*, client:clients(*))")
+    .eq("status", status)
+    .eq("reminders_enabled", true)
+    .lte("sent_at", threshold)
+    .not("sent_at", "is", null)
+
+  if (error) throw error
+
+  return ((quotes ?? []) as unknown as QuoteWithContext[]).filter(
+    (q) => !alreadySentIds.has(q.id)
+  )
+}
+
+export async function logReminder(
+  quoteId: string,
+  type: ReminderType,
+  emailTo: string
+): Promise<QuoteReminder> {
+  const { data, error } = await supabaseService
+    .from("quote_reminders")
+    .insert({ quote_id: quoteId, type, email_to: emailTo })
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as QuoteReminder
+}
+
+export async function hasReminder(
+  quoteId: string,
+  type: ReminderType
+): Promise<boolean> {
+  const { data } = await supabaseService
+    .from("quote_reminders")
+    .select("id")
+    .eq("quote_id", quoteId)
+    .eq("type", type)
+    .limit(1)
+
+  return Boolean(data?.length)
+}
+
+export async function setQuoteRemindersEnabled(
+  quoteId: string,
+  enabled: boolean
+): Promise<void> {
+  const { error } = await supabaseService
+    .from("quotes")
+    .update({ reminders_enabled: enabled })
+    .eq("id", quoteId)
+
+  if (error) throw error
+}

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -1,5 +1,5 @@
 import { supabaseService } from "@/lib/supabase/service"
-import type { ReminderType, QuoteReminder, QuoteWithContext } from "@/types"
+import type { ReminderType, QuoteReminder, QuoteWithContext, QuoteStatus } from "@/types"
 
 const REMINDER_DAYS: Record<ReminderType, number> = {
   quote_j7: 7,
@@ -7,7 +7,7 @@ const REMINDER_DAYS: Record<ReminderType, number> = {
   payment: 7,
 }
 
-const REMINDER_STATUS: Record<ReminderType, string> = {
+const REMINDER_STATUS: Record<ReminderType, QuoteStatus> = {
   quote_j7: "sent",
   quote_j14: "sent",
   payment: "accepted",

--- a/supabase/migrations/20260430000011_quote_reminders.sql
+++ b/supabase/migrations/20260430000011_quote_reminders.sql
@@ -1,0 +1,23 @@
+-- Add reminders toggle to quotes
+ALTER TABLE public.quotes
+  ADD COLUMN reminders_enabled BOOLEAN NOT NULL DEFAULT true;
+
+-- Track sent reminders to prevent duplicates
+CREATE TABLE IF NOT EXISTS public.quote_reminders (
+  id        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  quote_id  UUID        NOT NULL REFERENCES public.quotes(id) ON DELETE CASCADE,
+  type      TEXT        NOT NULL CHECK (type IN ('quote_j7', 'quote_j14', 'payment')),
+  sent_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  email_to  TEXT        NOT NULL
+);
+
+ALTER TABLE public.quote_reminders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "bureau_admin_full_access" ON public.quote_reminders
+  FOR ALL TO authenticated
+  USING  ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'))
+  WITH CHECK ((auth.jwt() -> 'user_metadata' ->> 'role') IN ('bureau', 'admin'));
+
+CREATE INDEX IF NOT EXISTS quote_reminders_quote_id_idx ON public.quote_reminders(quote_id);
+CREATE INDEX IF NOT EXISTS quote_reminders_type_idx      ON public.quote_reminders(type);
+CREATE INDEX IF NOT EXISTS quote_reminders_sent_at_idx   ON public.quote_reminders(sent_at);

--- a/tests/unit/reminders.test.ts
+++ b/tests/unit/reminders.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { ReminderType, QuoteWithContext } from "@/types"
+
+// ─── supabaseService mock ──────────────────────────────────────────────────
+
+const mockFrom = vi.fn()
+vi.mock("@/lib/supabase/service", () => ({
+  supabaseService: { from: mockFrom },
+}))
+
+import {
+  getQuotesDueForReminder,
+  logReminder,
+  hasReminder,
+  setQuoteRemindersEnabled,
+} from "@/lib/reminders"
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeBuilder(result: { data: unknown; error: null | object }) {
+  const builder: Record<string, unknown> = {
+    then: (
+      resolve: (v: unknown) => unknown,
+      reject?: (r: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject),
+  }
+  for (const m of [
+    "select",
+    "insert",
+    "update",
+    "eq",
+    "lte",
+    "not",
+    "limit",
+    "single",
+  ]) {
+    builder[m] = vi.fn().mockReturnValue(builder)
+  }
+  return builder
+}
+
+// ─── fixtures ─────────────────────────────────────────────────────────────────
+
+const now = new Date("2026-04-30T08:00:00Z")
+
+function makeSentQuote(
+  overrides: Partial<{ id: string; sent_at: string; status: string }>
+): QuoteWithContext {
+  return {
+    id: "q1",
+    project_id: "p1",
+    status: "sent",
+    total_ht: 1000,
+    tva_rate: 20,
+    notes: null,
+    validity_days: 30,
+    reference: "DEV-001",
+    created_at: "2026-04-01T00:00:00Z",
+    sent_at: "2026-04-20T00:00:00Z",
+    reminders_enabled: true,
+    items: [],
+    project: {
+      id: "p1",
+      client_id: "c1",
+      title: "Portail acier",
+      description: null,
+      status: "in_progress",
+      created_at: "2026-04-01T00:00:00Z",
+      client: {
+        id: "c1",
+        name: "Jean Dupont",
+        email: "jean@example.com",
+        phone: null,
+        address: null,
+        created_at: "2026-04-01T00:00:00Z",
+      },
+    },
+    ...overrides,
+  } as QuoteWithContext
+}
+
+// ─── getQuotesDueForReminder ──────────────────────────────────────────────────
+
+describe("getQuotesDueForReminder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.setSystemTime(now)
+  })
+
+  it("returns quotes not yet reminded for quote_j7", async () => {
+    const quote = makeSentQuote({ id: "q1" })
+    const remindersBuilder = makeBuilder({ data: [], error: null })
+    const quotesBuilder = makeBuilder({ data: [quote], error: null })
+    mockFrom
+      .mockReturnValueOnce(remindersBuilder)
+      .mockReturnValueOnce(quotesBuilder)
+
+    const result = await getQuotesDueForReminder("quote_j7")
+
+    expect(mockFrom).toHaveBeenNthCalledWith(1, "quote_reminders")
+    expect(remindersBuilder.eq).toHaveBeenCalledWith("type", "quote_j7")
+    expect(mockFrom).toHaveBeenNthCalledWith(2, "quotes")
+    expect(quotesBuilder.eq).toHaveBeenCalledWith("status", "sent")
+    expect(quotesBuilder.eq).toHaveBeenCalledWith("reminders_enabled", true)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("q1")
+  })
+
+  it("excludes quotes that already have a reminder of the given type", async () => {
+    const remindersBuilder = makeBuilder({
+      data: [{ quote_id: "q1" }],
+      error: null,
+    })
+    const quote = makeSentQuote({ id: "q1" })
+    const quotesBuilder = makeBuilder({ data: [quote], error: null })
+    mockFrom
+      .mockReturnValueOnce(remindersBuilder)
+      .mockReturnValueOnce(quotesBuilder)
+
+    const result = await getQuotesDueForReminder("quote_j7")
+    expect(result).toHaveLength(0)
+  })
+
+  it("uses status 'accepted' for payment reminders", async () => {
+    const remindersBuilder = makeBuilder({ data: [], error: null })
+    const quotesBuilder = makeBuilder({ data: [], error: null })
+    mockFrom
+      .mockReturnValueOnce(remindersBuilder)
+      .mockReturnValueOnce(quotesBuilder)
+
+    await getQuotesDueForReminder("payment")
+
+    expect(quotesBuilder.eq).toHaveBeenCalledWith("status", "accepted")
+  })
+
+  it("throws when the quotes query fails", async () => {
+    const remindersBuilder = makeBuilder({ data: [], error: null })
+    const dbError = { message: "DB error", code: "500" }
+    const quotesBuilder = makeBuilder({ data: null, error: dbError })
+    mockFrom
+      .mockReturnValueOnce(remindersBuilder)
+      .mockReturnValueOnce(quotesBuilder)
+
+    await expect(getQuotesDueForReminder("quote_j14")).rejects.toEqual(dbError)
+  })
+})
+
+// ─── logReminder ──────────────────────────────────────────────────────────────
+
+describe("logReminder", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("inserts a reminder record and returns it", async () => {
+    const reminder = {
+      id: "r1",
+      quote_id: "q1",
+      type: "quote_j7",
+      sent_at: "2026-04-30T08:00:00Z",
+      email_to: "jean@example.com",
+    }
+    const builder = makeBuilder({ data: reminder, error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await logReminder("q1", "quote_j7", "jean@example.com")
+
+    expect(mockFrom).toHaveBeenCalledWith("quote_reminders")
+    expect(builder.insert).toHaveBeenCalledWith({
+      quote_id: "q1",
+      type: "quote_j7",
+      email_to: "jean@example.com",
+    })
+    expect(result).toEqual(reminder)
+  })
+
+  it("throws on insert error", async () => {
+    const dbError = { message: "Insert failed", code: "500" }
+    const builder = makeBuilder({ data: null, error: dbError })
+    mockFrom.mockReturnValueOnce(builder)
+
+    await expect(
+      logReminder("q1", "quote_j7", "jean@example.com")
+    ).rejects.toEqual(dbError)
+  })
+})
+
+// ─── hasReminder ─────────────────────────────────────────────────────────────
+
+describe("hasReminder", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns true when a reminder record exists", async () => {
+    const builder = makeBuilder({ data: [{ id: "r1" }], error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await hasReminder("q1", "quote_j7")
+
+    expect(result).toBe(true)
+    expect(builder.eq).toHaveBeenCalledWith("quote_id", "q1")
+    expect(builder.eq).toHaveBeenCalledWith("type", "quote_j7")
+  })
+
+  it("returns false when no reminder record exists", async () => {
+    const builder = makeBuilder({ data: [], error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await hasReminder("q1", "quote_j14")
+    expect(result).toBe(false)
+  })
+})
+
+// ─── setQuoteRemindersEnabled ─────────────────────────────────────────────────
+
+describe("setQuoteRemindersEnabled", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("updates reminders_enabled to false", async () => {
+    const builder = makeBuilder({ data: null, error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    await expect(
+      setQuoteRemindersEnabled("q1", false)
+    ).resolves.toBeUndefined()
+
+    expect(mockFrom).toHaveBeenCalledWith("quotes")
+    expect(builder.update).toHaveBeenCalledWith({ reminders_enabled: false })
+    expect(builder.eq).toHaveBeenCalledWith("id", "q1")
+  })
+
+  it("throws on update error", async () => {
+    const dbError = { message: "Update failed", code: "500" }
+    const builder = makeBuilder({ data: null, error: dbError })
+    mockFrom.mockReturnValueOnce(builder)
+
+    await expect(
+      setQuoteRemindersEnabled("q1", true)
+    ).rejects.toEqual(dbError)
+  })
+})
+
+// ─── Reminder trigger day logic ───────────────────────────────────────────────
+
+describe("reminder trigger day logic", () => {
+  const REMINDER_DAYS: Record<ReminderType, number> = {
+    quote_j7: 7,
+    quote_j14: 14,
+    payment: 7,
+  }
+
+  it.each([
+    ["quote_j7", 7],
+    ["quote_j14", 14],
+    ["payment", 7],
+  ] as [ReminderType, number][])(
+    "%s triggers after %d days",
+    (type, days) => {
+      const today = new Date("2026-04-30T00:00:00Z")
+      const sentAt = new Date(today.getTime() - days * 24 * 60 * 60 * 1000)
+      const threshold = new Date(
+        today.getTime() - REMINDER_DAYS[type] * 24 * 60 * 60 * 1000
+      )
+
+      expect(sentAt.getTime()).toBeLessThanOrEqual(threshold.getTime())
+    }
+  )
+
+  it("quote sent 6 days ago should NOT trigger quote_j7", () => {
+    const today = new Date("2026-04-30T00:00:00Z")
+    const sentAt = new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000)
+    const threshold = new Date(
+      today.getTime() - REMINDER_DAYS["quote_j7"] * 24 * 60 * 60 * 1000
+    )
+
+    expect(sentAt.getTime()).toBeGreaterThan(threshold.getTime())
+  })
+})

--- a/tests/unit/reminders.test.ts
+++ b/tests/unit/reminders.test.ts
@@ -3,7 +3,7 @@ import type { ReminderType, QuoteWithContext } from "@/types"
 
 // ─── supabaseService mock ──────────────────────────────────────────────────
 
-const mockFrom = vi.fn()
+const mockFrom = vi.hoisted(() => vi.fn())
 vi.mock("@/lib/supabase/service", () => ({
   supabaseService: { from: mockFrom },
 }))

--- a/types/index.ts
+++ b/types/index.ts
@@ -151,3 +151,13 @@ export type AppSetting = {
   value: string
   updated_at: string
 }
+
+export type ReminderType = "quote_j7" | "quote_j14" | "payment"
+
+export type QuoteReminder = {
+  id: string
+  quote_id: string
+  type: ReminderType
+  sent_at: string
+  email_to: string
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -303,6 +303,38 @@ export type Database = {
           },
         ]
       }
+      quote_reminders: {
+        Row: {
+          id: string
+          quote_id: string
+          type: string
+          sent_at: string
+          email_to: string
+        }
+        Insert: {
+          id?: string
+          quote_id: string
+          type: string
+          sent_at?: string
+          email_to: string
+        }
+        Update: {
+          id?: string
+          quote_id?: string
+          type?: string
+          sent_at?: string
+          email_to?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quote_reminders_quote_id_fkey"
+            columns: ["quote_id"]
+            isOneToOne: false
+            referencedRelation: "quotes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       quotes: {
         Row: {
           created_at: string
@@ -310,6 +342,7 @@ export type Database = {
           notes: string | null
           project_id: string
           reference: string | null
+          reminders_enabled: boolean
           sent_at: string | null
           status: Database["public"]["Enums"]["quote_status"]
           total_ht: number
@@ -322,6 +355,7 @@ export type Database = {
           notes?: string | null
           project_id: string
           reference?: string | null
+          reminders_enabled?: boolean
           sent_at?: string | null
           status?: Database["public"]["Enums"]["quote_status"]
           total_ht?: number
@@ -334,6 +368,7 @@ export type Database = {
           notes?: string | null
           project_id?: string
           reference?: string | null
+          reminders_enabled?: boolean
           sent_at?: string | null
           status?: Database["public"]["Enums"]["quote_status"]
           total_ht?: number

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/email-acknowledgment",
       "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/api/cron/quote-reminders",
+      "schedule": "0 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
- Migration: adds reminders_enabled (boolean, default true) to quotes and creates quote_reminders log table with dedup indexes
- lib/reminders.ts: getQuotesDueForReminder (J+7, J+14, payment), logReminder, hasReminder, setQuoteRemindersEnabled
- lib/email/reminder.ts: HTML email templates for quote follow-ups (J+7 / J+14) and payment reminder, matching existing brand style
- app/api/cron/quote-reminders: daily cron (08:00) iterates all three reminder types and sends via Resend, skips on missing email or prior reminder
- app/api/devis/[id]/reminders: GET/PUT endpoint to toggle reminders per quote (auth-protected)
- vercel.json: adds daily 08:00 cron entry
- QuotesTable: Bell / BellOff toggle button per row with optimistic refresh
- tests/unit/reminders.test.ts: Vitest unit tests covering trigger logic, dedup, and CRUD helpers

https://claude.ai/code/session_01TVWPgLdXGGzU1kUZZLUwt9