### PR TITLE
feat: rapport hebdomadaire automatique chaque lundi à 8h

### DIFF
--- a/app/api/cron/weekly-report/route.ts
+++ b/app/api/cron/weekly-report/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server"
+import { Resend } from "resend"
+import { getWeeklyReportData, getWeeklyReportRecipients } from "@/lib/weekly-report"
+import { generateWeeklyReportNarrative } from "@/lib/agents/weekly-report"
+import { buildWeeklyReportHtml, buildWeeklyReportSubject } from "@/lib/email/weekly-report"
+import { env } from "@/lib/env"
+
+function isCronAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return false
+  const auth = request.headers.get("authorization")
+  return auth === `Bearer ${secret}`
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  let data
+  try {
+    data = await getWeeklyReportData()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: `data_fetch_error: ${message}` }, { status: 500 })
+  }
+
+  const recipients = await getWeeklyReportRecipients()
+  if (recipients.length === 0) {
+    return NextResponse.json({ status: "skipped", reason: "no_recipients_configured" })
+  }
+
+  let narrative
+  try {
+    narrative = await generateWeeklyReportNarrative(data)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: `narrative_error: ${message}` }, { status: 500 })
+  }
+
+  try {
+    const resend = new Resend(env.RESEND_API_KEY)
+    await resend.emails.send({
+      from: "BTP × AI Métallerie <rapport@btpxai.fr>",
+      to: recipients,
+      subject: buildWeeklyReportSubject(data.weekRange.start),
+      html: buildWeeklyReportHtml(data, narrative),
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: `send_error: ${message}` }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    status: "sent",
+    recipients: recipients.length,
+    weekRange: data.weekRange,
+  })
+}

--- a/lib/agents/weekly-report.ts
+++ b/lib/agents/weekly-report.ts
@@ -1,0 +1,85 @@
+import { generateObject } from "ai"
+import { anthropic } from "@ai-sdk/anthropic"
+import { z } from "zod"
+import type { WeeklyReportData } from "@/lib/weekly-report"
+
+export const weeklyReportNarrativeSchema = z.object({
+  summary: z.string().min(1),
+  highlights: z.array(z.string()),
+  attentionItems: z.array(z.string()),
+})
+export type WeeklyReportNarrative = z.infer<typeof weeklyReportNarrativeSchema>
+
+const aiNarrativeSchema = z.object({
+  summary: z.string(),
+  highlights: z.array(z.string()),
+  attentionItems: z.array(z.string()),
+})
+
+const SYSTEM_PROMPT = `Tu es l'assistant de gestion d'une PME familiale de métallerie et serrurerie. Tu génères le rapport hebdomadaire de l'activité de la semaine passée, destiné au gérant et à l'équipe bureau.
+
+Règles :
+- summary : 2-3 phrases résumant l'activité globale de la semaine, en français
+- highlights : 2-4 points positifs ou faits marquants de la semaine (ex : CA réalisé, devis acceptés, chantiers actifs)
+- attentionItems : 0-4 points nécessitant une action (ex : devis en attente de réponse, alertes terrain ouvertes) — liste vide si aucun point d'attention
+- Ton professionnel, factuel, encourageant pour une entreprise familiale
+- N'invente aucun chiffre, utilise uniquement les données fournies`
+
+function fmtEur(n: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(n)
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  })
+}
+
+export async function generateWeeklyReportNarrative(
+  data: WeeklyReportData,
+  signal?: AbortSignal
+): Promise<WeeklyReportNarrative> {
+  const timeoutSignal = AbortSignal.timeout(30_000)
+  const abortSignal =
+    signal && typeof AbortSignal.any === "function"
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+
+  const weekEndDisplay = new Date(new Date(data.weekRange.end).getTime() - 1)
+  const prompt = `Données de la semaine du ${fmtDate(data.weekRange.start)} au ${fmtDate(weekEndDisplay.toISOString())} :
+
+DEVIS :
+- Devis envoyés : ${data.quotes.sent}
+- Devis acceptés : ${data.quotes.accepted}
+- Devis refusés : ${data.quotes.rejected}
+- CA réalisé (HT) : ${fmtEur(data.quotes.caRealiseHT)}
+
+CHANTIERS :
+- Chantiers en cours : ${data.projects.inProgressTotal}
+- Chantiers terminés (total cumulé) : ${data.projects.completedTotal}
+
+POINTS D'ATTENTION :
+- Devis anciens en attente de réponse : ${data.attentionPoints.pendingQuotes}
+- Alertes terrain ouvertes : ${data.attentionPoints.openAlerts}
+- Demandes matériaux en attente : ${data.attentionPoints.pendingMaterials}
+- Emails non traités : ${data.attentionPoints.unprocessedEmails}
+
+Génère le rapport hebdomadaire.`
+
+  const { object } = await generateObject({
+    model: anthropic("claude-sonnet-4-6"),
+    schema: aiNarrativeSchema,
+    system: SYSTEM_PROMPT,
+    prompt,
+    maxOutputTokens: 512,
+    abortSignal,
+  })
+
+  return weeklyReportNarrativeSchema.parse(object)
+}

