### PR TITLE
feat: admin settings page with company info, automations, users management

### DIFF
--- a/app/(bureau)/parametres/page.tsx
+++ b/app/(bureau)/parametres/page.tsx
@@ -1,15 +1,29 @@
+import { redirect } from "next/navigation"
 import type { Metadata } from "next"
 import { Settings } from "lucide-react"
+import { getUser, getUserRole } from "@/lib/supabase/server"
 import { supabaseService } from "@/lib/supabase/service"
-import { GmailConnectionSection } from "@/components/parametres/gmail-connection-section"
-import { AutoAcknowledgmentSection } from "@/components/parametres/auto-acknowledgment-section"
-import { SheetsSyncSection } from "@/components/parametres/sheets-sync-section"
 import { getAutoAcknowledgmentEnabled } from "@/lib/acknowledgments"
 import { getLastSyncAt } from "@/lib/sheets"
+import { getMultipleSettings } from "@/lib/settings"
+import { SettingsShell } from "@/components/parametres/settings-shell"
 
 export const metadata: Metadata = {
   title: "Paramètres — BTP×AI",
 }
+
+const SETTINGS_KEYS = [
+  "company_name",
+  "company_address",
+  "company_siret",
+  "company_logo_url",
+  "weekly_report_recipients",
+  "weekly_report_enabled",
+  "auto_reminders_enabled",
+  "reminder_delay_j7",
+  "reminder_delay_j14",
+  "default_cgv",
+]
 
 type SearchParams = Promise<{ gmail?: string }>
 
@@ -18,45 +32,56 @@ export default async function ParametresPage({
 }: {
   searchParams: SearchParams
 }) {
+  const user = await getUser()
+  if (!user) redirect("/login")
+
+  const role = getUserRole(user)
+  if (role !== "admin") redirect("/dashboard")
+
   const { gmail } = await searchParams
 
-  const [{ data: connection }, autoAckEnabled, lastSyncAt] = await Promise.all([
-    supabaseService.from("gmail_connections").select("email, created_at").limit(1).single(),
-    getAutoAcknowledgmentEnabled(),
-    getLastSyncAt(),
-  ])
+  const [settings, { data: connection }, autoAckEnabled, lastSyncAt, { data: usersData }] =
+    await Promise.all([
+      getMultipleSettings(SETTINGS_KEYS),
+      supabaseService.from("gmail_connections").select("email, created_at").limit(1).single(),
+      getAutoAcknowledgmentEnabled(),
+      getLastSyncAt(),
+      supabaseService.auth.admin.listUsers({ perPage: 200 }),
+    ])
+
+  const users = (usersData?.users ?? []).map((u) => ({
+    id: u.id,
+    email: u.email ?? "",
+    role: (u.user_metadata?.role as "admin" | "bureau" | "ouvrier" | undefined) ?? null,
+    created_at: u.created_at,
+  }))
 
   return (
     <div className="space-y-6">
+      {/* Page header */}
       <div>
         <div className="flex items-center gap-2 mb-1">
           <Settings className="size-3.5 text-muted-foreground" />
           <span className="text-xs text-muted-foreground tracking-wider uppercase">
-            Configuration
+            Administration
           </span>
         </div>
         <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
           Paramètres
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Gérez les intégrations et la configuration de l'application.
+          Configuration globale de l'application — accès admin uniquement.
         </p>
       </div>
 
-      <div className="max-w-2xl space-y-4">
-        <h2 className="text-sm font-medium text-muted-foreground tracking-wider uppercase">
-          Intégrations
-        </h2>
-        <GmailConnectionSection connection={connection} gmailParam={gmail} />
-      </div>
-
-      <div className="max-w-2xl space-y-4">
-        <h2 className="text-sm font-medium text-muted-foreground tracking-wider uppercase">
-          Automatisations
-        </h2>
-        <AutoAcknowledgmentSection initialEnabled={autoAckEnabled} />
-        <SheetsSyncSection lastSyncAt={lastSyncAt} />
-      </div>
+      <SettingsShell
+        settings={settings}
+        connection={connection}
+        gmailParam={gmail}
+        autoAckEnabled={autoAckEnabled}
+        lastSyncAt={lastSyncAt}
+        users={users}
+      />
     </div>
   )
 }

--- a/app/api/parametres/company/logo/route.ts
+++ b/app/api/parametres/company/logo/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { createClient, getUserRole } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+import { setAppSetting } from "@/lib/settings"
+
+const BUCKET = "company-logos"
+const FILE_KEY = "logo"
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const form = await request.formData()
+  const file = form.get("file")
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 })
+  }
+
+  const allowed = ["image/png", "image/jpeg", "image/webp", "image/svg+xml"]
+  if (!allowed.includes(file.type)) {
+    return NextResponse.json({ error: "Unsupported file type" }, { status: 400 })
+  }
+
+  if (file.size > 2 * 1024 * 1024) {
+    return NextResponse.json({ error: "File too large (max 2 MB)" }, { status: 400 })
+  }
+
+  const ext = file.name.split(".").pop() ?? "png"
+  const path = `${FILE_KEY}.${ext}`
+
+  const { error } = await supabaseService.storage
+    .from(BUCKET)
+    .upload(path, file, { upsert: true, contentType: file.type })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const { data: { publicUrl } } = supabaseService.storage
+    .from(BUCKET)
+    .getPublicUrl(path)
+
+  await setAppSetting("company_logo_url", publicUrl)
+
+  return NextResponse.json({ url: publicUrl })
+}

