### PR TITLE
feat: bouton d'alerte rapide terrain avec dashboard bureau

### DIFF
--- a/app/(bureau)/alertes/page.tsx
+++ b/app/(bureau)/alertes/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next"
+import { AlertTriangle, Clock } from "lucide-react"
+import { supabaseService } from "@/lib/supabase/service"
+import { getAllAlertes } from "@/lib/terrain-alertes"
+import type { AlerteTerrainWithProject } from "@/types"
+import AlertesFeed from "@/components/bureau/alertes-feed"
+
+export const metadata: Metadata = {
+  title: "Alertes terrain — BTP×AI",
+}
+
+export default async function AlertesPage() {
+  let alertes: AlerteTerrainWithProject[] = []
+  try {
+    alertes = await getAllAlertes(supabaseService)
+  } catch {
+    alertes = []
+  }
+
+  const openCount = alertes.filter(
+    (a) => a.status === "ouvert" || a.status === "pris_en_charge"
+  ).length
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <AlertTriangle className="size-3.5 text-destructive" />
+            <span className="text-xs text-muted-foreground tracking-wider uppercase">
+              Interface bureau
+            </span>
+          </div>
+          <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+            Alertes terrain
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Signalements envoyés par les ouvriers depuis le chantier.
+          </p>
+        </div>
+
+        {openCount > 0 && (
+          <div
+            className="flex items-center gap-2 px-3 py-2 rounded-sm shrink-0"
+            style={{ background: "oklch(0.28 0.14 25)", border: "1px solid oklch(0.45 0.18 25)" }}
+          >
+            <span
+              className="w-2 h-2 rounded-full"
+              style={{ background: "oklch(0.62 0.22 25)", animation: "alertPulse 2.4s ease infinite" }}
+            />
+            <span
+              className="text-sm font-bold uppercase tracking-wider"
+              style={{ fontFamily: "var(--font-barlow)", color: "oklch(0.92 0.2 25)" }}
+            >
+              {openCount} en cours
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Feed */}
+      {alertes.length === 0 ? (
+        <div className="rounded-sm border border-border border-dashed bg-card/50 p-12 text-center">
+          <div className="size-12 rounded-sm bg-muted mx-auto mb-3 flex items-center justify-center">
+            <Clock className="size-5 text-muted-foreground/50" />
+          </div>
+          <p className="text-sm font-medium text-muted-foreground">Aucune alerte</p>
+          <p className="text-xs text-muted-foreground/60 mt-1">
+            Les signalements du terrain apparaîtront ici.
+          </p>
+        </div>
+      ) : (
+        <AlertesFeed initialAlertes={alertes} />
+      )}
+    </div>
+  )
+}

--- a/app/(bureau)/alertes/page.tsx
+++ b/app/(bureau)/alertes/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next"
-import { cookies } from "next/headers"
-import { AlertTriangle, Clock } from "lucide-react"
+import { AlertTriangle } from "lucide-react"
 import { supabaseService } from "@/lib/supabase/service"
 import { getAllAlertes } from "@/lib/terrain-alertes"
 import type { AlerteTerrainWithProject } from "@/types"
@@ -10,41 +9,13 @@ export const metadata: Metadata = {
   title: "Alertes terrain — BTP×AI",
 }
 
-const CYPRESS_FIXTURE: AlerteTerrainWithProject[] = [
-  {
-    id: "alerte-bureau-1",
-    project_id: "test-project-id",
-    user_id: "test-user-id",
-    urgency: "critique",
-    description: "Fuite de gaz détectée sur le chantier",
-    photo_url: null,
-    status: "ouvert",
-    handled_by: null,
-    handled_at: null,
-    resolved_at: null,
-    created_at: new Date().toISOString(),
-    projects: { id: "test-project-id", title: "Portail Dumont" },
-  },
-]
-
-async function isE2ETestRequest(): Promise<boolean> {
-  if (process.env.NODE_ENV === "production" && process.env.IS_E2E !== "true") return false
-  const cookieStore = await cookies()
-  const role = cookieStore.get("cypress-test-user")?.value
-  return role === "bureau" || role === "admin"
-}
-
 export default async function AlertesPage() {
   let alertes: AlerteTerrainWithProject[] = []
 
-  if (await isE2ETestRequest()) {
-    alertes = CYPRESS_FIXTURE
-  } else {
-    try {
-      alertes = await getAllAlertes(supabaseService)
-    } catch {
-      alertes = []
-    }
+  try {
+    alertes = await getAllAlertes(supabaseService)
+  } catch {
+    alertes = []
   }
 
   const openCount = alertes.filter(
@@ -89,20 +60,8 @@ export default async function AlertesPage() {
         )}
       </div>
 
-      {/* Feed */}
-      {alertes.length === 0 ? (
-        <div className="rounded-sm border border-border border-dashed bg-card/50 p-12 text-center">
-          <div className="size-12 rounded-sm bg-muted mx-auto mb-3 flex items-center justify-center">
-            <Clock className="size-5 text-muted-foreground/50" />
-          </div>
-          <p className="text-sm font-medium text-muted-foreground">Aucune alerte</p>
-          <p className="text-xs text-muted-foreground/60 mt-1">
-            Les signalements du terrain apparaîtront ici.
-          </p>
-        </div>
-      ) : (
-        <AlertesFeed initialAlertes={alertes} />
-      )}
+      {/* Feed — always mounted so useEffect can fetch client-side (testable via cy.intercept) */}
+      <AlertesFeed initialAlertes={alertes} />
     </div>
   )
 }

--- a/app/(bureau)/alertes/page.tsx
+++ b/app/(bureau)/alertes/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { cookies } from "next/headers"
 import { AlertTriangle, Clock } from "lucide-react"
 import { supabaseService } from "@/lib/supabase/service"
 import { getAllAlertes } from "@/lib/terrain-alertes"
@@ -9,12 +10,41 @@ export const metadata: Metadata = {
   title: "Alertes terrain — BTP×AI",
 }
 
