### PR TITLE
feat: afficher un résumé IA du contexte client dans la vue email

### DIFF
--- a/app/api/agents/email/client-summary/route.ts
+++ b/app/api/agents/email/client-summary/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser, createClient } from "@/lib/supabase/server"
+import { generateClientSummary } from "@/lib/agents/email"
+
+export const maxDuration = 30
+
+const requestSchema = z.object({
+  clientId: z.string().uuid(),
+  currentEmailSubject: z.string().optional(),
+  currentEmailSnippet: z.string().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  const user = await getUser()
+  if (!user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 })
+  }
+
+  const parsed = requestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    )
+  }
+
+  const { clientId, currentEmailSubject, currentEmailSnippet } = parsed.data
+
+  try {
+    const supabase = await createClient()
+
+    const { data: client, error: clientError } = await supabase
+      .from("clients")
+      .select("id, name, email, phone, address, created_at")
+      .eq("id", clientId)
+      .single()
+
+    if (clientError || !client) {
+      return NextResponse.json({ error: "Client introuvable" }, { status: 404 })
+    }
+
+    const [{ data: emailStatuses }, { data: projects }] = await Promise.all([
+      supabase
+        .from("email_statuses")
+        .select("status, category, created_at, updated_at")
+        .eq("client_id", clientId)
+        .order("created_at", { ascending: false })
+        .limit(20),
+      supabase
+        .from("projects")
+        .select("id, title, quotes(id, reference, status, total_ht, created_at, sent_at)")
+        .eq("client_id", clientId)
+        .order("created_at", { ascending: false }),
+    ])
+
+    type QuoteRow = {
+      id: string
+      reference: string | null
+      status: string
+      total_ht: number | null
+      created_at: string
+      sent_at: string | null
+    }
+    type ProjectRow = { id: string; title: string; quotes: QuoteRow[] | null }
+    type EmailStatusRow = {
+      status: string
+      category: string | null
+      created_at: string
+      updated_at: string
+    }
+
+    const emailHistory: EmailStatusRow[] = emailStatuses ?? []
+    const allQuotes = (projects as ProjectRow[] | null ?? []).flatMap(
+      (p: ProjectRow) =>
+        (p.quotes ?? []).map((q: QuoteRow) => ({ ...q, projectTitle: p.title }))
+    )
+
+    const clientAge = formatAge(client.created_at)
+    const emailCategories = [
+      ...new Set(
+        emailHistory
+          .map((e: EmailStatusRow) => e.category)
+          .filter((c): c is string => c !== null)
+      ),
+    ]
+    const latestEmailDate = emailHistory[0]?.updated_at
+    const acceptedRevenue = allQuotes
+      .filter((q) => q.status === "accepted" || q.status === "signed")
+      .reduce((sum: number, q) => sum + (q.total_ht ?? 0), 0)
+
+    const lines: string[] = [
+      `Client : ${client.name}`,
+      `Email : ${client.email ?? "non renseigné"}`,
+      `Téléphone : ${client.phone ?? "non renseigné"}`,
+      `Client depuis : ${clientAge}`,
+      "",
+      `Historique emails : ${emailHistory.length} email(s) traité(s)`,
+    ]
+
+    if (emailCategories.length > 0) {
+      lines.push(`Catégories : ${emailCategories.join(", ")}`)
+    }
+    if (latestEmailDate) {
+      lines.push(`Dernier contact : ${formatRelativeDate(latestEmailDate)}`)
+    }
+
+    lines.push("", `Devis : ${allQuotes.length} devis au total`)
+
+    if (allQuotes.length > 0) {
+      const recent = allQuotes.slice(0, 3).map(
+        (q) =>
+          `${q.reference ?? q.projectTitle} (${q.status}${q.total_ht ? `, ${q.total_ht}€ HT` : ""})`
+      )
+      lines.push(`Récents : ${recent.join(", ")}`)
+    }
+
+    if (acceptedRevenue > 0) {
+      lines.push(`CA accepté : ${acceptedRevenue}€ HT`)
+    }
+
+    if (currentEmailSubject) {
+      lines.push("", `Email consulté : "${currentEmailSubject}"`)
+      if (currentEmailSnippet) {
+        lines.push(`Aperçu : ${currentEmailSnippet.slice(0, 200)}`)
+      }
+    }
+
+    const context = lines.join("\n")
+    const result = await generateClientSummary(context, req.signal)
+    return NextResponse.json(result)
+  } catch (err) {
+    const isTimeout =
+      err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")
+    console.error("Client summary error:", err)
+    return NextResponse.json(
+      {
+        error: isTimeout
+          ? "Délai de génération dépassé (30s)"
+          : "Erreur lors de la génération du résumé",
+      },
+      { status: isTimeout ? 504 : 502 }
+    )
+  }
+}
+
+function formatAge(createdAt: string): string {
+  const date = new Date(createdAt)
+  const now = new Date()
+  const months =
+    (now.getFullYear() - date.getFullYear()) * 12 +
+    (now.getMonth() - date.getMonth())
+  if (months < 1) return "moins d'un mois"
+  if (months === 1) return "1 mois"
+  if (months < 12) return `${months} mois`
+  const years = Math.floor(months / 12)
+  return years === 1 ? "1 an" : `${years} ans`
+}
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  const diffDays = Math.floor(
+    (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24)
+  )
+  if (diffDays === 0) return "aujourd'hui"
+  if (diffDays === 1) return "hier"
+  if (diffDays < 7) return `il y a ${diffDays} jours`
+  if (diffDays < 30) return `il y a ${Math.floor(diffDays / 7)} semaine(s)`
+  if (diffDays < 365) return `il y a ${Math.floor(diffDays / 30)} mois`
+  return `il y a ${Math.floor(diffDays / 365)} an(s)`
+}

