### PR TITLE
feat(dashboard): build main dashboard with 6 KPI metrics

### DIFF
--- a/app/(bureau)/dashboard/page.tsx
+++ b/app/(bureau)/dashboard/page.tsx
@@ -2,21 +2,31 @@ import type { Metadata } from "next"
 import Link from "next/link"
 import { getUser, getUserRole } from "@/lib/supabase/server"
 import { supabaseService } from "@/lib/supabase/service"
-import { getOpenAlertesCount } from "@/lib/terrain-alertes"
+import { getDashboardMetrics } from "@/lib/dashboard"
+import { DashboardAutoRefresh } from "@/components/dashboard/auto-refresh"
 import {
   FileText,
   Users,
   Mail,
-  Clock,
-  TrendingUp,
-  Wrench,
+  Package,
   AlertTriangle,
+  Euro,
+  HardHat,
+  Clock,
+  ArrowRight,
 } from "lucide-react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 
 export const metadata: Metadata = {
   title: "Tableau de bord — BTP×AI",
+}
+
+function formatRevenue(amount: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(amount)
 }
 
 const quickActions = [
@@ -25,21 +35,18 @@ const quickActions = [
     description: "Brief client → devis en quelques secondes",
     href: "/devis/nouveau",
     icon: FileText,
-    accent: "primary",
   },
   {
     label: "Voir la messagerie",
     description: "Emails classifiés automatiquement",
     href: "/inbox",
     icon: Mail,
-    accent: "violet",
   },
   {
     label: "Nouveau client",
     description: "Ajouter un contact au répertoire",
     href: "/clients/nouveau",
     icon: Users,
-    accent: "sky",
   },
 ]
 