--- a/lib/email/weekly-report.ts
+++ b/lib/email/weekly-report.ts
@@ -1,0 +1,162 @@
+import type { WeeklyReportData } from "@/lib/weekly-report"
+import type { WeeklyReportNarrative } from "@/lib/agents/weekly-report"
+
+function fmtEur(n: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(n)
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  })
+}
+
+export function buildWeeklyReportSubject(weekStart: string): string {
+  const date = new Date(weekStart)
+  const weekLabel = date.toLocaleDateString("fr-FR", { day: "2-digit", month: "long" })
+  return `Rapport hebdomadaire — semaine du ${weekLabel}`
+}
+
+export function buildWeeklyReportHtml(
+  data: WeeklyReportData,
+  narrative: WeeklyReportNarrative
+): string {
+  const weekEndDisplay = new Date(new Date(data.weekRange.end).getTime() - 1)
+  const weekLabel = `${fmtDate(data.weekRange.start)} – ${fmtDate(weekEndDisplay.toISOString())}`
+
+  const highlightsHtml = narrative.highlights
+    .map(
+      (h) =>
+        `<tr><td style="padding:6px 0;border-bottom:1px solid #f0f0f0;font-size:14px;color:#3f3f46;line-height:1.5;">
+          <span style="color:#10b981;font-weight:700;margin-right:8px;">✓</span>${h}
+        </td></tr>`
+    )
+    .join("")
+
+  const attentionHtml =
+    narrative.attentionItems.length > 0
+      ? `<tr>
+          <td style="padding:32px 40px 0;">
+            <p style="margin:0 0 12px;font-size:12px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;font-weight:600;">Points d'attention</p>
+            <table width="100%" cellpadding="0" cellspacing="0" style="background:#fffbeb;border:1px solid #fde68a;border-radius:6px;margin-bottom:4px;">
+              <tr><td style="padding:16px 20px;">
+                ${narrative.attentionItems
+                  .map(
+                    (item) =>
+                      `<p style="margin:0 0 8px;font-size:14px;color:#92400e;line-height:1.5;">
+                        <span style="font-weight:700;margin-right:8px;">⚠</span>${item}
+                      </p>`
+                  )
+                  .join("")}
+                <p style="margin:0;"></p>
+              </td></tr>
+            </table>
+          </td>
+        </tr>`
+      : ""
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${buildWeeklyReportSubject(data.weekRange.start)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:system-ui,-apple-system,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table width="620" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;border:1px solid #e4e4e7;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#18181b;padding:32px 40px;">
+              <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">BTP × AI Métallerie</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#a1a1aa;">12 rue de la Forge, 75001 Paris · 01 23 45 67 89</p>
+            </td>
+          </tr>
+
+          <!-- Report title -->
+          <tr>
+            <td style="padding:32px 40px 24px;">
+              <p style="margin:0 0 4px;display:inline-block;padding:4px 12px;background:#6366f11a;color:#6366f1;font-size:11px;font-weight:600;border-radius:4px;border:1px solid #6366f133;text-transform:uppercase;letter-spacing:0.08em;">Rapport hebdomadaire</p>
+              <h1 style="margin:16px 0 4px;font-size:22px;font-weight:700;color:#18181b;letter-spacing:-0.02em;">Bilan de la semaine</h1>
+              <p style="margin:0;font-size:14px;color:#71717a;">${weekLabel}</p>
+            </td>
+          </tr>
+
+          <!-- Summary -->
+          <tr>
+            <td style="padding:0 40px 24px;">
+              <p style="margin:0;font-size:15px;color:#3f3f46;line-height:1.7;">${narrative.summary}</p>
+            </td>
+          </tr>
+
+          <!-- Stats grid -->
+          <tr>
+            <td style="padding:0 40px 32px;">
+              <p style="margin:0 0 12px;font-size:12px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;font-weight:600;">Chiffres de la semaine</p>
+              <table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e4e4e7;border-radius:6px;overflow:hidden;">
+                <tr style="background:#fafafa;">
+                  <td style="padding:16px 20px;border-right:1px solid #e4e4e7;border-bottom:1px solid #e4e4e7;width:25%;" align="center">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.08em;">Devis envoyés</p>
+                    <p style="margin:0;font-size:26px;font-weight:700;color:#18181b;">${data.quotes.sent}</p>
+                  </td>
+                  <td style="padding:16px 20px;border-right:1px solid #e4e4e7;border-bottom:1px solid #e4e4e7;width:25%;" align="center">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.08em;">Acceptés</p>
+                    <p style="margin:0;font-size:26px;font-weight:700;color:#10b981;">${data.quotes.accepted}</p>
+                  </td>
+                  <td style="padding:16px 20px;border-right:1px solid #e4e4e7;border-bottom:1px solid #e4e4e7;width:25%;" align="center">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.08em;">Refusés</p>
+                    <p style="margin:0;font-size:26px;font-weight:700;color:#ef4444;">${data.quotes.rejected}</p>
+                  </td>
+                  <td style="padding:16px 20px;border-bottom:1px solid #e4e4e7;width:25%;" align="center">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.08em;">Chantiers actifs</p>
+                    <p style="margin:0;font-size:26px;font-weight:700;color:#18181b;">${data.projects.inProgressTotal}</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="4" style="padding:16px 20px;" align="center">
+                    <p style="margin:0 0 4px;font-size:11px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.08em;">CA réalisé (HT)</p>
+                    <p style="margin:0;font-size:32px;font-weight:700;color:#18181b;">${fmtEur(data.quotes.caRealiseHT)}</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Highlights -->
+          <tr>
+            <td style="padding:0 40px 32px;">
+              <p style="margin:0 0 12px;font-size:12px;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.1em;font-weight:600;">Points forts</p>
+              <table width="100%" cellpadding="0" cellspacing="0">
+                ${highlightsHtml}
+              </table>
+            </td>
+          </tr>
+
+          <!-- Attention points (conditional) -->
+          ${attentionHtml}
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#fafafa;padding:20px 40px;border-top:1px solid #e4e4e7;margin-top:32px;">
+              <p style="margin:0;font-size:12px;color:#a1a1aa;text-align:center;">
+                BTP × AI Métallerie · SIRET 123 456 789 00010 · contact@btpxai.fr
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}

--- a/lib/weekly-report.ts
+++ b/lib/weekly-report.ts
@@ -1,0 +1,151 @@
+import { supabaseService } from "@/lib/supabase/service"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyClient = SupabaseClient<any>
+
+export type WeekRange = { start: string; end: string }
+
+export type WeeklyQuoteStats = {
+  sent: number
+  accepted: number
+  rejected: number
+  caRealiseHT: number
+}
+
+export type WeeklyProjectStats = {
+  completedTotal: number
+  inProgressTotal: number
+}
+
+export type WeeklyAttentionPoints = {
+  pendingQuotes: number
+  openAlerts: number
+  pendingMaterials: number
+  unprocessedEmails: number
+}
+
+export type WeeklyReportData = {
+  weekRange: WeekRange
+  quotes: WeeklyQuoteStats
+  projects: WeeklyProjectStats
+  attentionPoints: WeeklyAttentionPoints
+}
+
+export function getLastWeekRange(): WeekRange {
+  const now = new Date()
+  const end = new Date(now)
+  end.setHours(0, 0, 0, 0)
+  const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000)
+  return { start: start.toISOString(), end: end.toISOString() }
+}
+
+export async function getWeeklyQuoteStats(
+  supabase: AnyClient,
+  range: WeekRange
+): Promise<WeeklyQuoteStats> {
+  const { data, error } = await supabase
+    .from("quotes")
+    .select("status, total_ht")
+    .gte("sent_at", range.start)
+    .lt("sent_at", range.end)
+
+  if (error) throw error
+
+  const rows = (data ?? []) as { status: string; total_ht: number }[]
+  const sent = rows.length
+  const accepted = rows.filter((r) => r.status === "accepted").length
+  const rejected = rows.filter((r) => r.status === "rejected").length
+  const caRealiseHT =
+    Math.round(
+      rows
+        .filter((r) => r.status === "accepted")
+        .reduce((sum, r) => sum + (r.total_ht ?? 0), 0) * 100
+    ) / 100
+
+  return { sent, accepted, rejected, caRealiseHT }
+}
+
+export async function getWeeklyProjectStats(supabase: AnyClient): Promise<WeeklyProjectStats> {
+  const [{ count: completedTotal }, { count: inProgressTotal }] = await Promise.all([
+    supabase
+      .from("projects")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "completed"),
+    supabase
+      .from("projects")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "in_progress"),
+  ])
+
+  return {
+    completedTotal: completedTotal ?? 0,
+    inProgressTotal: inProgressTotal ?? 0,
+  }
+}
+
+export async function getWeeklyAttentionPoints(
+  supabase: AnyClient,
+  weekStart: string
+): Promise<WeeklyAttentionPoints> {
+  const [
+    { count: pendingQuotes },
+    { count: openAlerts },
+    { count: pendingMaterials },
+    { count: unprocessedEmails },
+  ] = await Promise.all([
+    supabase
+      .from("quotes")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "sent")
+      .lt("sent_at", weekStart),
+    supabase
+      .from("alertes_terrain")
+      .select("id", { count: "exact", head: true })
+      .in("status", ["ouvert", "pris_en_charge"]),
+    supabase
+      .from("materiaux_requests")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending"),
+    supabase
+      .from("email_statuses")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "a_traiter"),
+  ])
+
+  return {
+    pendingQuotes: pendingQuotes ?? 0,
+    openAlerts: openAlerts ?? 0,
+    pendingMaterials: pendingMaterials ?? 0,
+    unprocessedEmails: unprocessedEmails ?? 0,
+  }
+}
+
+export async function getWeeklyReportData(): Promise<WeeklyReportData> {
+  const weekRange = getLastWeekRange()
+
+  const [quotes, projects, attentionPoints] = await Promise.all([
+    getWeeklyQuoteStats(supabaseService, weekRange),
+    getWeeklyProjectStats(supabaseService),
+    getWeeklyAttentionPoints(supabaseService, weekRange.start),
+  ])
+
+  return { weekRange, quotes, projects, attentionPoints }
+}
+
+export async function getWeeklyReportRecipients(): Promise<string[]> {
+  const { data } = await supabaseService
+    .from("app_settings")
+    .select("value")
+    .eq("key", "weekly_report_recipients")
+    .single()
+
+  if (!data?.value) return []
+  try {
+    const parsed = JSON.parse(data.value) as unknown
+    if (Array.isArray(parsed)) return parsed.filter((e) => typeof e === "string")
+    return []
+  } catch {
+    return []
+  }
+}