--- a/app/api/parametres/company/route.ts
+++ b/app/api/parametres/company/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUserRole } from "@/lib/supabase/server"
+import { getMultipleSettings, setAppSetting } from "@/lib/settings"
+
+const COMPANY_KEYS = ["company_name", "company_address", "company_siret", "company_logo_url"]
+
+const bodySchema = z.object({
+  company_name: z.string().max(200),
+  company_address: z.string().max(500),
+  company_siret: z.string().max(20),
+})
+
+export async function GET(): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const settings = await getMultipleSettings(COMPANY_KEYS)
+  return NextResponse.json(settings)
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+
+  const { company_name, company_address, company_siret } = parsed.data
+  await Promise.all([
+    setAppSetting("company_name", company_name),
+    setAppSetting("company_address", company_address),
+    setAppSetting("company_siret", company_siret),
+  ])
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/parametres/settings/route.ts
+++ b/app/api/parametres/settings/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUserRole } from "@/lib/supabase/server"
+import { setAppSetting } from "@/lib/settings"
+
+const bodySchema = z.object({
+  key: z.enum([
+    "weekly_report_recipients",
+    "weekly_report_enabled",
+    "auto_reminders_enabled",
+    "reminder_delay_j7",
+    "reminder_delay_j14",
+    "default_cgv",
+  ]),
+  value: z.string(),
+})
+
+export async function PATCH(request: Request): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+
+  await setAppSetting(parsed.data.key, parsed.data.value)
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/parametres/users/[id]/route.ts
+++ b/app/api/parametres/users/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUserRole } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+
+const bodySchema = z.object({
+  role: z.enum(["admin", "bureau", "ouvrier"]),
+})
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const currentRole = getUserRole(user)
+  if (currentRole !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const { id } = await params
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+
+  const { role } = parsed.data
+
+  const { error } = await supabaseService.auth.admin.updateUserById(id, {
+    user_metadata: { role },
+  })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/parametres/users/invite/route.ts
+++ b/app/api/parametres/users/invite/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUserRole } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+
+const bodySchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["admin", "bureau", "ouvrier"]),
+})
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const currentRole = getUserRole(user)
+  if (currentRole !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+
+  const { email, role } = parsed.data
+
+  const { data, error } = await supabaseService.auth.admin.inviteUserByEmail(email, {
+    data: { role },
+  })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({
+    user: {
+      id: data.user.id,
+      email: data.user.email,
+      role,
+      created_at: data.user.created_at,
+    },
+  })
+}

--- a/app/api/parametres/users/route.ts
+++ b/app/api/parametres/users/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import type { User } from "@supabase/supabase-js"
+import { createClient, getUserRole } from "@/lib/supabase/server"
+import { supabaseService } from "@/lib/supabase/service"
+
+export async function GET(): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const role = getUserRole(user)
+  if (role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const { data, error } = await supabaseService.auth.admin.listUsers({ perPage: 200 })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const users = data.users.map((u: User) => ({
+    id: u.id,
+    email: u.email ?? "",
+    role: (u.user_metadata?.role as string | undefined) ?? null,
+    created_at: u.created_at,
+  }))
+
+  return NextResponse.json({ users })
+}