--- a/components/inbox/client-summary-panel.tsx
+++ b/components/inbox/client-summary-panel.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Brain, RotateCcw, AlertTriangle } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  clientId: string
+  clientName: string
+  currentEmailSubject?: string
+  currentEmailSnippet?: string
+  invalidationKey?: number
+}
+
+type CachedEntry = { summary: string; cachedAt: string }
+
+function cacheKey(clientId: string) {
+  return `client-summary-v1-${clientId}`
+}
+
+function readCache(clientId: string): string | null {
+  try {
+    const raw = sessionStorage.getItem(cacheKey(clientId))
+    if (!raw) return null
+    return (JSON.parse(raw) as CachedEntry).summary
+  } catch {
+    return null
+  }
+}
+
+function writeCache(clientId: string, summary: string) {
+  try {
+    const entry: CachedEntry = { summary, cachedAt: new Date().toISOString() }
+    sessionStorage.setItem(cacheKey(clientId), JSON.stringify(entry))
+  } catch {}
+}
+
+export function clearClientSummaryCache(clientId: string) {
+  try {
+    sessionStorage.removeItem(cacheKey(clientId))
+  } catch {}
+}
+
+export function ClientSummaryPanel({
+  clientId,
+  clientName,
+  currentEmailSubject,
+  currentEmailSnippet,
+  invalidationKey = 0,
+}: Props) {
+  const [summary, setSummary] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasError, setHasError] = useState(false)
+  const [revealed, setRevealed] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchSummary = useCallback(
+    async (skipCache: boolean) => {
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      if (!skipCache) {
+        const cached = readCache(clientId)
+        if (cached) {
+          setSummary(cached)
+          setRevealed(true)
+          return
+        }
+      }
+
+      setIsLoading(true)
+      setHasError(false)
+      setSummary(null)
+      setRevealed(false)
+
+      try {
+        const res = await fetch("/api/agents/email/client-summary", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            clientId,
+            currentEmailSubject,
+            currentEmailSnippet,
+          }),
+          signal: controller.signal,
+        })
+
+        if (!res.ok) throw new Error()
+        const data = (await res.json()) as { summary: string }
+        writeCache(clientId, data.summary)
+        setSummary(data.summary)
+        // Slight delay before reveal so the loader fades out cleanly
+        setTimeout(() => setRevealed(true), 80)
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") {
+          setHasError(true)
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [clientId, invalidationKey]
+  )
+
+  useEffect(() => {
+    setRevealed(false)
+    fetchSummary(false)
+    return () => abortRef.current?.abort()
+  }, [fetchSummary])
+
+  return (
+    <div className="relative border border-border bg-card overflow-hidden">
+      {/* Header bar */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/20">
+        <div className="flex items-center gap-2">
+          <div className="relative size-3.5 shrink-0">
+            <Brain
+              className={cn(
+                "size-3.5 transition-colors",
+                isLoading ? "text-primary animate-pulse" : "text-primary/70"
+              )}
+            />
+            {isLoading && (
+              <span className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
+            )}
+          </div>
+          <span className="text-[10px] font-mono tracking-widest uppercase text-muted-foreground">
+            Contexte client
+          </span>
+        </div>
+
+        {!isLoading && (summary || hasError) && (
+          <button
+            onClick={() => fetchSummary(true)}
+            title="Régénérer le résumé"
+            className="text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded"
+          >
+            <RotateCcw className="size-3" />
+          </button>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="px-3 py-2.5 min-h-[72px] flex items-start">
+        {isLoading && (
+          <div className="w-full space-y-1.5 pt-0.5" aria-label="Chargement du résumé">
+            <div className="h-2 bg-muted/60 rounded-sm animate-pulse w-full" />
+            <div className="h-2 bg-muted/60 rounded-sm animate-pulse w-[90%]" />
+            <div className="h-2 bg-muted/60 rounded-sm animate-pulse w-[75%]" />
+            <div className="h-2 bg-muted/60 rounded-sm animate-pulse w-[82%]" />
+          </div>
+        )}
+
+        {hasError && !isLoading && (
+          <div className="flex items-start gap-2 text-muted-foreground">
+            <AlertTriangle className="size-3.5 mt-0.5 shrink-0 text-amber-500/70" />
+            <p className="text-[11px] leading-relaxed">
+              Impossible de générer le résumé.{" "}
+              <button
+                onClick={() => fetchSummary(true)}
+                className="underline underline-offset-2 hover:text-foreground transition-colors"
+              >
+                Réessayer
+              </button>
+            </p>
+          </div>
+        )}
+
+        {summary && !isLoading && (
+          <p
+            className={cn(
+              "text-[11.5px] leading-[1.65] text-foreground/85 transition-all duration-500",
+              revealed ? "opacity-100 translate-y-0" : "opacity-0 translate-y-1"
+            )}
+          >
+            {summary}
+          </p>
+        )}
+      </div>
+
+      {/* Subtle AI watermark */}
+      {summary && !isLoading && (
+        <div className="absolute bottom-1.5 right-2.5">
+          <span className="text-[9px] font-mono tracking-widest uppercase text-muted-foreground/40">
+            IA · {clientName}
+          </span>
+        </div>
+      )}
+
+      {/* Scan-line accent on load */}
+      {isLoading && (
+        <div
+          className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent"
+          style={{ animation: "scan 1.4s ease-in-out infinite" }}
+        />
+      )}
+
+      <style>{`
+        @keyframes scan {
+          0% { transform: translateY(0); opacity: 0; }
+          10% { opacity: 1; }
+          90% { opacity: 1; }
+          100% { transform: translateY(80px); opacity: 0; }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/components/inbox/email-detail.tsx
+++ b/components/inbox/email-detail.tsx
@@ -26,6 +26,7 @@ import type {
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "sonner"
+import { ClientSummaryPanel } from "./client-summary-panel"
 
 type Client = { id: string; name: string; email: string | null }
 
@@ -452,6 +453,18 @@ export function EmailDetail({
             </div>
           )}
         </div>
+
+        {/* Client AI summary */}
+        {linkedClient && detail && (
+          <ClientSummaryPanel
+            clientId={linkedClient.id}
+            clientName={linkedClient.name}
+            currentEmailSubject={detail.subject}
+            currentEmailSnippet={detail.body.trimStart().startsWith("<")
+              ? stripHtml(detail.body).slice(0, 300)
+              : detail.body.slice(0, 300)}
+          />
+        )}
       </div>
 
       {/* Body */}

--- a/components/inbox/email-list.tsx
+++ b/components/inbox/email-list.tsx
@@ -18,6 +18,7 @@ import { createClient } from "@/lib/supabase/client"
 import { toast } from "sonner"
 import type { EmailSummary, EmailStatusRecord, EmailStatus, EmailCategory } from "@/types"
 import { EmailDetail } from "./email-detail"
+import { clearClientSummaryCache } from "./client-summary-panel"
 
 const CATEGORY_CONFIG: Record<
   EmailCategory,
@@ -137,6 +138,10 @@ export function EmailList({ emails, initialStatuses, clients }: Props) {
           const record = payload.new as EmailStatusRecord
           if (!record?.message_id) return
           setStatuses((prev) => ({ ...prev, [record.message_id]: record }))
+          // Invalidate cached AI summary when a new email arrives for a client
+          if (payload.eventType === "INSERT" && record.client_id) {
+            clearClientSummaryCache(record.client_id)
+          }
         }
       )
       .subscribe()

--- a/lib/agents/email.ts
+++ b/lib/agents/email.ts
@@ -2,6 +2,11 @@ import { generateObject } from "ai"
 import { anthropic } from "@ai-sdk/anthropic"
 import { z } from "zod"
 
+export const clientSummarySchema = z.object({
+  summary: z.string(),
+})
+export type ClientSummary = z.infer<typeof clientSummarySchema>
+
 export const emailCategorySchema = z.enum([
   "demande_devis",
   "suivi_commande",
@@ -81,6 +86,37 @@ export async function classifyEmail(
   })
 
   return emailClassificationSchema.parse(object)
+}
+
+const CLIENT_SUMMARY_SYSTEM_PROMPT = `Tu es l'assistant de gestion commerciale d'une PME familiale de métallerie et serrurerie. Tu génères des résumés contextuels concis sur les clients pour aider l'équipe bureau lors de la consultation des emails.
+
+Règles :
+- Résumé en 3-4 lignes maximum, en français
+- Inclure les informations utiles : ancienneté, projets/devis, historique email, points d'attention
+- Ton factuel et professionnel, sans redondance ni répétition
+- Si peu d'historique disponible, l'indiquer brièvement
+- Ne jamais inventer d'informations absentes des données fournies`
+
+export async function generateClientSummary(
+  context: string,
+  signal?: AbortSignal
+): Promise<ClientSummary> {
+  const timeoutSignal = AbortSignal.timeout(30_000)
+  const abortSignal =
+    signal && typeof AbortSignal.any === "function"
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+
+  const { object } = await generateObject({
+    model: anthropic("claude-sonnet-4-6"),
+    schema: z.object({ summary: z.string() }),
+    system: CLIENT_SUMMARY_SYSTEM_PROMPT,
+    prompt: context,
+    maxOutputTokens: 256,
+    abortSignal,
+  })
+
+  return clientSummarySchema.parse(object)
 }
 
 export async function draftEmailReply(


### PR DESCRIPTION
- Ajoute generateClientSummary() dans lib/agents/email.ts (Claude Sonnet 4.6, 3-4 lignes)
- Crée POST /api/agents/email/client-summary : récupère historique emails + devis Supabase, construit le contexte et appelle l'agent IA
- Crée ClientSummaryPanel : panneau latéral avec cache sessionStorage, skeleton animé, reveal fade-in, bouton de régénération
- Intègre le panneau dans EmailDetail (visible si client lié + email chargé)
- Invalide le cache dans EmailList via Realtime (INSERT email_statuses → clearClientSummaryCache)

https://claude.ai/code/session_01D5oi2gufZD3ogcGcsbywzJ