@@ -47,11 +54,19 @@ export default async function DashboardPage() {
   const user = await getUser()
   const role = getUserRole(user) ?? "bureau"
 
-  let openAlertes = 0
+  let metrics = {
+    pendingQuotes: 0,
+    activeProjects: 0,
+    unprocessedEmails: 0,
+    weeklyRevenue: 0,
+    pendingMaterials: 0,
+    openAlerts: 0,
+  }
+
   try {
-    openAlertes = await getOpenAlertesCount(supabaseService)
+    metrics = await getDashboardMetrics(supabaseService)
   } catch {
-    openAlertes = 0
+    // Fail gracefully — show zeros
   }
 
   const greeting = (() => {
@@ -61,78 +76,144 @@ export default async function DashboardPage() {
     return "Bonsoir"
   })()
 
-  const stats = [
+  const dateLabel = new Date().toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  })
+
+  type MetricCard = {
+    label: string
+    value: string
+    description: string
+    icon: React.ElementType
+    href?: string
+    linkLabel?: string
+    accentColor: string
+    iconBg: string
+    iconColor: string
+    urgent: boolean
+  }
+
+  const metricCards: MetricCard[] = [
     {
-      label: "Devis en cours",
-      value: "—",
+      label: "Devis en attente",
+      value: String(metrics.pendingQuotes),
+      description: "devis envoyés sans réponse",
       icon: FileText,
-      description: "À envoyer ou en attente",
-      color: "text-primary",
-      bg: "bg-primary/10",
-      href: undefined,
+      href: "/devis",
+      linkLabel: "Voir les devis",
+      accentColor: "oklch(0.69 0.168 47)",
+      iconBg: "oklch(0.69 0.168 47 / 0.12)",
+      iconColor: "oklch(0.69 0.168 47)",
+      urgent: false,
     },
     {
-      label: "Clients actifs",
-      value: "—",
-      icon: Users,
-      description: "Avec chantier en cours",
-      color: "text-sky-400",
-      bg: "bg-sky-400/10",
-      href: undefined,
+      label: "Chantiers actifs",
+      value: String(metrics.activeProjects),
+      description: "projets en cours",
+      icon: HardHat,
+      accentColor: "oklch(0.62 0.12 210)",
+      iconBg: "oklch(0.62 0.12 210 / 0.12)",
+      iconColor: "oklch(0.62 0.12 210)",
+      urgent: false,
     },
     {
-      label: "Messages non lus",
-      value: "—",
+      label: "Emails non traités",
+      value: String(metrics.unprocessedEmails),
+      description: "à traiter dans la messagerie",
       icon: Mail,
-      description: "Dans la messagerie",
-      color: "text-violet-400",
-      bg: "bg-violet-400/10",
-      href: undefined,
+      href: "/inbox",
+      linkLabel: "Ouvrir la messagerie",
+      accentColor: "oklch(0.65 0.15 280)",
+      iconBg: "oklch(0.65 0.15 280 / 0.12)",
+      iconColor: "oklch(0.65 0.15 280)",
+      urgent: false,
+    },
+    {
+      label: "CA de la semaine",
+      value: formatRevenue(metrics.weeklyRevenue),
+      description: "devis acceptés cette semaine",
+      icon: Euro,
+      href: "/devis",
+      linkLabel: "Voir les devis",
+      accentColor: "oklch(0.60 0.14 145)",
+      iconBg: "oklch(0.60 0.14 145 / 0.12)",
+      iconColor: "oklch(0.60 0.14 145)",
+      urgent: false,
+    },
+    {
+      label: "Matériaux en attente",
+      value: String(metrics.pendingMaterials),
+      description: "demandes à traiter",
+      icon: Package,
+      href: "/materiaux",
+      linkLabel: "Voir les demandes",
+      accentColor: "oklch(0.70 0.18 55)",
+      iconBg: "oklch(0.70 0.18 55 / 0.12)",
+      iconColor: "oklch(0.70 0.18 55)",
+      urgent: false,
     },
     {
       label: "Alertes terrain",
-      value: openAlertes > 0 ? String(openAlertes) : "—",
+      value: String(metrics.openAlerts),
+      description:
+        metrics.openAlerts > 0
+          ? "problèmes ouverts ou en cours"
+          : "aucun problème signalé",
       icon: AlertTriangle,
-      description: openAlertes > 0 ? "Signalements en attente" : "Aucun signalement",
-      color: openAlertes > 0 ? "text-red-400" : "text-muted-foreground",
-      bg: openAlertes > 0 ? "bg-red-400/10" : "bg-muted/30",
       href: "/alertes",
-      urgent: openAlertes > 0,
+      linkLabel: "Voir les alertes",
+      accentColor:
+        metrics.openAlerts > 0
+          ? "oklch(0.62 0.22 25)"
+          : "oklch(0.29 0.012 258)",
+      iconBg:
+        metrics.openAlerts > 0
+          ? "oklch(0.62 0.22 25 / 0.12)"
+          : "oklch(0.21 0.01 258)",
+      iconColor:
+        metrics.openAlerts > 0
+          ? "oklch(0.62 0.22 25)"
+          : "oklch(0.58 0.008 258)",
+      urgent: metrics.openAlerts > 0,
     },
   ]
 
   return (
     <div className="space-y-8">
-      {/* Page header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-2 mb-1">
-            <Clock className="size-3.5 text-muted-foreground" />
-            <span className="text-xs text-muted-foreground tracking-wider uppercase">
-              {new Date().toLocaleDateString("fr-FR", {
-                weekday: "long",
-                day: "numeric",
-                month: "long",
-              })}
-            </span>
-          </div>
-          <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
-            {greeting}
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Voici un résumé de l&apos;activité de votre entreprise.
-          </p>
+      <DashboardAutoRefresh />
+
+      {/* Header */}
+      <header>
+        <div className="flex items-center gap-2 mb-2">
+          <Clock className="size-3 text-muted-foreground" />
+          <span className="text-[11px] text-muted-foreground tracking-widest uppercase">
+            {dateLabel}
+          </span>
         </div>
-        <Badge
-          variant="outline"
-          className="shrink-0 text-primary border-primary/40 uppercase tracking-wider text-[10px] px-2 py-1"
-        >
-          {role === "admin" ? "Administrateur" : "Bureau"}
-        </Badge>
-      </div>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="font-heading text-4xl font-700 tracking-wide uppercase leading-none">
+              {greeting}
+            </h1>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              Résumé de l&apos;activité de la semaine.
+            </p>
+          </div>
+          <Badge
+            variant="outline"
+            className="shrink-0 border-primary/40 text-primary uppercase tracking-wider text-[10px] px-2 py-1"
+          >
+            {role === "admin" ? "Administrateur" : "Bureau"}
+          </Badge>
+        </div>
+        <div className="mt-4 h-px bg-border" />
+      </header>
 
       {/* Alert banner */}
-      {openAlertes > 0 && (
+      {metrics.openAlerts > 0 && (
         <Link
           href="/alertes"
           className="flex items-center gap-3 rounded-sm px-4 py-3 transition-opacity hover:opacity-90"
@@ -143,118 +224,162 @@ export default async function DashboardPage() {
           data-testid="alert-banner"
         >
           <span
-            className="w-2.5 h-2.5 rounded-full shrink-0"
-            style={{ background: "oklch(0.62 0.22 25)", animation: "alertPulse 2.4s ease infinite" }}
+            className="w-2 h-2 rounded-full shrink-0"
+            style={{
+              background: "oklch(0.62 0.22 25)",
+              animation: "alertPulse 2.4s ease infinite",
+            }}
           />
-          <p className="flex-1 text-sm font-bold" style={{ color: "oklch(0.92 0.2 25)", fontFamily: "var(--font-barlow)" }}>
-            {openAlertes} alerte{openAlertes > 1 ? "s" : ""} terrain en attente de traitement
+          <p
+            className="flex-1 text-sm font-bold"
+            style={{
+              color: "oklch(0.92 0.2 25)",
+              fontFamily: "var(--font-barlow)",
+            }}
+          >
+            {metrics.openAlerts} alerte
+            {metrics.openAlerts > 1 ? "s" : ""} terrain en attente de
+            traitement
           </p>
-          <span className="text-xs uppercase tracking-wider font-bold" style={{ color: "oklch(0.75 0.18 25)", fontFamily: "var(--font-barlow)" }}>
+          <span
+            className="text-xs uppercase tracking-wider font-bold"
+            style={{
+              color: "oklch(0.75 0.18 25)",
+              fontFamily: "var(--font-barlow)",
+            }}
+          >
             Voir →
           </span>
         </Link>
       )}
 
-      {/* Stats grid */}
+      {/* Metric cards */}
       <section>
-        <div className="flex items-center gap-2 mb-4">
-          <TrendingUp className="size-3.5 text-muted-foreground" />
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        <div className="flex items-center gap-3 mb-5">
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.15em]">
             Indicateurs
           </span>
           <div className="flex-1 h-px bg-border" />
         </div>
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          {stats.map((stat) => {
-            const card = (
-              <Card
-                key={stat.label}
-                className="bg-card border-border hover:border-border/80 transition-colors"
-                style={stat.urgent ? { borderColor: "oklch(0.45 0.18 25)" } : undefined}
+
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+          {metricCards.map((card, i) => {
+            const cardContent = (
+              <div
+                className="relative flex flex-col gap-3 h-full rounded-sm border border-border bg-card p-5 overflow-hidden transition-colors"
+                style={{
+                  borderLeftColor: card.accentColor,
+                  borderLeftWidth: "3px",
+                  animation: "fadeSlideIn 0.35s ease both",
+                  animationDelay: `${i * 0.06}s`,
+                  ...(card.urgent
+                    ? {
+                        boxShadow:
+                          "0 0 0 1px oklch(0.5 0.2 25 / 0.25) inset",
+                      }
+                    : {}),
+                }}
               >
-                <CardHeader className="pb-2 pt-4 px-4">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                      {stat.label}
-                    </CardTitle>
-                    <div className={`size-7 rounded-sm ${stat.bg} flex items-center justify-center`}>
-                      <stat.icon className={`size-3.5 ${stat.color}`} />
-                    </div>
+                {/* Label + icon */}
+                <div className="flex items-start justify-between gap-2">
+                  <span
+                    className="text-[10px] font-medium uppercase tracking-[0.1em] leading-tight"
+                    style={{ color: "oklch(0.55 0.008 258)" }}
+                  >
+                    {card.label}
+                  </span>
+                  <div
+                    className="size-7 rounded-sm flex items-center justify-center shrink-0"
+                    style={{ background: card.iconBg }}
+                  >
+                    <card.icon
+                      className="size-3.5"
+                      style={{ color: card.iconColor }}
+                    />
                   </div>
-                </CardHeader>
-                <CardContent className="pb-4 px-4">
-                  <p className="font-heading text-2xl font-700 text-foreground">
-                    {stat.value}
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    {stat.description}
-                  </p>
-                </CardContent>
-              </Card>
+                </div>
+
+                {/* Value */}
+                <p
+                  className="font-heading font-700 leading-none tracking-tight"
+                  style={{
+                    fontSize:
+                      card.value.length > 8 ? "1.6rem" : "2.25rem",
+                    color: card.urgent
+                      ? card.iconColor
+                      : "oklch(0.92 0.012 78)",
+                  }}
+                >
+                  {card.value}
+                </p>
+
+                {/* Description */}
+                <p
+                  className="text-xs leading-relaxed"
+                  style={{ color: "oklch(0.55 0.008 258)" }}
+                >
+                  {card.description}
+                </p>
+
+                {/* Link */}
+                {card.href && card.linkLabel && (
+                  <div
+                    className="flex items-center gap-1 text-[11px] font-medium mt-auto transition-opacity hover:opacity-70"
+                    style={{ color: card.accentColor }}
+                  >
+                    {card.linkLabel}
+                    <ArrowRight className="size-3" />
+                  </div>
+                )}
+              </div>
             )
 
-            return stat.href ? (
-              <Link key={stat.label} href={stat.href} className="block">
-                {card}
+            return card.href ? (
+              <Link key={card.label} href={card.href} className="block">
+                {cardContent}
               </Link>
-            ) : card
+            ) : (
+              <div key={card.label}>{cardContent}</div>
+            )
           })}
         </div>
       </section>
 
       {/* Quick actions */}
       <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Wrench className="size-3.5 text-muted-foreground" />
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        <div className="flex items-center gap-3 mb-5">
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.15em]">
             Actions rapides
           </span>
           <div className="flex-1 h-px bg-border" />
         </div>
+
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           {quickActions.map((action) => (
-            <a
+            <Link
               key={action.label}
               href={action.href}
-              className="group flex items-start gap-3 rounded-sm border border-border bg-card p-4 transition-all hover:border-primary/50 hover:bg-primary/5"
+              className="group flex items-start gap-3 rounded-sm border border-border bg-card p-4 transition-all hover:border-primary/40 hover:bg-primary/5"
             >
-              <div className="size-8 rounded-sm bg-muted flex items-center justify-center shrink-0 group-hover:bg-primary/20 transition-colors">
-                <action.icon className="size-4 text-muted-foreground group-hover:text-primary transition-colors" />
+              <div className="size-8 rounded-sm bg-muted flex items-center justify-center shrink-0 transition-colors group-hover:bg-primary/15">
+                <action.icon className="size-4 text-muted-foreground transition-colors group-hover:text-primary" />
               </div>
               <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
+                <p className="text-sm font-medium text-foreground transition-colors group-hover:text-primary">
                   {action.label}
                 </p>
                 <p className="text-xs text-muted-foreground mt-0.5">
                   {action.description}
                 </p>
               </div>
-            </a>
+            </Link>
           ))}
         </div>
       </section>
 
-      {/* Empty activity feed */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Clock className="size-3.5 text-muted-foreground" />
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            Activité récente
-          </span>
-          <div className="flex-1 h-px bg-border" />
-        </div>
-        <div className="rounded-sm border border-border border-dashed bg-card/50 p-12 text-center">
-          <div className="size-12 rounded-sm bg-muted mx-auto mb-3 flex items-center justify-center">
-            <Clock className="size-5 text-muted-foreground/50" />
-          </div>
-          <p className="text-sm font-medium text-muted-foreground">
-            Aucune activité récente
-          </p>
-          <p className="text-xs text-muted-foreground/60 mt-1">
-            Les devis, emails et chantiers apparaîtront ici.
-          </p>
-        </div>
-      </section>
+      <p className="text-[10px] text-muted-foreground/40 text-right tracking-wider uppercase">
+        Données actualisées toutes les 5 minutes
+      </p>
     </div>
   )
 }

--- a/components/dashboard/auto-refresh.tsx
+++ b/components/dashboard/auto-refresh.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+
+export function DashboardAutoRefresh() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const id = setInterval(() => router.refresh(), 5 * 60 * 1000)
+    return () => clearInterval(id)
+  }, [router])
+
+  return null
+}

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,116 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyClient = SupabaseClient<any>
+
+export type DashboardMetrics = {
+  pendingQuotes: number
+  activeProjects: number
+  unprocessedEmails: number
+  weeklyRevenue: number
+  pendingMaterials: number
+  openAlerts: number
+}
+
+export function getWeekStart(): Date {
+  const now = new Date()
+  const dayOfWeek = now.getDay()
+  const daysFromMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  const monday = new Date(now)
+  monday.setDate(now.getDate() - daysFromMonday)
+  monday.setHours(0, 0, 0, 0)
+  return monday
+}
+
+export async function getPendingQuotesCount(supabase: AnyClient): Promise<number> {
+  const { count, error } = await supabase
+    .from("quotes")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "sent")
+
+  if (error) return 0
+  return count ?? 0
+}
+
+export async function getActiveProjectsCount(supabase: AnyClient): Promise<number> {
+  const { count, error } = await supabase
+    .from("projects")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "in_progress")
+
+  if (error) return 0
+  return count ?? 0
+}
+
+export async function getUnprocessedEmailsCount(supabase: AnyClient): Promise<number> {
+  const { count, error } = await supabase
+    .from("email_statuses")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "a_traiter")
+
+  if (error) return 0
+  return count ?? 0
+}
+
+export async function getWeeklyRevenue(supabase: AnyClient): Promise<number> {
+  const weekStart = getWeekStart().toISOString()
+  const { data, error } = await supabase
+    .from("quotes")
+    .select("total_ht")
+    .eq("status", "accepted")
+    .gte("created_at", weekStart)
+
+  if (error || !data) return 0
+  return (
+    Math.round(
+      (data as { total_ht: number }[]).reduce((sum, q) => sum + (q.total_ht ?? 0), 0) * 100
+    ) / 100
+  )
+}
+
+export async function getPendingMaterialsCount(supabase: AnyClient): Promise<number> {
+  const { count, error } = await supabase
+    .from("materiaux_requests")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "pending")
+
+  if (error) return 0
+  return count ?? 0
+}
+
+export async function getOpenAlertsCount(supabase: AnyClient): Promise<number> {
+  const { count, error } = await supabase
+    .from("alertes_terrain")
+    .select("id", { count: "exact", head: true })
+    .in("status", ["ouvert", "pris_en_charge"])
+
+  if (error) return 0
+  return count ?? 0
+}
+
+export async function getDashboardMetrics(supabase: AnyClient): Promise<DashboardMetrics> {
+  const [
+    pendingQuotes,
+    activeProjects,
+    unprocessedEmails,
+    weeklyRevenue,
+    pendingMaterials,
+    openAlerts,
+  ] = await Promise.all([
+    getPendingQuotesCount(supabase),
+    getActiveProjectsCount(supabase),
+    getUnprocessedEmailsCount(supabase),
+    getWeeklyRevenue(supabase),
+    getPendingMaterialsCount(supabase),
+    getOpenAlertsCount(supabase),
+  ])
+
+  return {
+    pendingQuotes,
+    activeProjects,
+    unprocessedEmails,
+    weeklyRevenue,
+    pendingMaterials,
+    openAlerts,
+  }
+}