--- a/components/parametres/cgv-section.tsx
+++ b/components/parametres/cgv-section.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { FileText, Loader2, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+
+type Props = {
+  initialCgv: string
+}
+
+export function CgvSection({ initialCgv }: Props) {
+  const [value, setValue] = useState(initialCgv)
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  function handleSave() {
+    startTransition(async () => {
+      const res = await fetch("/api/parametres/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "default_cgv", value }),
+      })
+      if (res.ok) {
+        setSaved(true)
+        setTimeout(() => setSaved(false), 2500)
+      }
+    })
+  }
+
+  return (
+    <div className="rounded-sm border border-border overflow-hidden">
+      <div className="flex items-center gap-2.5 px-5 py-3 border-b border-border bg-muted/40">
+        <FileText className="size-3.5 text-primary" />
+        <span className="text-xs font-medium tracking-wider uppercase text-foreground">
+          Conditions générales de vente par défaut
+        </span>
+      </div>
+
+      <div className="p-5 space-y-3">
+        <Label htmlFor="cgv" className="text-xs tracking-wider uppercase text-muted-foreground">
+          Texte CGV
+        </Label>
+        <Textarea
+          id="cgv"
+          data-testid="cgv-textarea"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          rows={10}
+          placeholder="Saisissez vos conditions générales de vente…"
+          className="font-mono text-xs resize-y leading-relaxed"
+        />
+        <p className="text-xs text-muted-foreground">
+          Ces CGV seront pré-remplies sur chaque nouveau devis. Vous pourrez les modifier devis par devis.
+        </p>
+
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            size="sm"
+            disabled={isPending}
+            onClick={handleSave}
+            data-testid="cgv-save-btn"
+          >
+            {isPending && <Loader2 className="size-3.5 animate-spin" />}
+            Sauvegarder
+          </Button>
+          {saved && (
+            <span className="flex items-center gap-1.5 text-xs text-primary animate-in fade-in duration-200">
+              <CheckCircle2 className="size-3.5" />
+              Sauvegardé
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/parametres/company-section.tsx
+++ b/components/parametres/company-section.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import { useState, useRef, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { Building2, Upload, Loader2, CheckCircle2, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const schema = z.object({
+  company_name: z.string().max(200),
+  company_address: z.string().max(500),
+  company_siret: z.string().max(20),
+})
+
+type FormValues = z.infer<typeof schema>
+
+type Props = {
+  initialSettings: Record<string, string>
+}
+
+export function CompanySection({ initialSettings }: Props) {
+  const [logoUrl, setLogoUrl] = useState(initialSettings.company_logo_url ?? "")
+  const [logoUploading, setLogoUploading] = useState(false)
+  const [logoError, setLogoError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const { register, handleSubmit, formState: { errors } } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      company_name: initialSettings.company_name ?? "",
+      company_address: initialSettings.company_address ?? "",
+      company_siret: initialSettings.company_siret ?? "",
+    },
+  })
+
+  function onSubmit(data: FormValues) {
+    startTransition(async () => {
+      const res = await fetch("/api/parametres/company", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      })
+      if (res.ok) {
+        setSaved(true)
+        setTimeout(() => setSaved(false), 2500)
+      }
+    })
+  }
+
+  async function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setLogoError(null)
+    setLogoUploading(true)
+    const form = new FormData()
+    form.append("file", file)
+
+    try {
+      const res = await fetch("/api/parametres/company/logo", {
+        method: "POST",
+        body: form,
+      })
+      const json = await res.json() as { url?: string; error?: string }
+      if (!res.ok) {
+        setLogoError(json.error ?? "Erreur upload")
+      } else {
+        setLogoUrl(json.url ?? "")
+      }
+    } catch {
+      setLogoError("Erreur réseau")
+    } finally {
+      setLogoUploading(false)
+      if (fileRef.current) fileRef.current.value = ""
+    }
+  }
+
+  return (
+    <div
+      data-testid="company-section"
+      className="rounded-sm border border-border overflow-hidden"
+    >
+      {/* Panel header */}
+      <div className="flex items-center gap-2.5 px-5 py-3 border-b border-border bg-muted/40">
+        <Building2 className="size-3.5 text-primary" />
+        <span className="text-xs font-medium tracking-wider uppercase text-foreground">
+          Informations entreprise
+        </span>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="p-5 space-y-5">
+        {/* Logo */}
+        <div className="space-y-2">
+          <Label className="text-xs tracking-wider uppercase text-muted-foreground">
+            Logo
+          </Label>
+          <div className="flex items-center gap-4">
+            <div
+              className="relative size-16 rounded-sm border border-border bg-muted/30 flex items-center justify-center overflow-hidden shrink-0"
+            >
+              {logoUrl ? (
+                <img
+                  src={logoUrl}
+                  alt="Logo entreprise"
+                  className="object-contain size-full p-1"
+                />
+              ) : (
+                <Building2 className="size-6 text-muted-foreground/40" />
+              )}
+            </div>
+            <div className="space-y-1.5">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={logoUploading}
+                onClick={() => fileRef.current?.click()}
+                className="gap-2 text-xs h-8"
+              >
+                {logoUploading
+                  ? <Loader2 className="size-3.5 animate-spin" />
+                  : <Upload className="size-3.5" />
+                }
+                {logoUploading ? "Envoi…" : "Changer le logo"}
+              </Button>
+              <p className="text-xs text-muted-foreground">PNG, JPG, WebP — max 2 Mo</p>
+              {logoError && (
+                <p className="flex items-center gap-1 text-xs text-destructive">
+                  <X className="size-3" /> {logoError}
+                </p>
+              )}
+            </div>
+          </div>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/svg+xml"
+            className="sr-only"
+            onChange={handleLogoChange}
+          />
+        </div>
+
+        {/* Nom */}
+        <div className="space-y-1.5">
+          <Label htmlFor="company_name" className="text-xs tracking-wider uppercase text-muted-foreground">
+            Nom de l'entreprise
+          </Label>
+          <Input
+            id="company_name"
+            data-testid="company-name-input"
+            placeholder="BTP Services Dupont"
+            {...register("company_name")}
+          />
+          {errors.company_name && (
+            <p className="text-xs text-destructive">{errors.company_name.message}</p>
+          )}
+        </div>
+
+        {/* Adresse */}
+        <div className="space-y-1.5">
+          <Label htmlFor="company_address" className="text-xs tracking-wider uppercase text-muted-foreground">
+            Adresse
+          </Label>
+          <Input
+            id="company_address"
+            data-testid="company-address-input"
+            placeholder="12 rue de la Forge, 75001 Paris"
+            {...register("company_address")}
+          />
+          {errors.company_address && (
+            <p className="text-xs text-destructive">{errors.company_address.message}</p>
+          )}
+        </div>
+
+        {/* SIRET */}
+        <div className="space-y-1.5">
+          <Label htmlFor="company_siret" className="text-xs tracking-wider uppercase text-muted-foreground">
+            SIRET
+          </Label>
+          <Input
+            id="company_siret"
+            data-testid="company-siret-input"
+            placeholder="12345678900012"
+            className="font-mono"
+            {...register("company_siret")}
+          />
+          {errors.company_siret && (
+            <p className="text-xs text-destructive">{errors.company_siret.message}</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 pt-1">
+          <Button
+            type="submit"
+            size="sm"
+            disabled={isPending}
+            data-testid="company-save-btn"
+          >
+            {isPending && <Loader2 className="size-3.5 animate-spin" />}
+            Sauvegarder
+          </Button>
+          {saved && (
+            <span className="flex items-center gap-1.5 text-xs text-primary animate-in fade-in duration-200">
+              <CheckCircle2 className="size-3.5" />
+              Sauvegardé
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/components/parametres/reminders-section.tsx
+++ b/components/parametres/reminders-section.tsx
@@ -10,8 +10,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 const schema = z.object({
-  reminder_delay_j7: z.coerce.number().min(1).max(30),
-  reminder_delay_j14: z.coerce.number().min(1).max(60),
+  reminder_delay_j7: z.number().min(1).max(30),
+  reminder_delay_j14: z.number().min(1).max(60),
 })
 
 type FormValues = z.infer<typeof schema>
@@ -120,7 +120,7 @@ export function RemindersSection({ initialSettings }: Props) {
                 max={30}
                 data-testid="reminders-delay-j7"
                 className="font-mono"
-                {...register("reminder_delay_j7")}
+                {...register("reminder_delay_j7", { valueAsNumber: true })}
               />
               {errors.reminder_delay_j7 && (
                 <p className="text-xs text-destructive">{errors.reminder_delay_j7.message}</p>
@@ -137,7 +137,7 @@ export function RemindersSection({ initialSettings }: Props) {
                 max={60}
                 data-testid="reminders-delay-j14"
                 className="font-mono"
-                {...register("reminder_delay_j14")}
+                {...register("reminder_delay_j14", { valueAsNumber: true })}
               />
               {errors.reminder_delay_j14 && (
                 <p className="text-xs text-destructive">{errors.reminder_delay_j14.message}</p>

--- a/components/parametres/reminders-section.tsx
+++ b/components/parametres/reminders-section.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { Bell, Loader2, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const schema = z.object({
+  reminder_delay_j7: z.coerce.number().int().min(1).max(30),
+  reminder_delay_j14: z.coerce.number().int().min(1).max(60),
+})
+
+type FormValues = z.infer<typeof schema>
+
+type Props = {
+  initialSettings: Record<string, string>
+}
+
+async function patchSetting(key: string, value: string) {
+  return fetch("/api/parametres/settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, value }),
+  })
+}
+
+export function RemindersSection({ initialSettings }: Props) {
+  const [enabled, setEnabled] = useState(
+    initialSettings.auto_reminders_enabled !== "false"
+  )
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const { register, handleSubmit, formState: { errors } } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      reminder_delay_j7: Number(initialSettings.reminder_delay_j7 ?? 7),
+      reminder_delay_j14: Number(initialSettings.reminder_delay_j14 ?? 14),
+    },
+  })
+
+  function flash() {
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2500)
+  }
+
+  function handleToggle() {
+    startTransition(async () => {
+      const next = !enabled
+      const res = await patchSetting("auto_reminders_enabled", String(next))
+      if (res.ok) { setEnabled(next); flash() }
+    })
+  }
+
+  function onSubmit(data: FormValues) {
+    startTransition(async () => {
+      await Promise.all([
+        patchSetting("reminder_delay_j7", String(data.reminder_delay_j7)),
+        patchSetting("reminder_delay_j14", String(data.reminder_delay_j14)),
+      ])
+      flash()
+    })
+  }
+
+  return (
+    <div className="rounded-sm border border-border overflow-hidden">
+      <div className="flex items-center gap-2.5 px-5 py-3 border-b border-border bg-muted/40">
+        <Bell className="size-3.5 text-primary" />
+        <span className="text-xs font-medium tracking-wider uppercase text-foreground">
+          Relances automatiques
+        </span>
+      </div>
+
+      <div className="p-5 space-y-5">
+        {/* Global toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-foreground">Activer les relances</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Envoie des relances automatiques pour les devis sans réponse.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={enabled}
+            onClick={handleToggle}
+            disabled={isPending}
+            data-testid="reminders-toggle"
+            className={[
+              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full",
+              "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              enabled ? "bg-primary" : "bg-input",
+            ].join(" ")}
+          >
+            <span
+              className={[
+                "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg transition-transform",
+                enabled ? "translate-x-5" : "translate-x-0.5",
+              ].join(" ")}
+            />
+          </button>
+        </div>
+
+        {/* Delay configuration */}
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="delay_j7" className="text-xs tracking-wider uppercase text-muted-foreground">
+                1re relance (jours)
+              </Label>
+              <Input
+                id="delay_j7"
+                type="number"
+                min={1}
+                max={30}
+                data-testid="reminders-delay-j7"
+                className="font-mono"
+                {...register("reminder_delay_j7")}
+              />
+              {errors.reminder_delay_j7 && (
+                <p className="text-xs text-destructive">{errors.reminder_delay_j7.message}</p>
+              )}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="delay_j14" className="text-xs tracking-wider uppercase text-muted-foreground">
+                2e relance (jours)
+              </Label>
+              <Input
+                id="delay_j14"
+                type="number"
+                min={1}
+                max={60}
+                data-testid="reminders-delay-j14"
+                className="font-mono"
+                {...register("reminder_delay_j14")}
+              />
+              {errors.reminder_delay_j14 && (
+                <p className="text-xs text-destructive">{errors.reminder_delay_j14.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button type="submit" size="sm" disabled={isPending}>
+              {isPending && <Loader2 className="size-3.5 animate-spin" />}
+              Sauvegarder
+            </Button>
+            {saved && (
+              <span className="flex items-center gap-1.5 text-xs text-primary animate-in fade-in duration-200">
+                <CheckCircle2 className="size-3.5" />
+                Sauvegardé
+              </span>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/components/parametres/reminders-section.tsx
+++ b/components/parametres/reminders-section.tsx
@@ -10,8 +10,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 const schema = z.object({
-  reminder_delay_j7: z.coerce.number().int().min(1).max(30),
-  reminder_delay_j14: z.coerce.number().int().min(1).max(60),
+  reminder_delay_j7: z.coerce.number().min(1).max(30),
+  reminder_delay_j14: z.coerce.number().min(1).max(60),
 })
 
 type FormValues = z.infer<typeof schema>

--- a/components/parametres/report-recipients-section.tsx
+++ b/components/parametres/report-recipients-section.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { BarChart2, Plus, Trash2, Loader2, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const addSchema = z.object({ email: z.string().email("Email invalide") })
+type AddForm = z.infer<typeof addSchema>
+
+type Props = {
+  initialRecipients: string[]
+  initialEnabled: boolean
+}
+
+async function patchSetting(key: string, value: string) {
+  return fetch("/api/parametres/settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, value }),
+  })
+}
+
+export function ReportRecipientsSection({ initialRecipients, initialEnabled }: Props) {
+  const [recipients, setRecipients] = useState<string[]>(initialRecipients)
+  const [enabled, setEnabled] = useState(initialEnabled)
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<AddForm>({
+    resolver: zodResolver(addSchema),
+  })
+
+  function flash() {
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2500)
+  }
+
+  function handleToggle() {
+    startTransition(async () => {
+      const next = !enabled
+      const res = await patchSetting("weekly_report_enabled", String(next))
+      if (res.ok) { setEnabled(next); flash() }
+    })
+  }
+
+  function onAddEmail(data: AddForm) {
+    if (recipients.includes(data.email)) return
+    const next = [...recipients, data.email]
+    startTransition(async () => {
+      const res = await patchSetting("weekly_report_recipients", JSON.stringify(next))
+      if (res.ok) { setRecipients(next); reset(); flash() }
+    })
+  }
+
+  function removeEmail(email: string) {
+    const next = recipients.filter((r) => r !== email)
+    startTransition(async () => {
+      const res = await patchSetting("weekly_report_recipients", JSON.stringify(next))
+      if (res.ok) { setRecipients(next); flash() }
+    })
+  }
+
+  return (
+    <div className="rounded-sm border border-border overflow-hidden">
+      <div className="flex items-center gap-2.5 px-5 py-3 border-b border-border bg-muted/40">
+        <BarChart2 className="size-3.5 text-primary" />
+        <span className="text-xs font-medium tracking-wider uppercase text-foreground">
+          Rapport hebdomadaire
+        </span>
+      </div>
+
+      <div className="p-5 space-y-5">
+        {/* Toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-foreground">Envoi automatique</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Rapport envoyé chaque lundi à 8h aux destinataires ci-dessous.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={enabled}
+            onClick={handleToggle}
+            disabled={isPending}
+            className={[
+              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full",
+              "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              enabled ? "bg-primary" : "bg-input",
+            ].join(" ")}
+          >
+            <span
+              className={[
+                "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg transition-transform",
+                enabled ? "translate-x-5" : "translate-x-0.5",
+              ].join(" ")}
+            />
+          </button>
+        </div>
+
+        {/* Recipients list */}
+        <div className="space-y-2">
+          <Label className="text-xs tracking-wider uppercase text-muted-foreground">
+            Destinataires
+          </Label>
+          {recipients.length === 0 ? (
+            <p className="text-xs text-muted-foreground italic">Aucun destinataire configuré.</p>
+          ) : (
+            <ul className="space-y-1.5">
+              {recipients.map((email) => (
+                <li
+                  key={email}
+                  className="flex items-center justify-between gap-2 rounded-sm border border-border px-3 py-2 bg-muted/20"
+                >
+                  <span className="text-sm font-mono text-foreground">{email}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeEmail(email)}
+                    disabled={isPending}
+                    className="text-muted-foreground hover:text-destructive transition-colors disabled:opacity-40"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Add email */}
+        <form onSubmit={handleSubmit(onAddEmail)} className="space-y-1.5">
+          <div className="flex gap-2">
+            <Input
+              data-testid="report-recipient-input"
+              placeholder="destinataire@email.com"
+              type="email"
+              className="font-mono text-sm"
+              {...register("email")}
+            />
+            <Button type="submit" size="sm" disabled={isPending} className="shrink-0 gap-1.5">
+              {isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+              Ajouter
+            </Button>
+          </div>
+          {errors.email && (
+            <p className="text-xs text-destructive">{errors.email.message}</p>
+          )}
+        </form>
+
+        {saved && (
+          <span className="flex items-center gap-1.5 text-xs text-primary animate-in fade-in duration-200">
+            <CheckCircle2 className="size-3.5" />
+            Sauvegardé
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/parametres/settings-shell.tsx
+++ b/components/parametres/settings-shell.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { useState } from "react"
+import { Building2, Zap, Plug, Users } from "lucide-react"
+import { CompanySection } from "./company-section"
+import { ReportRecipientsSection } from "./report-recipients-section"
+import { RemindersSection } from "./reminders-section"
+import { CgvSection } from "./cgv-section"
+import { AutoAcknowledgmentSection } from "./auto-acknowledgment-section"
+import { SheetsSyncSection } from "./sheets-sync-section"
+import { GmailConnectionSection } from "./gmail-connection-section"
+import { UsersSection } from "./users-section"
+
+type Tab = "entreprise" | "automatisations" | "integrations" | "equipe"
+
+const TABS: { id: Tab; label: string; icon: React.ElementType }[] = [
+  { id: "entreprise",      label: "Entreprise",      icon: Building2 },
+  { id: "automatisations", label: "Automatisations",  icon: Zap },
+  { id: "integrations",    label: "Intégrations",     icon: Plug },
+  { id: "equipe",          label: "Équipe",            icon: Users },
+]
+
+type AdminUser = {
+  id: string
+  email: string
+  role: "admin" | "bureau" | "ouvrier" | null
+  created_at: string
+}
+
+type Props = {
+  settings: Record<string, string>
+  connection: { email: string; created_at: string } | null
+  gmailParam?: string
+  autoAckEnabled: boolean
+  lastSyncAt: string | null
+  users: AdminUser[]
+}
+
+export function SettingsShell({
+  settings,
+  connection,
+  gmailParam,
+  autoAckEnabled,
+  lastSyncAt,
+  users,
+}: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("entreprise")
+
+  const recipients = (() => {
+    try {
+      const parsed: unknown = JSON.parse(settings.weekly_report_recipients ?? "[]")
+      return Array.isArray(parsed) ? (parsed as string[]) : []
+    } catch {
+      return []
+    }
+  })()
+
+  return (
+    <div>
+      {/* Tab navigation — industrial segment selector */}
+      <div className="flex border-b border-border mb-6 overflow-x-auto">
+        {TABS.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            onClick={() => setActiveTab(id)}
+            data-testid={`tab-${id}`}
+            className={[
+              "flex items-center gap-2 px-5 py-3 text-xs font-medium tracking-wider uppercase whitespace-nowrap",
+              "border-b-2 transition-colors focus-visible:outline-none",
+              activeTab === id
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+            ].join(" ")}
+          >
+            <Icon className="size-3.5 shrink-0" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="max-w-2xl space-y-4">
+        {activeTab === "entreprise" && (
+          <>
+            <CompanySection initialSettings={settings} />
+            <CgvSection initialCgv={settings.default_cgv ?? ""} />
+          </>
+        )}
+
+        {activeTab === "automatisations" && (
+          <>
+            <RemindersSection initialSettings={settings} />
+            <AutoAcknowledgmentSection initialEnabled={autoAckEnabled} />
+            <SheetsSyncSection lastSyncAt={lastSyncAt} />
+            <ReportRecipientsSection
+              initialRecipients={recipients}
+              initialEnabled={settings.weekly_report_enabled !== "false"}
+            />
+          </>
+        )}
+
+        {activeTab === "integrations" && (
+          <GmailConnectionSection connection={connection} gmailParam={gmailParam} />
+        )}
+
+        {activeTab === "equipe" && (
+          <UsersSection initialUsers={users} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/parametres/users-section.tsx
+++ b/components/parametres/users-section.tsx
@@ -187,7 +187,7 @@ export function UsersSection({ initialUsers }: Props) {
           </span>
         </div>
 
-        <form onSubmit={handleSubmit(onInvite)} className="space-y-3">
+        <form onSubmit={handleSubmit(onInvite)} className="space-y-3" noValidate>
           <div className="flex gap-2">
             <div className="flex-1 space-y-1">
               <Input

--- a/components/parametres/users-section.tsx
+++ b/components/parametres/users-section.tsx
@@ -1,0 +1,309 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { Users, UserPlus, Loader2, Shield, Briefcase, HardHat, CheckCircle2, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+
+type UserRole = "admin" | "bureau" | "ouvrier"
+
+type AdminUser = {
+  id: string
+  email: string
+  role: UserRole | null
+  created_at: string
+}
+
+const inviteSchema = z.object({
+  email: z.string().email("Email invalide"),
+  role: z.enum(["admin", "bureau", "ouvrier"]),
+})
+
+type InviteForm = z.infer<typeof inviteSchema>
+
+type Props = {
+  initialUsers: AdminUser[]
+}
+
+const ROLE_CONFIG: Record<UserRole, { label: string; icon: React.ElementType; className: string }> = {
+  admin: {
+    label: "Admin",
+    icon: Shield,
+    className: "bg-primary/15 text-primary border-primary/30",
+  },
+  bureau: {
+    label: "Bureau",
+    icon: Briefcase,
+    className: "bg-secondary text-secondary-foreground border-border",
+  },
+  ouvrier: {
+    label: "Ouvrier",
+    icon: HardHat,
+    className: "bg-muted text-muted-foreground border-border",
+  },
+}
+
+function RoleBadge({ role }: { role: UserRole | null }) {
+  if (!role) return <span className="text-xs text-muted-foreground italic">—</span>
+  const cfg = ROLE_CONFIG[role]
+  const Icon = cfg.icon
+  return (
+    <span
+      className={[
+        "inline-flex items-center gap-1 px-2 py-0.5 rounded-sm border text-xs font-medium",
+        cfg.className,
+      ].join(" ")}
+    >
+      <Icon className="size-3" />
+      {cfg.label}
+    </span>
+  )
+}
+
+function initials(email: string) {
+  return email.slice(0, 2).toUpperCase()
+}
+
+export function UsersSection({ initialUsers }: Props) {
+  const [users, setUsers] = useState<AdminUser[]>(initialUsers)
+  const [isPending, startTransition] = useTransition()
+  const [inviteSuccess, setInviteSuccess] = useState(false)
+  const [inviteError, setInviteError] = useState<string | null>(null)
+  const [roleDialog, setRoleDialog] = useState<AdminUser | null>(null)
+  const [roleChanging, setRoleChanging] = useState(false)
+
+  const { register, handleSubmit, reset, watch, setValue, formState: { errors } } = useForm<InviteForm>({
+    resolver: zodResolver(inviteSchema),
+    defaultValues: { email: "", role: "bureau" },
+  })
+
+  const selectedRole = watch("role")
+
+  function onInvite(data: InviteForm) {
+    setInviteError(null)
+    startTransition(async () => {
+      const res = await fetch("/api/parametres/users/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      })
+      const json = await res.json() as { user?: AdminUser; error?: string }
+      if (!res.ok) {
+        setInviteError(json.error ?? "Erreur lors de l'invitation")
+      } else {
+        setUsers((prev) => [
+          ...prev,
+          json.user ?? { id: crypto.randomUUID(), email: data.email, role: data.role, created_at: new Date().toISOString() },
+        ])
+        reset()
+        setInviteSuccess(true)
+        setTimeout(() => setInviteSuccess(false), 3000)
+      }
+    })
+  }
+
+  async function changeRole(userId: string, newRole: UserRole) {
+    setRoleChanging(true)
+    try {
+      const res = await fetch(`/api/parametres/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: newRole }),
+      })
+      if (res.ok) {
+        setUsers((prev) =>
+          prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u))
+        )
+        setRoleDialog(null)
+      }
+    } finally {
+      setRoleChanging(false)
+    }
+  }
+
+  return (
+    <div className="rounded-sm border border-border overflow-hidden">
+      <div className="flex items-center gap-2.5 px-5 py-3 border-b border-border bg-muted/40">
+        <Users className="size-3.5 text-primary" />
+        <span className="text-xs font-medium tracking-wider uppercase text-foreground">
+          Gestion des membres
+        </span>
+        <Badge variant="secondary" className="ml-auto text-xs py-0 h-5">
+          {users.length}
+        </Badge>
+      </div>
+
+      {/* Users table */}
+      <div className="divide-y divide-border">
+        {users.length === 0 ? (
+          <p className="px-5 py-8 text-sm text-muted-foreground text-center italic">
+            Aucun utilisateur.
+          </p>
+        ) : (
+          users.map((user) => (
+            <div
+              key={user.id}
+              data-testid="user-row"
+              className="flex items-center gap-3 px-5 py-3 hover:bg-muted/20 transition-colors"
+            >
+              <Avatar className="size-8 shrink-0">
+                <AvatarFallback className="text-xs bg-secondary text-secondary-foreground">
+                  {initials(user.email)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-mono text-foreground truncate">{user.email}</p>
+                <p className="text-xs text-muted-foreground">
+                  Membre depuis {new Date(user.created_at).toLocaleDateString("fr-FR")}
+                </p>
+              </div>
+              <RoleBadge role={user.role} />
+              <button
+                type="button"
+                onClick={() => setRoleDialog(user)}
+                className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors shrink-0"
+                data-testid={`change-role-${user.id}`}
+              >
+                Modifier
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Invite form */}
+      <div className="p-5 border-t border-border bg-muted/10 space-y-4">
+        <div className="flex items-center gap-2">
+          <UserPlus className="size-3.5 text-primary" />
+          <span className="text-xs font-medium tracking-wider uppercase text-foreground">
+            Inviter un membre
+          </span>
+        </div>
+
+        <form onSubmit={handleSubmit(onInvite)} className="space-y-3">
+          <div className="flex gap-2">
+            <div className="flex-1 space-y-1">
+              <Input
+                type="email"
+                placeholder="email@exemple.com"
+                data-testid="invite-email-input"
+                className="font-mono text-sm"
+                {...register("email")}
+              />
+              {errors.email && (
+                <p className="text-xs text-destructive">{errors.email.message}</p>
+              )}
+            </div>
+            {/* Role selector */}
+            <div className="flex rounded-sm border border-border overflow-hidden shrink-0">
+              {(["bureau", "ouvrier", "admin"] as UserRole[]).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setValue("role", r)}
+                  data-testid={`invite-role-${r}`}
+                  className={[
+                    "px-3 py-1.5 text-xs font-medium tracking-wide transition-colors",
+                    selectedRole === r
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/40",
+                  ].join(" ")}
+                >
+                  {r === "bureau" ? "Bureau" : r === "ouvrier" ? "Ouvrier" : "Admin"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isPending}
+              data-testid="invite-submit-btn"
+              className="gap-2"
+            >
+              {isPending
+                ? <Loader2 className="size-3.5 animate-spin" />
+                : <UserPlus className="size-3.5" />
+              }
+              Inviter
+            </Button>
+            {inviteSuccess && (
+              <span className="flex items-center gap-1.5 text-xs text-primary animate-in fade-in duration-200">
+                <CheckCircle2 className="size-3.5" />
+                Invitation envoyée
+              </span>
+            )}
+            {inviteError && (
+              <span className="flex items-center gap-1.5 text-xs text-destructive">
+                <X className="size-3.5" />
+                {inviteError}
+              </span>
+            )}
+          </div>
+        </form>
+      </div>
+
+      {/* Role change dialog */}
+      {roleDialog && (
+        <Dialog open={!!roleDialog} onOpenChange={(open) => { if (!open) setRoleDialog(null) }}>
+          <DialogContent className="max-w-sm">
+            <div className="space-y-4">
+              <div>
+                <h3 className="font-heading text-lg font-600 tracking-wide uppercase">
+                  Changer le rôle
+                </h3>
+                <p className="text-sm text-muted-foreground mt-1 font-mono">
+                  {roleDialog.email}
+                </p>
+              </div>
+
+              <Label className="text-xs tracking-wider uppercase text-muted-foreground">
+                Nouveau rôle
+              </Label>
+
+              <div className="grid grid-cols-3 gap-2">
+                {(Object.entries(ROLE_CONFIG) as [UserRole, typeof ROLE_CONFIG[UserRole]][]).map(
+                  ([role, cfg]) => {
+                    const Icon = cfg.icon
+                    const isActive = roleDialog.role === role
+                    return (
+                      <button
+                        key={role}
+                        type="button"
+                        onClick={() => changeRole(roleDialog.id, role)}
+                        disabled={roleChanging || isActive}
+                        data-testid={`confirm-role-${role}`}
+                        className={[
+                          "flex flex-col items-center gap-2 p-3 rounded-sm border transition-colors",
+                          "disabled:cursor-not-allowed",
+                          isActive
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border hover:border-primary/50 hover:bg-muted/30 text-muted-foreground hover:text-foreground",
+                        ].join(" ")}
+                      >
+                        {roleChanging && !isActive
+                          ? <Loader2 className="size-4 animate-spin" />
+                          : <Icon className="size-4" />
+                        }
+                        <span className="text-xs font-medium">{cfg.label}</span>
+                      </button>
+                    )
+                  }
+                )}
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  )
+}

--- a/cypress/e2e/admin-settings.cy.ts
+++ b/cypress/e2e/admin-settings.cy.ts
@@ -1,0 +1,199 @@
+/**
+ * Admin settings page — E2E tests
+ *
+ * Covers:
+ * 1. Admin can access /parametres
+ * 2. Non-admin (bureau) is redirected away from /parametres
+ * 3. Tab navigation works
+ * 4. Company name can be updated (mocked API) and feedback is shown
+ * 5. Reminders toggle changes state
+ * 6. CGV text can be saved
+ * 7. User invite form validates and submits
+ */
+
+const DESKTOP = { width: 1280, height: 800 } as const
+
+describe("Page /parametres — accès et navigation", () => {
+  beforeEach(() => {
+    cy.viewport(DESKTOP.width, DESKTOP.height)
+  })
+
+  it("redirige un utilisateur bureau vers /dashboard", () => {
+    cy.loginAsBureau()
+    cy.visit("/parametres")
+    cy.url().should("include", "/dashboard")
+  })
+
+  it("permet à un admin d'accéder à /parametres", () => {
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+    cy.get("h1").should("contain.text", "Paramètres")
+  })
+
+  it("affiche le sous-titre administration", () => {
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+    cy.contains("Administration").should("be.visible")
+  })
+})
+
+describe("Page /parametres — navigation par onglets", () => {
+  beforeEach(() => {
+    cy.viewport(DESKTOP.width, DESKTOP.height)
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+  })
+
+  it("affiche l'onglet Entreprise par défaut", () => {
+    cy.get("[data-testid='tab-entreprise']").should("be.visible")
+    cy.get("[data-testid='company-section']").should("be.visible")
+  })
+
+  it("navigue vers l'onglet Automatisations", () => {
+    cy.get("[data-testid='tab-automatisations']").click()
+    cy.get("[data-testid='reminders-toggle']").should("be.visible")
+  })
+
+  it("navigue vers l'onglet Intégrations", () => {
+    cy.get("[data-testid='tab-integrations']").click()
+    cy.contains("Boîte mail").should("be.visible")
+  })
+
+  it("navigue vers l'onglet Équipe", () => {
+    cy.get("[data-testid='tab-equipe']").click()
+    cy.get("[data-testid='invite-email-input']").should("be.visible")
+  })
+})
+
+describe("Page /parametres — informations entreprise", () => {
+  beforeEach(() => {
+    cy.viewport(DESKTOP.width, DESKTOP.height)
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+
+    // Mock the API to avoid real DB writes
+    cy.intercept("POST", "/api/parametres/company", { statusCode: 200, body: { ok: true } }).as(
+      "saveCompany"
+    )
+  })
+
+  it("affiche les champs du formulaire", () => {
+    cy.get("[data-testid='company-name-input']").should("be.visible")
+    cy.get("[data-testid='company-address-input']").should("be.visible")
+    cy.get("[data-testid='company-siret-input']").should("be.visible")
+  })
+
+  it("sauvegarde les informations et affiche la confirmation", () => {
+    cy.get("[data-testid='company-name-input']").clear().type("Forge Dupont Métallerie")
+    cy.get("[data-testid='company-siret-input']").clear().type("12345678900012")
+    cy.get("[data-testid='company-save-btn']").click()
+
+    cy.wait("@saveCompany")
+    cy.contains("Sauvegardé").should("be.visible")
+  })
+
+  it("persiste la valeur saisie dans le champ après sauvegarde", () => {
+    cy.get("[data-testid='company-name-input']").clear().type("Acier & Co")
+    cy.get("[data-testid='company-save-btn']").click()
+    cy.wait("@saveCompany")
+    cy.get("[data-testid='company-name-input']").should("have.value", "Acier & Co")
+  })
+})
+
+describe("Page /parametres — CGV", () => {
+  beforeEach(() => {
+    cy.viewport(DESKTOP.width, DESKTOP.height)
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+
+    cy.intercept("PATCH", "/api/parametres/settings", { statusCode: 200, body: { ok: true } }).as(
+      "saveSetting"
+    )
+  })
+
+  it("sauvegarde le texte des CGV", () => {
+    cy.get("[data-testid='cgv-textarea']").clear().type("Article 1 — Conditions générales")
+    cy.get("[data-testid='cgv-save-btn']").click()
+    cy.wait("@saveSetting")
+    cy.contains("Sauvegardé").should("be.visible")
+  })
+})
+
+describe("Page /parametres — relances automatiques", () => {
+  beforeEach(() => {
+    cy.viewport(DESKTOP.width, DESKTOP.height)
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+    cy.get("[data-testid='tab-automatisations']").click()
+
+    cy.intercept("PATCH", "/api/parametres/settings", { statusCode: 200, body: { ok: true } }).as(
+      "saveSetting"
+    )
+  })
+
+  it("peut basculer le toggle relances", () => {
+    cy.get("[data-testid='reminders-toggle']").then(($btn) => {
+      const initial = $btn.attr("aria-checked")
+      cy.wrap($btn).click()
+      cy.wait("@saveSetting")
+      cy.get("[data-testid='reminders-toggle']").should(
+        "have.attr",
+        "aria-checked",
+        initial === "true" ? "false" : "true"
+      )
+    })
+  })
+
+  it("affiche les champs de délai", () => {
+    cy.get("[data-testid='reminders-delay-j7']").should("be.visible")
+    cy.get("[data-testid='reminders-delay-j14']").should("be.visible")
+  })
+})
+
+describe("Page /parametres — gestion des utilisateurs", () => {
+  beforeEach(() => {
+    cy.viewport(DESKTOP.width, DESKTOP.height)
+    cy.loginAsAdmin()
+    cy.visit("/parametres")
+    cy.get("[data-testid='tab-equipe']").click()
+  })
+
+  it("affiche le formulaire d'invitation", () => {
+    cy.get("[data-testid='invite-email-input']").should("be.visible")
+    cy.get("[data-testid='invite-submit-btn']").should("be.visible")
+  })
+
+  it("les sélecteurs de rôle sont visibles", () => {
+    cy.get("[data-testid='invite-role-bureau']").should("be.visible")
+    cy.get("[data-testid='invite-role-ouvrier']").should("be.visible")
+    cy.get("[data-testid='invite-role-admin']").should("be.visible")
+  })
+
+  it("refuse une invitation avec email invalide", () => {
+    cy.get("[data-testid='invite-email-input']").type("pas-un-email")
+    cy.get("[data-testid='invite-submit-btn']").click()
+    cy.contains("Email invalide").should("be.visible")
+  })
+
+  it("invite un utilisateur avec succès (API mockée)", () => {
+    cy.intercept("POST", "/api/parametres/users/invite", {
+      statusCode: 200,
+      body: {
+        user: {
+          id: "new-user-id",
+          email: "nouveau@exemple.com",
+          role: "bureau",
+          created_at: new Date().toISOString(),
+        },
+      },
+    }).as("inviteUser")
+
+    cy.get("[data-testid='invite-email-input']").type("nouveau@exemple.com")
+    cy.get("[data-testid='invite-role-bureau']").click()
+    cy.get("[data-testid='invite-submit-btn']").click()
+
+    cy.wait("@inviteUser")
+    cy.contains("Invitation envoyée").should("be.visible")
+    cy.contains("nouveau@exemple.com").should("be.visible")
+  })
+})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,6 +15,11 @@ declare global {
        * Must be called before cy.visit() for any protected bureau route.
        */
       loginAsBureau(): Chainable<void>
+      /**
+       * Set a cookie that bypasses server-side Supabase auth as an admin user.
+       * Must be called before cy.visit() for any admin-only route.
+       */
+      loginAsAdmin(): Chainable<void>
     }
   }
 }
@@ -27,4 +32,8 @@ Cypress.Commands.add("loginAsOuvrier", () => {
 
 Cypress.Commands.add("loginAsBureau", () => {
   cy.setCookie("cypress-test-user", "bureau", { path: "/", sameSite: "lax" })
+})
+
+Cypress.Commands.add("loginAsAdmin", () => {
+  cy.setCookie("cypress-test-user", "admin", { path: "/", sameSite: "lax" })
 })

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,0 +1,32 @@
+import { supabaseService } from "@/lib/supabase/service"
+
+export async function getAppSetting(key: string): Promise<string | null> {
+  const { data } = await supabaseService
+    .from("app_settings")
+    .select("value")
+    .eq("key", key)
+    .single()
+  return data?.value ?? null
+}
+
+export async function setAppSetting(key: string, value: string): Promise<void> {
+  await supabaseService.from("app_settings").upsert(
+    { key, value, updated_at: new Date().toISOString() },
+    { onConflict: "key" }
+  )
+}
+
+export async function getMultipleSettings(
+  keys: string[]
+): Promise<Record<string, string>> {
+  const { data } = await supabaseService
+    .from("app_settings")
+    .select("key, value")
+    .in("key", keys)
+
+  const result: Record<string, string> = {}
+  data?.forEach(({ key, value }) => {
+    result[key] = value
+  })
+  return result
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -48,6 +48,13 @@ export async function getUser() {
         user_metadata: { role: "bureau" },
       }
     }
+    if (cypressRole === "admin") {
+      return {
+        id: "test-admin-id",
+        email: "admin@test.com",
+        user_metadata: { role: "admin" },
+      }
+    }
   }
 
   const supabase = await createClient()

--- a/supabase/migrations/20260501000014_company_settings.sql
+++ b/supabase/migrations/20260501000014_company_settings.sql
@@ -1,0 +1,40 @@
+-- Company settings: seed default keys in app_settings KV store
+INSERT INTO public.app_settings (key, value)
+VALUES
+  ('company_name',               ''),
+  ('company_address',            ''),
+  ('company_siret',              ''),
+  ('company_logo_url',           ''),
+  ('weekly_report_recipients',   '[]'),
+  ('weekly_report_enabled',      'true'),
+  ('auto_reminders_enabled',     'true'),
+  ('reminder_delay_j7',          '7'),
+  ('reminder_delay_j14',         '14'),
+  ('default_cgv',                '')
+ON CONFLICT (key) DO NOTHING;
+
+-- Storage bucket for company logos (public read)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('company-logos', 'company-logos', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Only admins may upload logos
+CREATE POLICY "admin_insert_company_logo"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'company-logos'
+    AND (auth.jwt() -> 'user_metadata' ->> 'role') = 'admin'
+  );
+
+-- Only admins may delete / replace logos
+CREATE POLICY "admin_delete_company_logo"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'company-logos'
+    AND (auth.jwt() -> 'user_metadata' ->> 'role') = 'admin'
+  );
+
+-- Everyone (authenticated) may read logos
+CREATE POLICY "authenticated_read_company_logo"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (bucket_id = 'company-logos');


### PR DESCRIPTION
- Page /parametres now admin-only (redirects bureau to /dashboard)
- Tabbed shell: Entreprise / Automatisations / Intégrations / Équipe
- Company section: name, address, SIRET, logo upload (Supabase Storage)
- CGV section: editable default conditions générales
- Reminders section: global toggle + J+7/J+14 delays
- Weekly report section: recipients list + enabled toggle
- Users section: list all members, invite by email with role, change role via dialog
- New API routes: /company, /company/logo, /users, /users/invite, /users/[id]
- lib/settings.ts: getAppSetting / setAppSetting / getMultipleSettings helpers
- DB migration: seed company settings keys + company-logos storage bucket
- Cypress: loginAsAdmin command + admin E2E bypass in server.ts
- Cypress: admin-settings.cy.ts covering access, tabs, forms, invite flow

https://claude.ai/code/session_01GpChxxAE2EjtMbZCEZTW9r