--- a/tests/unit/weekly-report.test.ts
+++ b/tests/unit/weekly-report.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { WeeklyReportData } from "@/lib/weekly-report"
+import { weeklyReportNarrativeSchema } from "@/lib/agents/weekly-report"
+import { buildWeeklyReportSubject, buildWeeklyReportHtml } from "@/lib/email/weekly-report"
+
+// ─── supabaseService mock ─────────────────────────────────────────────────────
+
+const mockFrom = vi.hoisted(() => vi.fn())
+vi.mock("@/lib/supabase/service", () => ({
+  supabaseService: { from: mockFrom },
+}))
+
+import {
+  getLastWeekRange,
+  getWeeklyQuoteStats,
+  getWeeklyProjectStats,
+  getWeeklyAttentionPoints,
+  getWeeklyReportRecipients,
+} from "@/lib/weekly-report"
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeBuilder(result: { data: unknown; error: null | object; count?: number | null }) {
+  const builder: Record<string, unknown> = {
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve),
+  }
+  for (const m of ["select", "eq", "gte", "lt", "lte", "in", "not", "limit", "single", "head"]) {
+    builder[m] = vi.fn().mockReturnValue(builder)
+  }
+  return builder
+}
+
+function makeCountBuilder(count: number) {
+  return makeBuilder({ data: null, error: null, count })
+}
+
+// ─── getLastWeekRange ─────────────────────────────────────────────────────────
+
+describe("getLastWeekRange", () => {
+  const monday = new Date("2026-05-04T08:00:00Z") // a Monday
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(monday)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("returns end as start of today (midnight UTC)", () => {
+    const { end } = getLastWeekRange()
+    expect(end).toBe("2026-05-04T00:00:00.000Z")
+  })
+
+  it("returns start exactly 7 days before end", () => {
+    const { start, end } = getLastWeekRange()
+    const diff = new Date(end).getTime() - new Date(start).getTime()
+    expect(diff).toBe(7 * 24 * 60 * 60 * 1000)
+  })
+
+  it("start is the previous Monday (2026-04-27)", () => {
+    const { start } = getLastWeekRange()
+    expect(start).toBe("2026-04-27T00:00:00.000Z")
+  })
+})
+
+// ─── getWeeklyQuoteStats ──────────────────────────────────────────────────────
+
+describe("getWeeklyQuoteStats", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const range = {
+    start: "2026-04-27T00:00:00.000Z",
+    end: "2026-05-04T00:00:00.000Z",
+  }
+
+  it("counts sent, accepted, rejected and sums CA", async () => {
+    const rows = [
+      { status: "sent", total_ht: 1200 },
+      { status: "accepted", total_ht: 3000 },
+      { status: "accepted", total_ht: 1500 },
+      { status: "rejected", total_ht: 800 },
+    ]
+    const builder = makeBuilder({ data: rows, error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const stats = await getWeeklyQuoteStats({ from: mockFrom } as never, range)
+
+    expect(stats.sent).toBe(4)
+    expect(stats.accepted).toBe(2)
+    expect(stats.rejected).toBe(1)
+    expect(stats.caRealiseHT).toBe(4500)
+  })
+
+  it("returns zeros when no quotes exist", async () => {
+    const builder = makeBuilder({ data: [], error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const stats = await getWeeklyQuoteStats({ from: mockFrom } as never, range)
+
+    expect(stats.sent).toBe(0)
+    expect(stats.accepted).toBe(0)
+    expect(stats.rejected).toBe(0)
+    expect(stats.caRealiseHT).toBe(0)
+  })
+
+  it("throws on database error", async () => {
+    const dbError = { message: "DB error", code: "500" }
+    const builder = makeBuilder({ data: null, error: dbError })
+    mockFrom.mockReturnValueOnce(builder)
+
+    await expect(getWeeklyQuoteStats({ from: mockFrom } as never, range)).rejects.toEqual(dbError)
+  })
+
+  it("filters by sent_at range (gte start, lt end)", async () => {
+    const builder = makeBuilder({ data: [], error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    await getWeeklyQuoteStats({ from: mockFrom } as never, range)
+
+    expect(builder.gte).toHaveBeenCalledWith("sent_at", range.start)
+    expect(builder.lt).toHaveBeenCalledWith("sent_at", range.end)
+  })
+})
+
+// ─── getWeeklyProjectStats ────────────────────────────────────────────────────
+
+describe("getWeeklyProjectStats", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns completed and in_progress counts", async () => {
+    const completedBuilder = makeCountBuilder(5)
+    const inProgressBuilder = makeCountBuilder(3)
+    mockFrom.mockReturnValueOnce(completedBuilder).mockReturnValueOnce(inProgressBuilder)
+
+    const stats = await getWeeklyProjectStats({ from: mockFrom } as never)
+
+    expect(stats.completedTotal).toBe(5)
+    expect(stats.inProgressTotal).toBe(3)
+  })
+
+  it("defaults to 0 when count is null", async () => {
+    const completedBuilder = makeCountBuilder(0)
+    const inProgressBuilder = makeCountBuilder(0)
+    mockFrom.mockReturnValueOnce(completedBuilder).mockReturnValueOnce(inProgressBuilder)
+
+    const stats = await getWeeklyProjectStats({ from: mockFrom } as never)
+
+    expect(stats.completedTotal).toBe(0)
+    expect(stats.inProgressTotal).toBe(0)
+  })
+})
+
+// ─── getWeeklyAttentionPoints ─────────────────────────────────────────────────
+
+describe("getWeeklyAttentionPoints", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const weekStart = "2026-04-27T00:00:00.000Z"
+
+  it("returns all four attention point counts", async () => {
+    mockFrom
+      .mockReturnValueOnce(makeCountBuilder(2))  // pendingQuotes
+      .mockReturnValueOnce(makeCountBuilder(1))  // openAlerts
+      .mockReturnValueOnce(makeCountBuilder(4))  // pendingMaterials
+      .mockReturnValueOnce(makeCountBuilder(7))  // unprocessedEmails
+
+    const points = await getWeeklyAttentionPoints({ from: mockFrom } as never, weekStart)
+
+    expect(points.pendingQuotes).toBe(2)
+    expect(points.openAlerts).toBe(1)
+    expect(points.pendingMaterials).toBe(4)
+    expect(points.unprocessedEmails).toBe(7)
+  })
+
+  it("filters pending quotes by sent_at < weekStart", async () => {
+    const pendingBuilder = makeCountBuilder(0)
+    mockFrom
+      .mockReturnValueOnce(pendingBuilder)
+      .mockReturnValueOnce(makeCountBuilder(0))
+      .mockReturnValueOnce(makeCountBuilder(0))
+      .mockReturnValueOnce(makeCountBuilder(0))
+
+    await getWeeklyAttentionPoints({ from: mockFrom } as never, weekStart)
+
+    expect(pendingBuilder.eq).toHaveBeenCalledWith("status", "sent")
+    expect(pendingBuilder.lt).toHaveBeenCalledWith("sent_at", weekStart)
+  })
+})
+
+// ─── getWeeklyReportRecipients ────────────────────────────────────────────────
+
+describe("getWeeklyReportRecipients", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns parsed email list from app_settings", async () => {
+    const builder = makeBuilder({
+      data: { value: '["gerant@btpxai.fr","bureau@btpxai.fr"]' },
+      error: null,
+    })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await getWeeklyReportRecipients()
+
+    expect(result).toEqual(["gerant@btpxai.fr", "bureau@btpxai.fr"])
+  })
+
+  it("returns empty array when setting is absent", async () => {
+    const builder = makeBuilder({ data: null, error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await getWeeklyReportRecipients()
+
+    expect(result).toEqual([])
+  })
+
+  it("returns empty array when value is invalid JSON", async () => {
+    const builder = makeBuilder({ data: { value: "not-json" }, error: null })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await getWeeklyReportRecipients()
+
+    expect(result).toEqual([])
+  })
+
+  it("filters out non-string entries from the array", async () => {
+    const builder = makeBuilder({
+      data: { value: '["valid@example.com", 42, null, "another@example.com"]' },
+      error: null,
+    })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await getWeeklyReportRecipients()
+
+    expect(result).toEqual(["valid@example.com", "another@example.com"])
+  })
+
+  it("returns empty array when value is a non-array JSON", async () => {
+    const builder = makeBuilder({
+      data: { value: '"single-email@example.com"' },
+      error: null,
+    })
+    mockFrom.mockReturnValueOnce(builder)
+
+    const result = await getWeeklyReportRecipients()
+
+    expect(result).toEqual([])
+  })
+})
+
+// ─── weeklyReportNarrativeSchema ──────────────────────────────────────────────
+
+describe("weeklyReportNarrativeSchema (agent output validation)", () => {
+  const valid = {
+    summary: "Bonne semaine avec 3 devis envoyés.",
+    highlights: ["CA de 4 500 € réalisé", "2 devis acceptés"],
+    attentionItems: ["1 devis ancien en attente de réponse"],
+  }
+
+  it("accepts a valid narrative", () => {
+    expect(weeklyReportNarrativeSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it("accepts empty attentionItems", () => {
+    expect(
+      weeklyReportNarrativeSchema.safeParse({ ...valid, attentionItems: [] }).success
+    ).toBe(true)
+  })
+
+  it("rejects empty summary", () => {
+    expect(
+      weeklyReportNarrativeSchema.safeParse({ ...valid, summary: "" }).success
+    ).toBe(false)
+  })
+
+  it("rejects missing highlights field", () => {
+    const { highlights: _h, ...rest } = valid
+    expect(weeklyReportNarrativeSchema.safeParse(rest).success).toBe(false)
+  })
+})
+
+// ─── buildWeeklyReportSubject ─────────────────────────────────────────────────
+
+describe("buildWeeklyReportSubject", () => {
+  it("includes the week start date in the subject", () => {
+    const subject = buildWeeklyReportSubject("2026-04-27T00:00:00.000Z")
+    expect(subject).toContain("27 avril")
+    expect(subject).toMatch(/rapport hebdomadaire/i)
+  })
+})
+
+// ─── buildWeeklyReportHtml ────────────────────────────────────────────────────
+
+describe("buildWeeklyReportHtml", () => {
+  const data: WeeklyReportData = {
+    weekRange: {
+      start: "2026-04-27T00:00:00.000Z",
+      end: "2026-05-04T00:00:00.000Z",
+    },
+    quotes: { sent: 5, accepted: 3, rejected: 1, caRealiseHT: 7500 },
+    projects: { completedTotal: 10, inProgressTotal: 4 },
+    attentionPoints: {
+      pendingQuotes: 2,
+      openAlerts: 1,
+      pendingMaterials: 0,
+      unprocessedEmails: 3,
+    },
+  }
+
+  const narrative = {
+    summary: "Bonne semaine avec 5 devis envoyés et 3 acceptés.",
+    highlights: ["CA de 7 500 € réalisé", "3 devis acceptés cette semaine"],
+    attentionItems: ["2 anciens devis en attente", "1 alerte terrain ouverte"],
+  }
+
+  it("renders quote counts in the HTML", () => {
+    const html = buildWeeklyReportHtml(data, narrative)
+    expect(html).toContain(">5<")   // sent
+    expect(html).toContain(">3<")   // accepted
+    expect(html).toContain(">1<")   // rejected
+    expect(html).toContain(">4<")   // in_progress
+  })
+
+  it("renders the summary text", () => {
+    const html = buildWeeklyReportHtml(data, narrative)
+    expect(html).toContain(narrative.summary)
+  })
+
+  it("renders highlights", () => {
+    const html = buildWeeklyReportHtml(data, narrative)
+    expect(html).toContain(narrative.highlights[0])
+    expect(html).toContain(narrative.highlights[1])
+  })
+
+  it("renders attention items when present", () => {
+    const html = buildWeeklyReportHtml(data, narrative)
+    expect(html).toContain(narrative.attentionItems[0])
+  })
+
+  it("omits attention section when attentionItems is empty", () => {
+    const html = buildWeeklyReportHtml(data, {
+      ...narrative,
+      attentionItems: [],
+    })
+    expect(html).not.toContain("Points d'attention")
+  })
+
+  it("includes BTP branding", () => {
+    const html = buildWeeklyReportHtml(data, narrative)
+    expect(html).toContain("BTP × AI Métallerie")
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/quote-reminders",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/weekly-report",
+      "schedule": "0 8 * * 1"
     }
   ]
 }


### PR DESCRIPTION
- Cron Vercel (0 8 * * 1) → /api/cron/weekly-report
- lib/weekly-report.ts : récupère les données de la semaine passée
  (devis envoyés/acceptés/refusés, CA HT, chantiers, points d'attention)
- lib/agents/weekly-report.ts : génère un résumé narratif via claude-sonnet-4-6
- lib/email/weekly-report.ts : template HTML avec stats et narrative IA
- Destinataires configurés via app_settings (clé weekly_report_recipients, JSON)
- 27 tests Vitest couvrant la récupération des données, la validation du schéma
  et le rendu du template email

https://claude.ai/code/session_01SsVD1tUcbNoyLW14VDngEg