--- a/tests/unit/dashboard.test.ts
+++ b/tests/unit/dashboard.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi } from "vitest"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import {
+  getPendingQuotesCount,
+  getActiveProjectsCount,
+  getUnprocessedEmailsCount,
+  getWeeklyRevenue,
+  getPendingMaterialsCount,
+  getOpenAlertsCount,
+  getDashboardMetrics,
+  getWeekStart,
+} from "@/lib/dashboard"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyClient = SupabaseClient<any>
+
+// Creates a fluent Supabase-like builder that resolves to `result` when awaited.
+// Supports: select, eq, in, gte, head (for count queries).
+function makeBuilder(result: {
+  data?: unknown
+  count?: number | null
+  error: null | object
+}) {
+  const builder: Record<string, unknown> = {
+    then: (
+      resolve: (v: unknown) => unknown,
+      reject?: (r: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject),
+  }
+
+  for (const method of ["select", "eq", "in", "gte", "head"]) {
+    builder[method] = vi.fn().mockReturnValue(builder)
+  }
+
+  return builder
+}
+
+function makeSupabase(...builders: ReturnType<typeof makeBuilder>[]) {
+  const from = vi.fn()
+  builders.forEach((b) => from.mockReturnValueOnce(b))
+  return { from } as unknown as AnyClient
+}
+
+// ── getWeekStart ──────────────────────────────────────────────────────────────
+
+describe("getWeekStart", () => {
+  it("always returns a Monday", () => {
+    const result = getWeekStart()
+    expect(result.getDay()).toBe(1)
+  })
+
+  it("returns midnight (00:00:00.000)", () => {
+    const result = getWeekStart()
+    expect(result.getHours()).toBe(0)
+    expect(result.getMinutes()).toBe(0)
+    expect(result.getSeconds()).toBe(0)
+    expect(result.getMilliseconds()).toBe(0)
+  })
+
+  it("returns a date in the past or today", () => {
+    const result = getWeekStart()
+    expect(result.getTime()).toBeLessThanOrEqual(Date.now())
+  })
+})
+
+// ── getPendingQuotesCount ─────────────────────────────────────────────────────
+
+describe("getPendingQuotesCount", () => {
+  it("returns count of sent quotes", async () => {
+    const builder = makeBuilder({ count: 7, error: null })
+    const supabase = makeSupabase(builder)
+
+    const result = await getPendingQuotesCount(supabase)
+
+    expect(result).toBe(7)
+    expect(builder.eq).toHaveBeenCalledWith("status", "sent")
+  })
+
+  it("returns 0 when count is null", async () => {
+    const builder = makeBuilder({ count: null, error: null })
+    const supabase = makeSupabase(builder)
+
+    expect(await getPendingQuotesCount(supabase)).toBe(0)
+  })
+
+  it("returns 0 on error", async () => {
+    const builder = makeBuilder({ count: null, error: { message: "db error" } })
+    const supabase = makeSupabase(builder)
+
+    expect(await getPendingQuotesCount(supabase)).toBe(0)
+  })
+})
+
+// ── getActiveProjectsCount ────────────────────────────────────────────────────
+
+describe("getActiveProjectsCount", () => {
+  it("returns count of in_progress projects", async () => {
+    const builder = makeBuilder({ count: 3, error: null })
+    const supabase = makeSupabase(builder)
+
+    const result = await getActiveProjectsCount(supabase)
+
+    expect(result).toBe(3)
+    expect(builder.eq).toHaveBeenCalledWith("status", "in_progress")
+  })
+
+  it("returns 0 when count is null", async () => {
+    const builder = makeBuilder({ count: null, error: null })
+    const supabase = makeSupabase(builder)
+
+    expect(await getActiveProjectsCount(supabase)).toBe(0)
+  })
+
+  it("returns 0 on error", async () => {
+    const builder = makeBuilder({ count: null, error: { message: "db error" } })
+    const supabase = makeSupabase(builder)
+
+    expect(await getActiveProjectsCount(supabase)).toBe(0)
+  })
+})
+
+// ── getUnprocessedEmailsCount ─────────────────────────────────────────────────
+
+describe("getUnprocessedEmailsCount", () => {
+  it("returns count of a_traiter email statuses", async () => {
+    const builder = makeBuilder({ count: 12, error: null })
+    const supabase = makeSupabase(builder)
+
+    const result = await getUnprocessedEmailsCount(supabase)
+
+    expect(result).toBe(12)
+    expect(builder.eq).toHaveBeenCalledWith("status", "a_traiter")
+  })
+
+  it("returns 0 on error", async () => {
+    const builder = makeBuilder({ count: null, error: { message: "db error" } })
+    const supabase = makeSupabase(builder)
+
+    expect(await getUnprocessedEmailsCount(supabase)).toBe(0)
+  })
+})
+
+// ── getWeeklyRevenue ──────────────────────────────────────────────────────────
+
+describe("getWeeklyRevenue", () => {
+  it("sums total_ht for accepted quotes this week", async () => {
+    const builder = makeBuilder({
+      data: [{ total_ht: 1200 }, { total_ht: 3450.5 }],
+      error: null,
+    })
+    const supabase = makeSupabase(builder)
+
+    const result = await getWeeklyRevenue(supabase)
+
+    expect(result).toBe(4650.5)
+    expect(builder.eq).toHaveBeenCalledWith("status", "accepted")
+  })
+
+  it("returns 0 for empty data", async () => {
+    const builder = makeBuilder({ data: [], error: null })
+    const supabase = makeSupabase(builder)
+
+    expect(await getWeeklyRevenue(supabase)).toBe(0)
+  })
+
+  it("returns 0 on error", async () => {
+    const builder = makeBuilder({ data: null, error: { message: "db error" } })
+    const supabase = makeSupabase(builder)
+
+    expect(await getWeeklyRevenue(supabase)).toBe(0)
+  })
+
+  it("rounds result to 2 decimal places", async () => {
+    // 0.1 + 0.2 = 0.30000000000000004 in IEEE 754
+    // Math.round(0.30000000000000004 * 100) / 100 = 0.3
+    const builder = makeBuilder({
+      data: [{ total_ht: 0.1 }, { total_ht: 0.2 }],
+      error: null,
+    })
+    const supabase = makeSupabase(builder)
+
+    const result = await getWeeklyRevenue(supabase)
+
+    expect(result).toBe(0.3)
+  })
+
+  it("filters by week start date via gte", async () => {
+    const builder = makeBuilder({ data: [], error: null })
+    const supabase = makeSupabase(builder)
+    const before = getWeekStart().toISOString()
+
+    await getWeeklyRevenue(supabase)
+
+    // The gte call should receive the Monday of the current week
+    const gteCall = (builder.gte as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(gteCall[0]).toBe("created_at")
+    expect(gteCall[1]).toBe(before)
+  })
+})
+
+// ── getPendingMaterialsCount ──────────────────────────────────────────────────
+
+describe("getPendingMaterialsCount", () => {
+  it("returns count of pending material requests", async () => {
+    const builder = makeBuilder({ count: 5, error: null })
+    const supabase = makeSupabase(builder)
+
+    const result = await getPendingMaterialsCount(supabase)
+
+    expect(result).toBe(5)
+    expect(builder.eq).toHaveBeenCalledWith("status", "pending")
+  })
+
+  it("returns 0 when count is null", async () => {
+    const builder = makeBuilder({ count: null, error: null })
+    const supabase = makeSupabase(builder)
+
+    expect(await getPendingMaterialsCount(supabase)).toBe(0)
+  })
+
+  it("returns 0 on error", async () => {
+    const builder = makeBuilder({ count: null, error: { message: "db error" } })
+    const supabase = makeSupabase(builder)
+
+    expect(await getPendingMaterialsCount(supabase)).toBe(0)
+  })
+})
+
+// ── getOpenAlertsCount ────────────────────────────────────────────────────────
+
+describe("getOpenAlertsCount", () => {
+  it("returns count of open and in-progress alerts", async () => {
+    const builder = makeBuilder({ count: 2, error: null })
+    const supabase = makeSupabase(builder)
+
+    const result = await getOpenAlertsCount(supabase)
+
+    expect(result).toBe(2)
+    expect(builder.in).toHaveBeenCalledWith("status", [
+      "ouvert",
+      "pris_en_charge",
+    ])
+  })
+
+  it("returns 0 when count is null", async () => {
+    const builder = makeBuilder({ count: null, error: null })
+    const supabase = makeSupabase(builder)
+
+    expect(await getOpenAlertsCount(supabase)).toBe(0)
+  })
+
+  it("returns 0 on error", async () => {
+    const builder = makeBuilder({ count: null, error: { message: "db error" } })
+    const supabase = makeSupabase(builder)
+
+    expect(await getOpenAlertsCount(supabase)).toBe(0)
+  })
+})
+
+// ── getDashboardMetrics ───────────────────────────────────────────────────────
+
+describe("getDashboardMetrics", () => {
+  it("fetches and combines all 6 metrics in parallel", async () => {
+    // Promise.all calls supabase.from() 6 times in order:
+    // 1. getPendingQuotesCount   → from("quotes")
+    // 2. getActiveProjectsCount  → from("projects")
+    // 3. getUnprocessedEmailsCount → from("email_statuses")
+    // 4. getWeeklyRevenue        → from("quotes")
+    // 5. getPendingMaterialsCount → from("materiaux_requests")
+    // 6. getOpenAlertsCount      → from("alertes_terrain")
+    const builders = [
+      makeBuilder({ count: 4, error: null }),
+      makeBuilder({ count: 2, error: null }),
+      makeBuilder({ count: 8, error: null }),
+      makeBuilder({ data: [{ total_ht: 5000 }, { total_ht: 3000 }], error: null }),
+      makeBuilder({ count: 1, error: null }),
+      makeBuilder({ count: 3, error: null }),
+    ]
+    const from = vi.fn()
+    builders.forEach((b) => from.mockReturnValueOnce(b))
+    const supabase = { from } as unknown as AnyClient
+
+    const metrics = await getDashboardMetrics(supabase)
+
+    expect(metrics.pendingQuotes).toBe(4)
+    expect(metrics.activeProjects).toBe(2)
+    expect(metrics.unprocessedEmails).toBe(8)
+    expect(metrics.weeklyRevenue).toBe(8000)
+    expect(metrics.pendingMaterials).toBe(1)
+    expect(metrics.openAlerts).toBe(3)
+  })
+
+  it("returns zeros when all queries error", async () => {
+    const errored = () =>
+      makeBuilder({ count: null, error: { message: "fail" } })
+    const builders = [errored(), errored(), errored(), errored(), errored(), errored()]
+    const from = vi.fn()
+    builders.forEach((b) => from.mockReturnValueOnce(b))
+
+    // getWeeklyRevenue needs data not count
+    builders[3] = makeBuilder({ data: null, error: { message: "fail" } })
+    builders.forEach((b, i) => from.mockReturnValueOnce(builders[i]))
+
+    const from2 = vi.fn()
+    builders.forEach((b) => from2.mockReturnValueOnce(b))
+    const supabase = { from: from2 } as unknown as AnyClient
+
+    const metrics = await getDashboardMetrics(supabase)
+
+    expect(metrics.pendingQuotes).toBe(0)
+    expect(metrics.activeProjects).toBe(0)
+    expect(metrics.unprocessedEmails).toBe(0)
+    expect(metrics.weeklyRevenue).toBe(0)
+    expect(metrics.pendingMaterials).toBe(0)
+    expect(metrics.openAlerts).toBe(0)
+  })
+})


### PR DESCRIPTION
- lib/dashboard.ts: six server-side metric functions (pending quotes,
  active projects, unprocessed emails, weekly revenue, pending materials,
  open alerts) all computed in parallel via Promise.all
- components/dashboard/auto-refresh.tsx: client component that calls
  router.refresh() every 5 minutes with no visible UI
- app/(bureau)/dashboard/page.tsx: full redesign with metric cards,
  staggered fadeSlideIn animations, colored left-border accents per
  metric category, alert banner when terrain alerts > 0, and quick actions
- tests/unit/dashboard.test.ts: 24 Vitest tests covering all six metric
  functions, getWeekStart, and getDashboardMetrics (all 149 tests pass)

https://claude.ai/code/session_01KvEDLLhFKpWUZJmMnjqKTi