+const CYPRESS_FIXTURE: AlerteTerrainWithProject[] = [
+  {
+    id: "alerte-bureau-1",
+    project_id: "test-project-id",
+    user_id: "test-user-id",
+    urgency: "critique",
+    description: "Fuite de gaz détectée sur le chantier",
+    photo_url: null,
+    status: "ouvert",
+    handled_by: null,
+    handled_at: null,
+    resolved_at: null,
+    created_at: new Date().toISOString(),
+    projects: { id: "test-project-id", title: "Portail Dumont" },
+  },
+]
+
+async function isE2ETestRequest(): Promise<boolean> {
+  if (process.env.NODE_ENV === "production" && process.env.IS_E2E !== "true") return false
+  const cookieStore = await cookies()
+  const role = cookieStore.get("cypress-test-user")?.value
+  return role === "bureau" || role === "admin"
+}
+
 export default async function AlertesPage() {
   let alertes: AlerteTerrainWithProject[] = []
-  try {
-    alertes = await getAllAlertes(supabaseService)
-  } catch {
-    alertes = []
+
+  if (await isE2ETestRequest()) {
+    alertes = CYPRESS_FIXTURE
+  } else {
+    try {
+      alertes = await getAllAlertes(supabaseService)
+    } catch {
+      alertes = []
+    }
   }
 
   const openCount = alertes.filter(

--- a/app/(bureau)/dashboard/page.tsx
+++ b/app/(bureau)/dashboard/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { getUser, getUserRole } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+import { getOpenAlertesCount } from "@/lib/terrain-alertes"
 import {
   FileText,
   Users,
@@ -7,6 +10,7 @@ import {
   Clock,
   TrendingUp,
   Wrench,
+  AlertTriangle,
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -14,41 +18,6 @@ import { Badge } from "@/components/ui/badge"
 export const metadata: Metadata = {
   title: "Tableau de bord — BTP×AI",
 }
-
-const stats = [
-  {
-    label: "Devis en cours",
-    value: "—",
-    icon: FileText,
-    description: "À envoyer ou en attente",
-    color: "text-primary",
-    bg: "bg-primary/10",
-  },
-  {
-    label: "Clients actifs",
-    value: "—",
-    icon: Users,
-    description: "Avec chantier en cours",
-    color: "text-sky-400",
-    bg: "bg-sky-400/10",
-  },
-  {
-    label: "Messages non lus",
-    value: "—",
-    icon: Mail,
-    description: "Dans la messagerie",
-    color: "text-violet-400",
-    bg: "bg-violet-400/10",
-  },
-  {
-    label: "Chantiers actifs",
-    value: "—",
-    icon: Wrench,
-    description: "En cours d'exécution",
-    color: "text-emerald-400",
-    bg: "bg-emerald-400/10",
-  },
-]
 
 const quickActions = [
   {
@@ -78,12 +47,59 @@ export default async function DashboardPage() {
   const user = await getUser()
   const role = getUserRole(user) ?? "bureau"
 
+  let openAlertes = 0
+  try {
+    openAlertes = await getOpenAlertesCount(supabaseService)
+  } catch {
+    openAlertes = 0
+  }
+
   const greeting = (() => {
     const hour = new Date().getHours()
     if (hour < 12) return "Bonjour"
     if (hour < 18) return "Bon après-midi"
     return "Bonsoir"
   })()
+
+  const stats = [
+    {
+      label: "Devis en cours",
+      value: "—",
+      icon: FileText,
+      description: "À envoyer ou en attente",
+      color: "text-primary",
+      bg: "bg-primary/10",
+      href: undefined,
+    },
+    {
+      label: "Clients actifs",
+      value: "—",
+      icon: Users,
+      description: "Avec chantier en cours",
+      color: "text-sky-400",
+      bg: "bg-sky-400/10",
+      href: undefined,
+    },
+    {
+      label: "Messages non lus",
+      value: "—",
+      icon: Mail,
+      description: "Dans la messagerie",
+      color: "text-violet-400",
+      bg: "bg-violet-400/10",
+      href: undefined,
+    },
+    {
+      label: "Alertes terrain",
+      value: openAlertes > 0 ? String(openAlertes) : "—",
+      icon: AlertTriangle,
+      description: openAlertes > 0 ? "Signalements en attente" : "Aucun signalement",
+      color: openAlertes > 0 ? "text-red-400" : "text-muted-foreground",
+      bg: openAlertes > 0 ? "bg-red-400/10" : "bg-muted/30",
+      href: "/alertes",
+      urgent: openAlertes > 0,
+    },
+  ]
 
   return (
     <div className="space-y-8">
@@ -115,6 +131,30 @@ export default async function DashboardPage() {
         </Badge>
       </div>
 
+      {/* Alert banner */}
+      {openAlertes > 0 && (
+        <Link
+          href="/alertes"
+          className="flex items-center gap-3 rounded-sm px-4 py-3 transition-opacity hover:opacity-90"
+          style={{
+            background: "oklch(0.22 0.1 25)",
+            border: "1px solid oklch(0.5 0.2 25)",
+          }}
+          data-testid="alert-banner"
+        >
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ background: "oklch(0.62 0.22 25)", animation: "alertPulse 2.4s ease infinite" }}
+          />
+          <p className="flex-1 text-sm font-bold" style={{ color: "oklch(0.92 0.2 25)", fontFamily: "var(--font-barlow)" }}>
+            {openAlertes} alerte{openAlertes > 1 ? "s" : ""} terrain en attente de traitement
+          </p>
+          <span className="text-xs uppercase tracking-wider font-bold" style={{ color: "oklch(0.75 0.18 25)", fontFamily: "var(--font-barlow)" }}>
+            Voir →
+          </span>
+        </Link>
+      )}
+
       {/* Stats grid */}
       <section>
         <div className="flex items-center gap-2 mb-4">
@@ -125,31 +165,40 @@ export default async function DashboardPage() {
           <div className="flex-1 h-px bg-border" />
         </div>
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          {stats.map((stat) => (
-            <Card
-              key={stat.label}
-              className="bg-card border-border hover:border-border/80 transition-colors"
-            >
-              <CardHeader className="pb-2 pt-4 px-4">
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                    {stat.label}
-                  </CardTitle>
-                  <div className={`size-7 rounded-sm ${stat.bg} flex items-center justify-center`}>
-                    <stat.icon className={`size-3.5 ${stat.color}`} />
+          {stats.map((stat) => {
+            const card = (
+              <Card
+                key={stat.label}
+                className="bg-card border-border hover:border-border/80 transition-colors"
+                style={stat.urgent ? { borderColor: "oklch(0.45 0.18 25)" } : undefined}
+              >
+                <CardHeader className="pb-2 pt-4 px-4">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                      {stat.label}
+                    </CardTitle>
+                    <div className={`size-7 rounded-sm ${stat.bg} flex items-center justify-center`}>
+                      <stat.icon className={`size-3.5 ${stat.color}`} />
+                    </div>
                   </div>
-                </div>
-              </CardHeader>
-              <CardContent className="pb-4 px-4">
-                <p className="font-heading text-2xl font-700 text-foreground">
-                  {stat.value}
-                </p>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {stat.description}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
+                </CardHeader>
+                <CardContent className="pb-4 px-4">
+                  <p className="font-heading text-2xl font-700 text-foreground">
+                    {stat.value}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {stat.description}
+                  </p>
+                </CardContent>
+              </Card>
+            )
+
+            return stat.href ? (
+              <Link key={stat.label} href={stat.href} className="block">
+                {card}
+              </Link>
+            ) : card
+          })}
         </div>
       </section>
 

--- a/app/(bureau)/layout.tsx
+++ b/app/(bureau)/layout.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation"
 import { getUser, getUserRole } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+import { getOpenAlertesCount } from "@/lib/terrain-alertes"
 import { AppSidebar } from "@/components/layout/sidebar"
 import { MobileHeader } from "@/components/layout/mobile-header"
 
@@ -22,15 +24,22 @@ export default async function BureauLayout({
     redirect("/profil")
   }
 
+  let alertBadge = 0
+  try {
+    alertBadge = await getOpenAlertesCount(supabaseService)
+  } catch {
+    alertBadge = 0
+  }
+
   return (
     <div className="min-h-screen bg-background">
       {/* Desktop sidebar */}
       <div className="hidden lg:block">
-        <AppSidebar email={user.email!} role={role} />
+        <AppSidebar email={user.email!} role={role} alertBadge={alertBadge} />
       </div>
 
       {/* Mobile header + drawer */}
-      <MobileHeader email={user.email!} role={role} />
+      <MobileHeader email={user.email!} role={role} alertBadge={alertBadge} />
 
       {/* Main content */}
       <main className="lg:pl-56 min-h-screen">

--- a/app/(terrain)/terrain/page.tsx
+++ b/app/(terrain)/terrain/page.tsx
@@ -4,6 +4,7 @@ import { HardHat, ChevronRight, Circle } from "lucide-react"
 import { createClient, getUser } from "@/lib/supabase/server"
 import { cookies } from "next/headers"
 import type { ProjectWithClient } from "@/types"
+import QuickAlertButton from "@/components/terrain/quick-alert-button"
 
 async function isE2ETestRequest(): Promise<boolean> {
   if (process.env.NODE_ENV === "production" && process.env.IS_E2E !== "true") return false
@@ -95,7 +96,8 @@ export default async function TerrainHomePage() {
         )}
       </main>
 
-      <footer className="px-4 pb-safe-bottom py-3 border-t border-border">
+      <footer className="px-4 pb-safe-bottom pt-3 pb-4 border-t border-border space-y-3">
+        <QuickAlertButton />
         <p className="text-center text-[11px] text-muted-foreground">
           {user?.email}
         </p>

--- a/app/api/terrain/alertes/[id]/route.ts
+++ b/app/api/terrain/alertes/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+import { updateAlerteStatus } from "@/lib/terrain-alertes"
+
+const patchSchema = z.object({
+  status: z.enum(["ouvert", "pris_en_charge", "resolu"]),
+})
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser()
+  if (!user) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json({ error: "ID manquant" }, { status: 400 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 })
+  }
+
+  const parsed = patchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    )
+  }
+
+  try {
+    const alerte = await updateAlerteStatus(
+      supabaseService,
+      id,
+      parsed.data.status,
+      user.id
+    )
+    return NextResponse.json({ alerte })
+  } catch {
+    return NextResponse.json({ error: "Erreur lors de la mise à jour" }, { status: 500 })
+  }
+}

--- a/app/api/terrain/alertes/route.ts
+++ b/app/api/terrain/alertes/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { getUser } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+import { createAlerte, getAllAlertes } from "@/lib/terrain-alertes"
+
+const postSchema = z.object({
+  project_id: z.string().uuid().nullable().optional(),
+  urgency: z.enum(["faible", "elevee", "critique"]),
+  description: z.string().min(1).max(1000),
+})
+
+export async function GET() {
+  const user = await getUser()
+  if (!user) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  try {
+    const alertes = await getAllAlertes(supabaseService)
+    return NextResponse.json({ alertes })
+  } catch {
+    return NextResponse.json({ error: "Erreur lors de la récupération des alertes" }, { status: 500 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getUser()
+  if (!user) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 })
+  }
+
+  const rawProjectId = formData.get("project_id")
+  const raw = {
+    project_id: rawProjectId && rawProjectId !== "" ? rawProjectId : null,
+    urgency: formData.get("urgency"),
+    description: formData.get("description"),
+  }
+
+  const parsed = postSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    )
+  }
+
+  let photoUrl: string | null = null
+  const photoFile = formData.get("photo")
+  if (photoFile instanceof File && photoFile.size > 0) {
+    const fileName = `alertes/${crypto.randomUUID()}.jpg`
+    const arrayBuffer = await photoFile.arrayBuffer()
+    const { error: uploadError } = await supabaseService.storage
+      .from("terrain-photos")
+      .upload(fileName, Buffer.from(arrayBuffer), { contentType: photoFile.type })
+
+    if (!uploadError) {
+      const { data: urlData } = supabaseService.storage
+        .from("terrain-photos")
+        .getPublicUrl(fileName)
+      photoUrl = urlData.publicUrl
+    }
+  }
+
+  try {
+    const alerte = await createAlerte(supabaseService, {
+      project_id: parsed.data.project_id ?? null,
+      user_id: user.id,
+      urgency: parsed.data.urgency,
+      description: parsed.data.description,
+      photo_url: photoUrl,
+    })
+
+    // Fire-and-forget email notification to bureau
+    notifyBureau(alerte).catch(() => null)
+
+    return NextResponse.json({ alerte }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: "Erreur lors de la création de l'alerte" }, { status: 500 })
+  }
+}
+
+async function notifyBureau(alerte: { urgency: string; description: string; id: string }) {
+  const resendKey = process.env.RESEND_API_KEY
+  if (!resendKey) return
+
+  const urgencyLabel: Record<string, string> = {
+    faible: "Faible",
+    elevee: "Élevée 🟠",
+    critique: "CRITIQUE 🔴",
+  }
+
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "alertes@btpxai.fr",
+      to: [process.env.BUREAU_EMAIL ?? "bureau@btpxai.fr"],
+      subject: `🚨 Alerte terrain — Urgence ${urgencyLabel[alerte.urgency] ?? alerte.urgency}`,
+      html: `<p><strong>Nouvelle alerte terrain</strong></p>
+<p><strong>Urgence :</strong> ${urgencyLabel[alerte.urgency] ?? alerte.urgency}</p>
+<p><strong>Description :</strong> ${alerte.description}</p>
+<p><a href="${process.env.NEXT_PUBLIC_APP_URL}/alertes">Voir dans le tableau de bord →</a></p>`,
+    }),
+  })
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -157,3 +157,23 @@
   from { transform: rotate(var(--spark-start)) translateX(36px); }
   to   { transform: rotate(var(--spark-end)) translateX(36px); }
 }
+
+@keyframes alertPulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 oklch(0.62 0.22 25 / 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 10px oklch(0.62 0.22 25 / 0);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+    opacity: 0.6;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/components/bureau/alertes-feed.tsx
+++ b/components/bureau/alertes-feed.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle, Clock, CheckCircle2, ChevronRight, Image as ImageIcon } from "lucide-react"
+import type { AlerteTerrainWithProject, AlerteStatus } from "@/types"
+
+type Props = {
+  initialAlertes: AlerteTerrainWithProject[]
+}
+
+const URGENCY_CONFIG = {
+  faible: {
+    label: "Faible",
+    icon: "ℹ",
+    border: "oklch(0.45 0.008 258)",
+    bg: "oklch(0.17 0.008 258)",
+    badge: "oklch(0.55 0.008 258)",
+    badgeText: "oklch(0.92 0.012 78)",
+  },
+  elevee: {
+    label: "Élevée",
+    icon: "⚠",
+    border: "oklch(0.65 0.18 75)",
+    bg: "oklch(0.19 0.04 75)",
+    badge: "oklch(0.45 0.12 75)",
+    badgeText: "oklch(0.95 0.14 75)",
+  },
+  critique: {
+    label: "Critique",
+    icon: "🛑",
+    border: "oklch(0.62 0.22 25)",
+    bg: "oklch(0.19 0.08 25)",
+    badge: "oklch(0.45 0.18 25)",
+    badgeText: "oklch(0.95 0.2 25)",
+  },
+}
+
+const STATUS_CONFIG: Record<AlerteStatus, { label: string; color: string; icon: React.ElementType }> = {
+  ouvert: { label: "Ouvert", color: "oklch(0.62 0.22 25)", icon: AlertTriangle },
+  pris_en_charge: { label: "Pris en charge", color: "oklch(0.75 0.18 75)", icon: Clock },
+  resolu: { label: "Résolu", color: "oklch(0.62 0.15 150)", icon: CheckCircle2 },
+}
+
+const NEXT_STATUS: Record<AlerteStatus, AlerteStatus | null> = {
+  ouvert: "pris_en_charge",
+  pris_en_charge: "resolu",
+  resolu: null,
+}
+
+const NEXT_LABEL: Record<AlerteStatus, string> = {
+  ouvert: "Prendre en charge",
+  pris_en_charge: "Marquer résolu",
+  resolu: "",
+}
+
+type Filter = "all" | AlerteStatus
+
+const FILTERS: { id: Filter; label: string }[] = [
+  { id: "all", label: "Toutes" },
+  { id: "ouvert", label: "Ouvertes" },
+  { id: "pris_en_charge", label: "En cours" },
+  { id: "resolu", label: "Résolues" },
+]
+
+export default function AlertesFeed({ initialAlertes }: Props) {
+  const [alertes, setAlertes] = useState<AlerteTerrainWithProject[]>(initialAlertes)
+  const [updating, setUpdating] = useState<string | null>(null)
+  const [filter, setFilter] = useState<Filter>("all")
+  const [expandedPhoto, setExpandedPhoto] = useState<string | null>(null)
+
+  const filtered = filter === "all" ? alertes : alertes.filter((a: AlerteTerrainWithProject) => a.status === filter)
+
+  const handleStatusUpdate = async (id: string, newStatus: AlerteStatus) => {
+    setUpdating(id)
+    try {
+      const res = await fetch(`/api/terrain/alertes/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      })
+      if (!res.ok) throw new Error()
+      const { alerte } = await res.json() as { alerte: AlerteTerrainWithProject }
+      setAlertes((prev: AlerteTerrainWithProject[]) => prev.map((a: AlerteTerrainWithProject) => (a.id === id ? { ...a, ...alerte } : a)))
+    } catch {
+      // silently revert — user can retry
+    } finally {
+      setUpdating(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Filters */}
+      <div className="flex gap-2 flex-wrap">
+        {FILTERS.map((f) => {
+          const isActive = filter === f.id
+          const count = f.id === "all"
+            ? alertes.length
+            : alertes.filter((a: AlerteTerrainWithProject) => a.status === f.id).length
+          return (
+            <button
+              key={f.id}
+              onClick={() => setFilter(f.id)}
+              data-testid={`filter-${f.id}`}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-sm text-xs font-bold uppercase tracking-wider transition-all"
+              style={{
+                fontFamily: "var(--font-barlow)",
+                background: isActive ? "oklch(0.69 0.168 47 / 0.15)" : "oklch(0.17 0.008 258)",
+                color: isActive ? "oklch(0.69 0.168 47)" : "oklch(0.55 0.008 258)",
+                border: `1px solid ${isActive ? "oklch(0.69 0.168 47 / 0.4)" : "oklch(0.25 0.008 258)"}`,
+              }}
+            >
+              {f.label}
+              <span
+                className="flex items-center justify-center rounded-sm text-[10px] font-bold min-w-[18px] h-[18px] px-1"
+                style={{
+                  background: isActive ? "oklch(0.69 0.168 47 / 0.2)" : "oklch(0.22 0.008 258)",
+                  color: isActive ? "oklch(0.9 0.15 47)" : "oklch(0.55 0.008 258)",
+                }}
+              >
+                {count}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Alertes list */}
+      {filtered.length === 0 ? (
+        <div className="rounded-sm border border-dashed border-border p-10 text-center">
+          <p className="text-sm text-muted-foreground">Aucune alerte dans cette catégorie.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((alerte: AlerteTerrainWithProject) => {
+            const urgConf = URGENCY_CONFIG[alerte.urgency]
+            const statConf = STATUS_CONFIG[alerte.status]
+            const nextStatus = NEXT_STATUS[alerte.status]
+            const StatusIcon = statConf.icon
+            const isUpdating = updating === alerte.id
+
+            return (
+              <article
+                key={alerte.id}
+                data-testid="alerte-card"
+                className="rounded-sm overflow-hidden"
+                style={{
+                  background: urgConf.bg,
+                  border: `1px solid ${urgConf.border}`,
+                }}
+              >
+                {/* Card header */}
+                <div className="flex items-start gap-3 p-4">
+                  <span className="text-xl leading-none pt-0.5 shrink-0">{urgConf.icon}</span>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap mb-1">
+                      {/* Urgency badge */}
+                      <span
+                        className="inline-flex items-center px-2 py-0.5 rounded-sm text-[10px] font-bold uppercase tracking-wider"
+                        style={{ background: urgConf.badge, color: urgConf.badgeText, fontFamily: "var(--font-barlow)" }}
+                      >
+                        {urgConf.label}
+                      </span>
+
+                      {/* Status badge */}
+                      <span
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-sm text-[10px] font-bold uppercase tracking-wider"
+                        style={{
+                          background: `${statConf.color}22`,
+                          color: statConf.color,
+                          border: `1px solid ${statConf.color}44`,
+                          fontFamily: "var(--font-barlow)",
+                        }}
+                        data-testid={`alerte-status-${alerte.id}`}
+                      >
+                        <StatusIcon className="w-3 h-3" />
+                        {statConf.label}
+                      </span>
+
+                      {alerte.projects && (
+                        <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+                          <ChevronRight className="w-3 h-3" />
+                          {alerte.projects.title}
+                        </span>
+                      )}
+                    </div>
+
+                    <p className="text-sm text-foreground leading-relaxed">{alerte.description}</p>
+
+                    <p className="text-[11px] text-muted-foreground mt-1">
+                      {new Date(alerte.created_at).toLocaleString("fr-FR", {
+                        day: "numeric",
+                        month: "short",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </p>
+                  </div>
+                </div>
+
+                {/* Photo thumbnail */}
+                {alerte.photo_url && (
+                  <div className="px-4 pb-3">
+                    <button
+                      onClick={() => setExpandedPhoto(expandedPhoto === alerte.id ? null : alerte.id)}
+                      className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      <ImageIcon className="w-3.5 h-3.5" />
+                      <span>Voir la photo</span>
+                    </button>
+                    {expandedPhoto === alerte.id && (
+                      <div className="mt-2 rounded-sm overflow-hidden">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={alerte.photo_url}
+                          alt="Photo du problème"
+                          className="w-full max-h-56 object-cover"
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Action button */}
+                {nextStatus && (
+                  <div
+                    className="px-4 pb-4"
+                  >
+                    <button
+                      onClick={() => handleStatusUpdate(alerte.id, nextStatus)}
+                      disabled={isUpdating}
+                      data-testid={`action-alerte-${alerte.id}`}
+                      className="flex items-center justify-center gap-2 w-full rounded-sm font-bold uppercase tracking-wider disabled:opacity-50 transition-all active:scale-[0.98]"
+                      style={{
+                        height: "44px",
+                        fontFamily: "var(--font-barlow)",
+                        fontSize: "12px",
+                        background: nextStatus === "resolu" ? "oklch(0.25 0.08 150)" : "oklch(0.25 0.08 75)",
+                        color: nextStatus === "resolu" ? "oklch(0.75 0.15 150)" : "oklch(0.85 0.15 75)",
+                        border: `1px solid ${nextStatus === "resolu" ? "oklch(0.4 0.12 150)" : "oklch(0.5 0.14 75)"}`,
+                      }}
+                    >
+                      {isUpdating ? "Mise à jour…" : NEXT_LABEL[alerte.status]}
+                    </button>
+                  </div>
+                )}
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/bureau/alertes-feed.tsx
+++ b/components/bureau/alertes-feed.tsx
@@ -1,11 +1,11 @@
 "use client"
 
-import { useState } from "react"
-import { AlertTriangle, Clock, CheckCircle2, ChevronRight, Image as ImageIcon } from "lucide-react"
+import { useState, useEffect } from "react"
+import { AlertTriangle, Clock, CheckCircle2, ChevronRight, Image as ImageIcon, Loader2 } from "lucide-react"
 import type { AlerteTerrainWithProject, AlerteStatus } from "@/types"
 
 type Props = {
-  initialAlertes: AlerteTerrainWithProject[]
+  initialAlertes?: AlerteTerrainWithProject[]
 }
 
 const URGENCY_CONFIG = {
@@ -62,13 +62,35 @@ const FILTERS: { id: Filter; label: string }[] = [
   { id: "resolu", label: "Résolues" },
 ]
 
-export default function AlertesFeed({ initialAlertes }: Props) {
+export default function AlertesFeed({ initialAlertes = [] }: Props) {
   const [alertes, setAlertes] = useState<AlerteTerrainWithProject[]>(initialAlertes)
+  const [loading, setLoading] = useState(initialAlertes.length === 0)
   const [updating, setUpdating] = useState<string | null>(null)
   const [filter, setFilter] = useState<Filter>("all")
   const [expandedPhoto, setExpandedPhoto] = useState<string | null>(null)
 
-  const filtered = filter === "all" ? alertes : alertes.filter((a: AlerteTerrainWithProject) => a.status === filter)
+  // Fetch client-side on mount so cy.intercept can mock the response in tests
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch("/api/terrain/alertes")
+        if (!res.ok) return
+        const data = await res.json() as { alertes: AlerteTerrainWithProject[] }
+        if (!cancelled) setAlertes(data.alertes ?? [])
+      } catch {
+        // Keep initial state on network error
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [])
+
+  const filtered = filter === "all"
+    ? alertes
+    : alertes.filter((a: AlerteTerrainWithProject) => a.status === filter)
 
   const handleStatusUpdate = async (id: string, newStatus: AlerteStatus) => {
     setUpdating(id)
@@ -80,7 +102,9 @@ export default function AlertesFeed({ initialAlertes }: Props) {
       })
       if (!res.ok) throw new Error()
       const { alerte } = await res.json() as { alerte: AlerteTerrainWithProject }
-      setAlertes((prev: AlerteTerrainWithProject[]) => prev.map((a: AlerteTerrainWithProject) => (a.id === id ? { ...a, ...alerte } : a)))
+      setAlertes((prev: AlerteTerrainWithProject[]) =>
+        prev.map((a: AlerteTerrainWithProject) => (a.id === id ? { ...a, ...alerte } : a))
+      )
     } catch {
       // silently revert — user can retry
     } finally {
@@ -88,8 +112,33 @@ export default function AlertesFeed({ initialAlertes }: Props) {
     }
   }
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16" data-testid="alertes-loading">
+        <Loader2
+          className="w-6 h-6 animate-spin"
+          style={{ color: "oklch(0.45 0.008 258)" }}
+        />
+      </div>
+    )
+  }
+
+  if (alertes.length === 0) {
+    return (
+      <div
+        className="rounded-sm border border-border border-dashed bg-card/50 p-12 text-center"
+        data-testid="alertes-empty"
+      >
+        <p className="text-sm font-medium text-muted-foreground">Aucune alerte</p>
+        <p className="text-xs text-muted-foreground/60 mt-1">
+          Les signalements du terrain apparaîtront ici.
+        </p>
+      </div>
+    )
+  }
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="alertes-feed">
       {/* Filters */}
       <div className="flex gap-2 flex-wrap">
         {FILTERS.map((f) => {
@@ -155,7 +204,6 @@ export default function AlertesFeed({ initialAlertes }: Props) {
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap mb-1">
-                      {/* Urgency badge */}
                       <span
                         className="inline-flex items-center px-2 py-0.5 rounded-sm text-[10px] font-bold uppercase tracking-wider"
                         style={{ background: urgConf.badge, color: urgConf.badgeText, fontFamily: "var(--font-barlow)" }}
@@ -163,7 +211,6 @@ export default function AlertesFeed({ initialAlertes }: Props) {
                         {urgConf.label}
                       </span>
 
-                      {/* Status badge */}
                       <span
                         className="inline-flex items-center gap-1 px-2 py-0.5 rounded-sm text-[10px] font-bold uppercase tracking-wider"
                         style={{
@@ -224,9 +271,7 @@ export default function AlertesFeed({ initialAlertes }: Props) {
 
                 {/* Action button */}
                 {nextStatus && (
-                  <div
-                    className="px-4 pb-4"
-                  >
+                  <div className="px-4 pb-4">
                     <button
                       onClick={() => handleStatusUpdate(alerte.id, nextStatus)}
                       disabled={isUpdating}

--- a/components/layout/mobile-header.tsx
+++ b/components/layout/mobile-header.tsx
@@ -8,9 +8,11 @@ import { AppSidebar } from "./sidebar"
 export function MobileHeader({
   email,
   role,
+  alertBadge = 0,
 }: {
   email: string
   role: "admin" | "bureau" | "ouvrier"
+  alertBadge?: number
 }) {
   const [open, setOpen] = useState(false)
 
@@ -53,7 +55,7 @@ export function MobileHeader({
           >
             <X className="size-4" />
           </Button>
-          <AppSidebar email={email} role={role} />
+          <AppSidebar email={email} role={role} alertBadge={alertBadge} />
         </div>
       </div>
     </>

--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -10,6 +10,7 @@ import {
   Settings,
   HardHat,
   Package,
+  AlertTriangle,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -17,14 +18,17 @@ type NavItem = {
   href: string
   label: string
   icon: React.ComponentType<{ className?: string }>
+  badge?: number
+  isAlert?: boolean
 }
 
-const bureauNav: NavItem[] = [
+const bureauNavBase: Omit<NavItem, "badge">[] = [
   { href: "/dashboard", label: "Tableau de bord", icon: LayoutDashboard },
   { href: "/devis", label: "Devis", icon: FileText },
   { href: "/clients", label: "Clients", icon: Users },
   { href: "/inbox", label: "Messagerie", icon: Mail },
   { href: "/materiaux", label: "Matériaux", icon: Package },
+  { href: "/alertes", label: "Alertes", icon: AlertTriangle, isAlert: true },
   { href: "/parametres", label: "Paramètres", icon: Settings },
 ]
 
@@ -34,14 +38,16 @@ const terrainNav: NavItem[] = [
 
 type Role = "admin" | "bureau" | "ouvrier"
 
-function getNavItems(role: Role): NavItem[] {
+function getNavItems(role: Role, alertBadge?: number): NavItem[] {
   if (role === "ouvrier") return terrainNav
-  return bureauNav
+  return bureauNavBase.map((item) =>
+    item.href === "/alertes" ? { ...item, badge: alertBadge } : item
+  )
 }
 
-export function SidebarNav({ role }: { role: Role }) {
+export function SidebarNav({ role, alertBadge }: { role: Role; alertBadge?: number }) {
   const pathname = usePathname()
-  const items = getNavItems(role)
+  const items = getNavItems(role, alertBadge)
 
   return (
     <nav className="flex-1 py-4 space-y-0.5">
@@ -51,6 +57,8 @@ export function SidebarNav({ role }: { role: Role }) {
             ? pathname === "/dashboard"
             : pathname.startsWith(item.href)
 
+        const showBadge = item.badge !== undefined && item.badge > 0
+
         return (
           <Link
             key={item.href}
@@ -59,7 +67,9 @@ export function SidebarNav({ role }: { role: Role }) {
               "flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-colors relative group",
               isActive
                 ? "text-primary bg-primary/10 before:absolute before:left-0 before:top-0 before:bottom-0 before:w-0.5 before:bg-primary"
-                : "text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                : item.isAlert && showBadge
+                  ? "text-red-400/90 hover:text-red-300 hover:bg-red-950/30"
+                  : "text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
             )}
           >
             <item.icon
@@ -67,10 +77,26 @@ export function SidebarNav({ role }: { role: Role }) {
                 "size-4 shrink-0 transition-colors",
                 isActive
                   ? "text-primary"
-                  : "text-sidebar-foreground/40 group-hover:text-sidebar-foreground/70"
+                  : item.isAlert && showBadge
+                    ? "text-red-400"
+                    : "text-sidebar-foreground/40 group-hover:text-sidebar-foreground/70"
               )}
             />
-            <span className="truncate tracking-wide">{item.label}</span>
+            <span className="truncate tracking-wide flex-1">{item.label}</span>
+
+            {showBadge && (
+              <span
+                className="flex items-center justify-center rounded-full min-w-[18px] h-[18px] px-1 text-[10px] font-bold leading-none"
+                style={{
+                  background: "oklch(0.55 0.22 25)",
+                  color: "white",
+                  animation: "alertPulse 2.4s ease infinite",
+                }}
+                data-testid="alert-badge"
+              >
+                {item.badge! > 99 ? "99+" : item.badge}
+              </span>
+            )}
           </Link>
         )
       })}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -6,9 +6,11 @@ type Role = "admin" | "bureau" | "ouvrier"
 export function AppSidebar({
   email,
   role,
+  alertBadge = 0,
 }: {
   email: string
   role: Role
+  alertBadge?: number
 }) {
   return (
     <aside className="fixed inset-y-0 left-0 z-40 flex w-56 flex-col bg-sidebar border-r border-sidebar-border">
@@ -31,7 +33,7 @@ export function AppSidebar({
       </div>
 
       {/* Navigation */}
-      <SidebarNav role={role} />
+      <SidebarNav role={role} alertBadge={alertBadge} />
 
       {/* User section */}
       <SidebarUser email={email} role={role} />

--- a/components/terrain/probleme-tab.tsx
+++ b/components/terrain/probleme-tab.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useState } from "react"
-import { AlertTriangle, Send, RotateCcw } from "lucide-react"
+import { useState, useRef } from "react"
+import { AlertTriangle, Send, RotateCcw, Camera, X } from "lucide-react"
+import { toast } from "sonner"
 import type { ProblemeUrgency } from "@/types"
 
 type UrgencyOption = {
@@ -44,26 +45,52 @@ const URGENCY_OPTIONS: UrgencyOption[] = [
   },
 ]
 
-export default function ProblemeTab({ projectId: _projectId }: { projectId: string }) {
+export default function ProblemeTab({ projectId }: { projectId: string }) {
   const [urgency, setUrgency] = useState<ProblemeUrgency | null>(null)
   const [description, setDescription] = useState("")
+  const [photo, setPhoto] = useState<File | null>(null)
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
 
   const canSubmit = urgency !== null && description.trim().length > 0
+
+  const handlePhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setPhoto(file)
+    setPhotoPreview(URL.createObjectURL(file))
+  }
 
   const handleSubmit = async () => {
     if (!canSubmit || isSubmitting) return
     setIsSubmitting(true)
-    await new Promise((r) => setTimeout(r, 700))
-    setSubmitted(true)
-    setIsSubmitting(false)
+
+    try {
+      const fd = new FormData()
+      fd.append("project_id", projectId)
+      fd.append("urgency", urgency!)
+      fd.append("description", description.trim())
+      if (photo) fd.append("photo", photo)
+
+      const res = await fetch("/api/terrain/alertes", { method: "POST", body: fd })
+      if (!res.ok) throw new Error("Erreur serveur")
+
+      setSubmitted(true)
+    } catch {
+      toast.error("Impossible d'envoyer l'alerte. Réessayez.")
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   const handleReset = () => {
     setSubmitted(false)
     setUrgency(null)
     setDescription("")
+    setPhoto(null)
+    setPhotoPreview(null)
   }
 
   if (submitted) {
@@ -131,6 +158,7 @@ export default function ProblemeTab({ projectId: _projectId }: { projectId: stri
         </h2>
       </div>
 
+      {/* Urgency selector */}
       <div className="space-y-2">
         <p
           className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground"
@@ -178,6 +206,7 @@ export default function ProblemeTab({ projectId: _projectId }: { projectId: stri
         </div>
       </div>
 
+      {/* Description */}
       <div className="space-y-2">
         <p
           className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground"
@@ -195,6 +224,62 @@ export default function ProblemeTab({ projectId: _projectId }: { projectId: stri
         />
       </div>
 
+      {/* Photo optionnelle */}
+      <div className="space-y-2">
+        <p
+          className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground"
+          style={{ fontFamily: "var(--font-barlow)" }}
+        >
+          Photo (optionnel)
+        </p>
+        {photoPreview ? (
+          <div className="relative rounded-sm overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={photoPreview}
+              alt="Aperçu du problème"
+              className="w-full h-40 object-cover"
+            />
+            <button
+              onClick={() => { setPhoto(null); setPhotoPreview(null) }}
+              className="absolute top-2 right-2 flex items-center justify-center rounded-sm"
+              style={{ width: "32px", height: "32px", background: "oklch(0.15 0.008 258 / 0.85)" }}
+              aria-label="Supprimer la photo"
+            >
+              <X className="w-4 h-4 text-white" />
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => fileRef.current?.click()}
+            className="w-full flex items-center justify-center gap-2 rounded-sm border border-dashed transition-colors active:scale-[0.98]"
+            style={{
+              height: "56px",
+              borderColor: "oklch(0.29 0.012 258)",
+              color: "oklch(0.55 0.008 258)",
+            }}
+          >
+            <Camera className="w-5 h-5" />
+            <span
+              className="text-sm font-bold uppercase tracking-wider"
+              style={{ fontFamily: "var(--font-barlow)" }}
+            >
+              Ajouter une photo
+            </span>
+          </button>
+        )}
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={handlePhoto}
+          className="hidden"
+          data-testid="probleme-photo-input"
+        />
+      </div>
+
+      {/* Submit */}
       <button
         onClick={handleSubmit}
         disabled={!canSubmit || isSubmitting}

--- a/components/terrain/quick-alert-button.tsx
+++ b/components/terrain/quick-alert-button.tsx
@@ -1,0 +1,389 @@
+"use client"
+
+import { useState, useRef } from "react"
+import { AlertTriangle, X, Send, Camera, RotateCcw } from "lucide-react"
+import { toast } from "sonner"
+import type { ProblemeUrgency } from "@/types"
+
+type UrgencyOption = {
+  level: ProblemeUrgency
+  label: string
+  sub: string
+  icon: string
+  activeBg: string
+  activeText: string
+  activeBorder: string
+}
+
+const URGENCY_OPTIONS: UrgencyOption[] = [
+  {
+    level: "faible",
+    label: "Faible",
+    sub: "Information",
+    icon: "ℹ",
+    activeBg: "oklch(0.23 0.012 258)",
+    activeText: "oklch(0.92 0.012 78)",
+    activeBorder: "oklch(0.55 0.008 258)",
+  },
+  {
+    level: "elevee",
+    label: "Élevée",
+    sub: "Traiter vite",
+    icon: "⚠",
+    activeBg: "oklch(0.32 0.1 75)",
+    activeText: "oklch(0.92 0.14 75)",
+    activeBorder: "oklch(0.75 0.18 75)",
+  },
+  {
+    level: "critique",
+    label: "Critique",
+    sub: "Arrêt chantier",
+    icon: "🛑",
+    activeBg: "oklch(0.28 0.14 25)",
+    activeText: "oklch(0.92 0.2 25)",
+    activeBorder: "oklch(0.62 0.22 25)",
+  },
+]
+
+export default function QuickAlertButton() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [urgency, setUrgency] = useState<ProblemeUrgency | null>(null)
+  const [description, setDescription] = useState("")
+  const [photo, setPhoto] = useState<File | null>(null)
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const canSubmit = urgency !== null && description.trim().length > 0
+
+  const handleOpen = () => {
+    setIsOpen(true)
+    setSubmitted(false)
+    setUrgency(null)
+    setDescription("")
+    setPhoto(null)
+    setPhotoPreview(null)
+  }
+
+  const handleClose = () => {
+    if (isSubmitting) return
+    setIsOpen(false)
+  }
+
+  const handlePhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setPhoto(file)
+    setPhotoPreview(URL.createObjectURL(file))
+  }
+
+  const handleSubmit = async () => {
+    if (!canSubmit || isSubmitting) return
+    setIsSubmitting(true)
+
+    try {
+      const fd = new FormData()
+      fd.append("urgency", urgency!)
+      fd.append("description", description.trim())
+      if (photo) fd.append("photo", photo)
+
+      const res = await fetch("/api/terrain/alertes", { method: "POST", body: fd })
+      if (!res.ok) throw new Error()
+
+      setSubmitted(true)
+    } catch {
+      toast.error("Impossible d'envoyer l'alerte. Réessayez.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleReset = () => {
+    setSubmitted(false)
+    setUrgency(null)
+    setDescription("")
+    setPhoto(null)
+    setPhotoPreview(null)
+  }
+
+  return (
+    <>
+      {/* Floating quick-alert trigger */}
+      <button
+        onClick={handleOpen}
+        data-testid="quick-alert-button"
+        aria-label="Signaler une alerte"
+        className="w-full flex items-center justify-center gap-3 rounded-sm font-bold uppercase tracking-widest transition-all active:scale-[0.97]"
+        style={{
+          minHeight: "64px",
+          background: "oklch(0.55 0.22 25)",
+          color: "white",
+          fontFamily: "var(--font-barlow)",
+          fontSize: "1rem",
+          letterSpacing: "0.12em",
+          boxShadow: "0 0 0 0 oklch(0.62 0.22 25)",
+          animation: "alertPulse 2.4s ease infinite",
+        }}
+      >
+        <AlertTriangle className="w-6 h-6" style={{ flexShrink: 0 }} />
+        <span>Signaler une alerte</span>
+      </button>
+
+      {/* Overlay + bottom sheet */}
+      {isOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            style={{ background: "oklch(0 0 0 / 0.72)" }}
+            onClick={handleClose}
+            data-testid="alert-overlay"
+          />
+
+          <div
+            className="fixed bottom-0 left-0 right-0 z-50 rounded-t-lg overflow-hidden flex flex-col"
+            style={{
+              background: "oklch(0.105 0.008 258)",
+              borderTop: "1px solid oklch(0.29 0.012 258)",
+              maxHeight: "92dvh",
+              animation: "slideUp 0.28s cubic-bezier(0.34,1.12,0.64,1) both",
+            }}
+          >
+            {/* Sheet header */}
+            <div
+              className="flex items-center justify-between px-4 py-4 shrink-0"
+              style={{ borderBottom: "1px solid oklch(0.18 0.008 258)" }}
+            >
+              <div className="flex items-center gap-2">
+                <AlertTriangle
+                  className="w-5 h-5"
+                  style={{ color: "oklch(0.62 0.22 25)" }}
+                />
+                <h2
+                  className="text-lg font-bold uppercase tracking-wide"
+                  style={{
+                    fontFamily: "var(--font-barlow)",
+                    color: "oklch(0.92 0.012 78)",
+                  }}
+                >
+                  Alerte rapide
+                </h2>
+              </div>
+              <button
+                onClick={handleClose}
+                className="flex items-center justify-center rounded-sm"
+                style={{
+                  width: "40px",
+                  height: "40px",
+                  background: "oklch(0.18 0.008 258)",
+                  border: "1px solid oklch(0.25 0.008 258)",
+                }}
+                aria-label="Fermer"
+                data-testid="close-alert-sheet"
+              >
+                <X className="w-4 h-4" style={{ color: "oklch(0.55 0.008 258)" }} />
+              </button>
+            </div>
+
+            {/* Sheet content */}
+            <div className="overflow-y-auto flex-1 p-4" style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}>
+              {submitted ? (
+                <div
+                  className="flex flex-col items-center text-center py-10"
+                  style={{ animation: "fadeSlideIn 0.3s ease both" }}
+                >
+                  <div
+                    className="w-20 h-20 rounded-full flex items-center justify-center mb-5"
+                    style={{ background: "oklch(0.22 0.14 25 / 0.4)" }}
+                  >
+                    <AlertTriangle
+                      className="w-10 h-10"
+                      style={{ color: "oklch(0.62 0.22 25)" }}
+                    />
+                  </div>
+                  <h3
+                    className="text-2xl font-bold uppercase tracking-wide mb-2"
+                    style={{ fontFamily: "var(--font-barlow)", color: "oklch(0.92 0.012 78)" }}
+                  >
+                    Alerte envoyée
+                  </h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed mb-8">
+                    Le bureau a été notifié immédiatement.
+                    <br />
+                    Restez disponible pour le suivi.
+                  </p>
+                  <div className="w-full space-y-3">
+                    <button
+                      onClick={handleReset}
+                      className="w-full flex items-center justify-center gap-2 rounded-sm font-bold uppercase tracking-wider active:scale-[0.97] transition-transform"
+                      style={{
+                        height: "52px",
+                        fontFamily: "var(--font-barlow)",
+                        background: "oklch(0.23 0.012 258)",
+                        color: "oklch(0.92 0.012 78)",
+                        border: "1px solid oklch(0.29 0.012 258)",
+                      }}
+                    >
+                      <RotateCcw className="w-4 h-4" />
+                      Nouvelle alerte
+                    </button>
+                    <button
+                      onClick={handleClose}
+                      className="w-full flex items-center justify-center gap-2 rounded-sm font-bold uppercase tracking-wider active:scale-[0.97] transition-transform"
+                      style={{
+                        height: "52px",
+                        fontFamily: "var(--font-barlow)",
+                        background: "transparent",
+                        color: "oklch(0.55 0.008 258)",
+                        border: "1px solid oklch(0.22 0.008 258)",
+                      }}
+                    >
+                      Fermer
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-5">
+                  {/* Urgency */}
+                  <div className="space-y-2">
+                    <p
+                      className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground"
+                      style={{ fontFamily: "var(--font-barlow)" }}
+                    >
+                      Niveau d&apos;urgence
+                    </p>
+                    <div className="grid grid-cols-3 gap-2">
+                      {URGENCY_OPTIONS.map((opt) => {
+                        const isActive = urgency === opt.level
+                        return (
+                          <button
+                            key={opt.level}
+                            onClick={() => setUrgency(opt.level)}
+                            data-testid={`quick-urgency-${opt.level}`}
+                            className="flex flex-col items-center justify-center gap-1 rounded-sm border transition-all active:scale-95"
+                            style={{
+                              minHeight: "72px",
+                              padding: "10px 6px",
+                              background: isActive ? opt.activeBg : "transparent",
+                              borderColor: isActive ? opt.activeBorder : "oklch(0.29 0.012 258)",
+                            }}
+                          >
+                            <span className="text-lg leading-none">{opt.icon}</span>
+                            <span
+                              className="text-xs font-bold uppercase tracking-wide leading-none"
+                              style={{
+                                fontFamily: "var(--font-barlow)",
+                                color: isActive ? opt.activeText : "oklch(0.92 0.012 78)",
+                              }}
+                            >
+                              {opt.label}
+                            </span>
+                            <span
+                              className="text-[9px] text-center leading-tight"
+                              style={{ color: "oklch(0.55 0.008 258)" }}
+                            >
+                              {opt.sub}
+                            </span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Description */}
+                  <div className="space-y-2">
+                    <p
+                      className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground"
+                      style={{ fontFamily: "var(--font-barlow)" }}
+                    >
+                      Description
+                    </p>
+                    <textarea
+                      value={description}
+                      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value)}
+                      placeholder="Décrivez le problème rencontré…"
+                      rows={3}
+                      data-testid="quick-alert-description"
+                      className="w-full bg-input border border-border rounded-sm px-3 py-3 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none text-sm leading-relaxed"
+                    />
+                  </div>
+
+                  {/* Photo */}
+                  <div className="space-y-2">
+                    <p
+                      className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground"
+                      style={{ fontFamily: "var(--font-barlow)" }}
+                    >
+                      Photo (optionnel)
+                    </p>
+                    {photoPreview ? (
+                      <div className="relative rounded-sm overflow-hidden">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={photoPreview}
+                          alt="Aperçu"
+                          className="w-full h-36 object-cover"
+                        />
+                        <button
+                          onClick={() => { setPhoto(null); setPhotoPreview(null) }}
+                          className="absolute top-2 right-2 flex items-center justify-center rounded-sm"
+                          style={{ width: "32px", height: "32px", background: "oklch(0.1 0.008 258 / 0.85)" }}
+                          aria-label="Supprimer la photo"
+                        >
+                          <X className="w-4 h-4 text-white" />
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => fileRef.current?.click()}
+                        className="w-full flex items-center justify-center gap-2 rounded-sm border border-dashed active:scale-[0.98] transition-colors"
+                        style={{
+                          height: "52px",
+                          borderColor: "oklch(0.29 0.012 258)",
+                          color: "oklch(0.55 0.008 258)",
+                        }}
+                      >
+                        <Camera className="w-5 h-5" />
+                        <span
+                          className="text-sm font-bold uppercase tracking-wider"
+                          style={{ fontFamily: "var(--font-barlow)" }}
+                        >
+                          Ajouter une photo
+                        </span>
+                      </button>
+                    )}
+                    <input
+                      ref={fileRef}
+                      type="file"
+                      accept="image/*"
+                      capture="environment"
+                      onChange={handlePhoto}
+                      className="hidden"
+                    />
+                  </div>
+
+                  {/* Submit */}
+                  <button
+                    onClick={handleSubmit}
+                    disabled={!canSubmit || isSubmitting}
+                    data-testid="submit-quick-alert"
+                    className="w-full flex items-center justify-center gap-2 rounded-sm font-bold uppercase tracking-wider disabled:opacity-40 active:scale-[0.97] transition-transform"
+                    style={{
+                      height: "56px",
+                      fontFamily: "var(--font-barlow)",
+                      background: "oklch(0.62 0.22 25)",
+                      color: "white",
+                    }}
+                  >
+                    <Send className="w-4 h-4" />
+                    {isSubmitting ? "Envoi en cours…" : "Envoyer l'alerte"}
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  )
+}

--- a/cypress/e2e/alertes.cy.ts
+++ b/cypress/e2e/alertes.cy.ts
@@ -139,29 +139,16 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
   })
 
   // ─── Bureau /alertes page ─────────────────────────────────────────────────────
+  //
+  // La page /alertes est un Server Component qui fetch directement via supabaseService.
+  // cy.intercept ne peut pas intercepter les appels server-side. À la place, la page
+  // détecte le cookie cypress-test-user=bureau et retourne une fixture identique ci-dessous.
 
   describe("Bureau — page /alertes", () => {
-    const ALERTE_FIXTURE = {
-      id: "alerte-bureau-1",
-      project_id: "test-project-id",
-      user_id: "test-user-id",
-      urgency: "critique",
-      description: "Fuite de gaz détectée sur le chantier",
-      photo_url: null,
-      status: "ouvert",
-      handled_by: null,
-      handled_at: null,
-      resolved_at: null,
-      created_at: new Date().toISOString(),
-      projects: { id: "test-project-id", title: "Portail Dumont" },
-    }
+    // Doit rester synchronisée avec CYPRESS_FIXTURE dans app/(bureau)/alertes/page.tsx
+    const ALERTE_ID = "alerte-bureau-1"
 
     beforeEach(() => {
-      cy.intercept("GET", "/api/terrain/alertes", {
-        statusCode: 200,
-        body: { alertes: [ALERTE_FIXTURE] },
-      }).as("getAlertes")
-
       cy.loginAsBureau()
     })
 
@@ -180,14 +167,26 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
       cy.intercept("PATCH", "/api/terrain/alertes/*", {
         statusCode: 200,
         body: {
-          alerte: { ...ALERTE_FIXTURE, status: "pris_en_charge", handled_at: new Date().toISOString() },
+          alerte: {
+            id: ALERTE_ID,
+            project_id: "test-project-id",
+            user_id: "test-user-id",
+            urgency: "critique",
+            description: "Fuite de gaz détectée sur le chantier",
+            photo_url: null,
+            status: "pris_en_charge",
+            handled_by: "test-bureau-id",
+            handled_at: new Date().toISOString(),
+            resolved_at: null,
+            created_at: new Date().toISOString(),
+          },
         },
       }).as("patchAlerte")
 
       cy.visit("/alertes")
-      cy.get(`[data-testid='action-alerte-${ALERTE_FIXTURE.id}']`).click()
+      cy.get(`[data-testid='action-alerte-${ALERTE_ID}']`).click()
       cy.wait("@patchAlerte")
-      cy.get(`[data-testid='alerte-status-${ALERTE_FIXTURE.id}']`).should(
+      cy.get(`[data-testid='alerte-status-${ALERTE_ID}']`).should(
         "contain.text",
         "Pris en charge"
       )
@@ -199,7 +198,7 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
       cy.get("[data-testid='alerte-card']").should("have.length.gte", 1)
     })
 
-    it("le filtre 'Résolues' affiche 0 alerte (fixture ouverte)", () => {
+    it("le filtre 'Résolues' affiche 0 alerte (fixture ouvert)", () => {
       cy.visit("/alertes")
       cy.get("[data-testid='filter-resolu']").click()
       cy.get("[data-testid='alerte-card']").should("have.length", 0)

--- a/cypress/e2e/alertes.cy.ts
+++ b/cypress/e2e/alertes.cy.ts
@@ -1,0 +1,208 @@
+/**
+ * Alertes terrain — E2E tests
+ *
+ * Covers:
+ * 1. Quick alert button visible on terrain home
+ * 2. Opening the sheet, filling urgency + description, submitting (mocked API)
+ * 3. ProblemeTab in project detail submits an alert
+ * 4. Bureau /alertes page shows alerts and allows status updates
+ *
+ * All suites run on 375×812 (iPhone SE) for mobile parity.
+ */
+describe("Alertes terrain — bouton d'alerte rapide", () => {
+  const MOBILE = { width: 375, height: 812 } as const
+
+  beforeEach(() => {
+    cy.viewport(MOBILE.width, MOBILE.height)
+  })
+
+  // ─── Quick alert button on terrain home ──────────────────────────────────────
+
+  describe("Page d'accueil /terrain — bouton Signaler une alerte", () => {
+    beforeEach(() => {
+      cy.loginAsOuvrier()
+      cy.visit("/terrain")
+    })
+
+    it("le bouton est visible dans le footer", () => {
+      cy.get("[data-testid='quick-alert-button']").should("be.visible")
+    })
+
+    it("le bouton a une hauteur ≥ 48px", () => {
+      cy.get("[data-testid='quick-alert-button']").should(($el) => {
+        expect($el[0].getBoundingClientRect().height).to.be.gte(48)
+      })
+    })
+
+    it("ouvre le sheet au tap", () => {
+      cy.get("[data-testid='quick-alert-button']").click()
+      cy.get("[data-testid='submit-quick-alert']").should("be.visible")
+    })
+
+    it("le bouton soumettre est désactivé sans saisie", () => {
+      cy.get("[data-testid='quick-alert-button']").click()
+      cy.get("[data-testid='submit-quick-alert']").should("be.disabled")
+    })
+
+    it("s'active après choix urgence + description", () => {
+      cy.get("[data-testid='quick-alert-button']").click()
+      cy.get("[data-testid='quick-urgency-elevee']").click()
+      cy.get("[data-testid='quick-alert-description']").type("Fissure dans la soudure principale")
+      cy.get("[data-testid='submit-quick-alert']").should("not.be.disabled")
+    })
+
+    it("soumet l'alerte et affiche la confirmation (API mockée)", () => {
+      cy.intercept("POST", "/api/terrain/alertes", {
+        statusCode: 201,
+        body: {
+          alerte: {
+            id: "alerte-test-1",
+            project_id: null,
+            user_id: "test-user-id",
+            urgency: "critique",
+            description: "Arrêt chantier — effondrement partiel du coffrage",
+            photo_url: null,
+            status: "ouvert",
+            created_at: new Date().toISOString(),
+          },
+        },
+      }).as("postAlerte")
+
+      cy.get("[data-testid='quick-alert-button']").click()
+      cy.get("[data-testid='quick-urgency-critique']").click()
+      cy.get("[data-testid='quick-alert-description']").type(
+        "Arrêt chantier — effondrement partiel du coffrage"
+      )
+      cy.get("[data-testid='submit-quick-alert']").click()
+      cy.wait("@postAlerte")
+
+      // Confirmation screen visible
+      cy.contains("Alerte envoyée").should("be.visible")
+    })
+
+    it("ferme le sheet avec le bouton de fermeture", () => {
+      cy.get("[data-testid='quick-alert-button']").click()
+      cy.get("[data-testid='close-alert-sheet']").click()
+      cy.get("[data-testid='submit-quick-alert']").should("not.exist")
+    })
+  })
+
+  // ─── ProblemeTab in project detail ───────────────────────────────────────────
+
+  describe("Onglet Problème (page projet) — soumission réelle", () => {
+    const TEST_PROJECT_ID = "test-project-id"
+
+    beforeEach(() => {
+      cy.intercept("GET", "/api/project-steps*", {
+        statusCode: 200,
+        body: { steps: [] },
+      }).as("getSteps")
+
+      cy.intercept("POST", "/api/terrain/alertes", {
+        statusCode: 201,
+        body: {
+          alerte: {
+            id: "alerte-test-2",
+            project_id: TEST_PROJECT_ID,
+            user_id: "test-user-id",
+            urgency: "elevee",
+            description: "Fissure dans la soudure",
+            photo_url: null,
+            status: "ouvert",
+            created_at: new Date().toISOString(),
+          },
+        },
+      }).as("postAlerte")
+
+      cy.loginAsOuvrier()
+      cy.visit(`/terrain/${TEST_PROJECT_ID}`)
+      cy.get("[data-testid='tab-probleme']").click()
+    })
+
+    it("le bouton signaler est désactivé par défaut", () => {
+      cy.get("[data-testid='submit-probleme']").should("be.disabled")
+    })
+
+    it("soumet et affiche la confirmation", () => {
+      cy.get("[data-testid='urgency-elevee']").click()
+      cy.get("[data-testid='probleme-description']").type("Fissure dans la soudure")
+      cy.get("[data-testid='submit-probleme']").click()
+      cy.wait("@postAlerte")
+      cy.contains("Signalement envoyé").should("be.visible")
+    })
+
+    it("le bouton soumettre a une hauteur ≥ 48px", () => {
+      cy.get("[data-testid='submit-probleme']").should(($el) => {
+        expect($el[0].getBoundingClientRect().height).to.be.gte(48)
+      })
+    })
+  })
+
+  // ─── Bureau /alertes page ─────────────────────────────────────────────────────
+
+  describe("Bureau — page /alertes", () => {
+    const ALERTE_FIXTURE = {
+      id: "alerte-bureau-1",
+      project_id: "test-project-id",
+      user_id: "test-user-id",
+      urgency: "critique",
+      description: "Fuite de gaz détectée sur le chantier",
+      photo_url: null,
+      status: "ouvert",
+      handled_by: null,
+      handled_at: null,
+      resolved_at: null,
+      created_at: new Date().toISOString(),
+      projects: { id: "test-project-id", title: "Portail Dumont" },
+    }
+
+    beforeEach(() => {
+      cy.intercept("GET", "/api/terrain/alertes", {
+        statusCode: 200,
+        body: { alertes: [ALERTE_FIXTURE] },
+      }).as("getAlertes")
+
+      cy.loginAsBureau()
+    })
+
+    it("affiche une alerte ouverte sur la page /alertes", () => {
+      cy.visit("/alertes")
+      cy.get("[data-testid='alerte-card']").should("have.length.gte", 1)
+      cy.contains("Fuite de gaz").should("be.visible")
+    })
+
+    it("le badge d'urgence Critique est visible", () => {
+      cy.visit("/alertes")
+      cy.contains("Critique").should("be.visible")
+    })
+
+    it("peut prendre en charge une alerte (mock PATCH)", () => {
+      cy.intercept("PATCH", "/api/terrain/alertes/*", {
+        statusCode: 200,
+        body: {
+          alerte: { ...ALERTE_FIXTURE, status: "pris_en_charge", handled_at: new Date().toISOString() },
+        },
+      }).as("patchAlerte")
+
+      cy.visit("/alertes")
+      cy.get(`[data-testid='action-alerte-${ALERTE_FIXTURE.id}']`).click()
+      cy.wait("@patchAlerte")
+      cy.get(`[data-testid='alerte-status-${ALERTE_FIXTURE.id}']`).should(
+        "contain.text",
+        "Pris en charge"
+      )
+    })
+
+    it("le filtre 'Ouvertes' filtre les alertes", () => {
+      cy.visit("/alertes")
+      cy.get("[data-testid='filter-ouvert']").click()
+      cy.get("[data-testid='alerte-card']").should("have.length.gte", 1)
+    })
+
+    it("le filtre 'Résolues' affiche 0 alerte (fixture ouverte)", () => {
+      cy.visit("/alertes")
+      cy.get("[data-testid='filter-resolu']").click()
+      cy.get("[data-testid='alerte-card']").should("have.length", 0)
+    })
+  })
+})

--- a/cypress/e2e/alertes.cy.ts
+++ b/cypress/e2e/alertes.cy.ts
@@ -140,26 +140,43 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
 
   // ─── Bureau /alertes page ─────────────────────────────────────────────────────
   //
-  // La page /alertes est un Server Component qui fetch directement via supabaseService.
-  // cy.intercept ne peut pas intercepter les appels server-side. À la place, la page
-  // détecte le cookie cypress-test-user=bureau et retourne une fixture identique ci-dessous.
+  // AlertesFeed fetches client-side via useEffect → cy.intercept can mock the response.
 
   describe("Bureau — page /alertes", () => {
-    // Doit rester synchronisée avec CYPRESS_FIXTURE dans app/(bureau)/alertes/page.tsx
     const ALERTE_ID = "alerte-bureau-1"
+    const ALERTE_FIXTURE = {
+      id: "alerte-bureau-1",
+      project_id: "test-project-id",
+      user_id: "test-user-id",
+      urgency: "critique",
+      description: "Fuite de gaz détectée sur le chantier",
+      photo_url: null,
+      status: "ouvert",
+      handled_by: null,
+      handled_at: null,
+      resolved_at: null,
+      created_at: new Date().toISOString(),
+      projects: { id: "test-project-id", title: "Portail Dumont" },
+    }
 
     beforeEach(() => {
+      cy.intercept("GET", "/api/terrain/alertes", {
+        statusCode: 200,
+        body: { alertes: [ALERTE_FIXTURE] },
+      }).as("getAlertes")
       cy.loginAsBureau()
     })
 
     it("affiche une alerte ouverte sur la page /alertes", () => {
       cy.visit("/alertes")
+      cy.wait("@getAlertes")
       cy.get("[data-testid='alerte-card']").should("have.length.gte", 1)
       cy.contains("Fuite de gaz").should("be.visible")
     })
 
     it("le badge d'urgence Critique est visible", () => {
       cy.visit("/alertes")
+      cy.wait("@getAlertes")
       cy.contains("Critique").should("be.visible")
     })
 
@@ -168,22 +185,16 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
         statusCode: 200,
         body: {
           alerte: {
-            id: ALERTE_ID,
-            project_id: "test-project-id",
-            user_id: "test-user-id",
-            urgency: "critique",
-            description: "Fuite de gaz détectée sur le chantier",
-            photo_url: null,
+            ...ALERTE_FIXTURE,
             status: "pris_en_charge",
             handled_by: "test-bureau-id",
             handled_at: new Date().toISOString(),
-            resolved_at: null,
-            created_at: new Date().toISOString(),
           },
         },
       }).as("patchAlerte")
 
       cy.visit("/alertes")
+      cy.wait("@getAlertes")
       cy.get(`[data-testid='action-alerte-${ALERTE_ID}']`).click()
       cy.wait("@patchAlerte")
       cy.get(`[data-testid='alerte-status-${ALERTE_ID}']`).should(
@@ -194,12 +205,14 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
 
     it("le filtre 'Ouvertes' filtre les alertes", () => {
       cy.visit("/alertes")
+      cy.wait("@getAlertes")
       cy.get("[data-testid='filter-ouvert']").click()
       cy.get("[data-testid='alerte-card']").should("have.length.gte", 1)
     })
 
     it("le filtre 'Résolues' affiche 0 alerte (fixture ouvert)", () => {
       cy.visit("/alertes")
+      cy.wait("@getAlertes")
       cy.get("[data-testid='filter-resolu']").click()
       cy.get("[data-testid='alerte-card']").should("have.length", 0)
     })

--- a/cypress/e2e/alertes.cy.ts
+++ b/cypress/e2e/alertes.cy.ts
@@ -143,6 +143,12 @@ describe("Alertes terrain — bouton d'alerte rapide", () => {
   // AlertesFeed fetches client-side via useEffect → cy.intercept can mock the response.
 
   describe("Bureau — page /alertes", () => {
+    // Desktop viewport: hides the sticky mobile header (lg:hidden) so filter
+    // buttons and action buttons are not covered and remain clickable.
+    beforeEach(() => {
+      cy.viewport(1280, 800)
+    })
+
     const ALERTE_ID = "alerte-bureau-1"
     const ALERTE_FIXTURE = {
       id: "alerte-bureau-1",

--- a/lib/terrain-alertes.ts
+++ b/lib/terrain-alertes.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { AlerteTerrain, AlerteStatus, AlerteTerrainWithProject, ProblemeUrgency } from "@/types"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyClient = SupabaseClient<any>
+
+export async function getAlertesForProject(
+  supabase: AnyClient,
+  projectId: string
+): Promise<AlerteTerrain[]> {
+  const { data, error } = await supabase
+    .from("alertes_terrain")
+    .select("*")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as AlerteTerrain[]
+}
+
+export async function getAllAlertes(
+  supabase: AnyClient
+): Promise<AlerteTerrainWithProject[]> {
+  const { data, error } = await supabase
+    .from("alertes_terrain")
+    .select("*, projects(id, title)")
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as AlerteTerrainWithProject[]
+}
+
+export async function getOpenAlertesCount(supabase: AnyClient): Promise<number> {
+  const { count, error } = await supabase
+    .from("alertes_terrain")
+    .select("id", { count: "exact", head: true })
+    .in("status", ["ouvert", "pris_en_charge"])
+
+  if (error) return 0
+  return count ?? 0
+}
+
+export async function createAlerte(
+  supabase: AnyClient,
+  payload: {
+    project_id: string | null
+    user_id: string
+    urgency: ProblemeUrgency
+    description: string
+    photo_url?: string | null
+  }
+): Promise<AlerteTerrain> {
+  const { data, error } = await supabase
+    .from("alertes_terrain")
+    .insert({
+      project_id: payload.project_id,
+      user_id: payload.user_id,
+      urgency: payload.urgency,
+      description: payload.description,
+      photo_url: payload.photo_url ?? null,
+      status: "ouvert",
+    })
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as AlerteTerrain
+}
+
+export async function updateAlerteStatus(
+  supabase: AnyClient,
+  id: string,
+  status: AlerteStatus,
+  handledBy?: string
+): Promise<AlerteTerrain> {
+  const now = new Date().toISOString()
+  const update: Record<string, unknown> = { status }
+
+  if (status === "pris_en_charge") {
+    update.handled_at = now
+    update.handled_by = handledBy ?? null
+  } else if (status === "resolu") {
+    update.resolved_at = now
+  }
+
+  const { data, error } = await supabase
+    .from("alertes_terrain")
+    .update(update)
+    .eq("id", id)
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as AlerteTerrain
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -201,6 +201,26 @@ export type ProjectStep = Tables<"project_steps">
 
 export type ProblemeUrgency = "faible" | "elevee" | "critique"
 
+export type AlerteStatus = "ouvert" | "pris_en_charge" | "resolu"
+
+export type AlerteTerrain = {
+  id: string
+  project_id: string | null
+  user_id: string
+  urgency: ProblemeUrgency
+  description: string
+  photo_url: string | null
+  status: AlerteStatus
+  handled_by: string | null
+  handled_at: string | null
+  resolved_at: string | null
+  created_at: string
+}
+
+export type AlerteTerrainWithProject = AlerteTerrain & {
+  projects: { id: string; title: string } | null
+}
+
 export type ProblemeReport = {
   id: string
   project_id: string

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -90,6 +90,56 @@ export type Database = {
           },
         ]
       }
+      alertes_terrain: {
+        Row: {
+          created_at: string
+          description: string
+          handled_at: string | null
+          handled_by: string | null
+          id: string
+          photo_url: string | null
+          project_id: string | null
+          resolved_at: string | null
+          status: "ouvert" | "pris_en_charge" | "resolu"
+          urgency: "faible" | "elevee" | "critique"
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          description: string
+          handled_at?: string | null
+          handled_by?: string | null
+          id?: string
+          photo_url?: string | null
+          project_id?: string | null
+          resolved_at?: string | null
+          status?: "ouvert" | "pris_en_charge" | "resolu"
+          urgency: "faible" | "elevee" | "critique"
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          description?: string
+          handled_at?: string | null
+          handled_by?: string | null
+          id?: string
+          photo_url?: string | null
+          project_id?: string | null
+          resolved_at?: string | null
+          status?: "ouvert" | "pris_en_charge" | "resolu"
+          urgency?: "faible" | "elevee" | "critique"
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "alertes_terrain_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       app_settings: {
         Row: {
           key: string


### PR DESCRIPTION
- Ajoute table `alertes_terrain` (types Supabase + types métier)
- `lib/terrain-alertes.ts` : CRUD alertes (create, getAll, getCount, updateStatus)
- API `POST/GET /api/terrain/alertes` + `PATCH /api/terrain/alertes/[id]`
- `QuickAlertButton` : bouton rouge pulsant + bottom-sheet sur /terrain
- `ProblemeTab` : branché sur l'API réelle avec upload photo optionnel
- Page bureau `/alertes` avec feed filtrable et gestion des statuts (ouvert → pris en charge → résolu)
- Badge rouge pulsant sur le lien "Alertes" de la sidebar bureau
- Bandeau d'alerte + stat sur le dashboard bureau si alertes ouvertes
- Animations `alertPulse` + `slideUp` dans globals.css
- Tests Cypress E2E complets : soumission ouvrier + traitement bureau

https://claude.ai/code/session_01TxSnHZC2LQKBjEQbeuR5J1