### PR TITLE
feat: add light mode theme with system/light/dark selector

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -103,6 +103,51 @@
   --sidebar-ring: oklch(0.69 0.168 47);
 }
 
+/* Atelier en plein jour — light mode */
+html.light {
+  /* Base surfaces */
+  --background:        oklch(0.97 0.004 258);
+  --foreground:        oklch(0.18 0.012 258);
+
+  /* Card / popover surfaces */
+  --card:              oklch(0.995 0.002 78);
+  --card-foreground:   oklch(0.18 0.012 258);
+  --popover:           oklch(0.995 0.002 78);
+  --popover-foreground: oklch(0.18 0.012 258);
+
+  /* Primary — welding-arc amber — inchangé */
+  --primary:           oklch(0.69 0.168 47);
+  --primary-foreground: oklch(0.11 0.008 258);
+
+  /* Secondary — panneau acier clair */
+  --secondary:         oklch(0.89 0.010 258);
+  --secondary-foreground: oklch(0.18 0.012 258);
+
+  /* Muted */
+  --muted:             oklch(0.93 0.006 258);
+  --muted-foreground:  oklch(0.48 0.010 258);
+
+  /* Accent */
+  --accent:            oklch(0.91 0.008 258);
+  --accent-foreground: oklch(0.18 0.012 258);
+
+  /* Sémantique — destructive inchangé */
+  --destructive:       oklch(0.62 0.22 25);
+  --border:            oklch(0.87 0.010 258);
+  --input:             oklch(0.92 0.006 258);
+  --ring:              oklch(0.69 0.168 47);
+
+  /* Sidebar — acier clair */
+  --sidebar:           oklch(0.93 0.008 258);
+  --sidebar-foreground: oklch(0.18 0.012 258);
+  --sidebar-primary:   oklch(0.69 0.168 47);
+  --sidebar-primary-foreground: oklch(0.11 0.008 258);
+  --sidebar-accent:    oklch(0.87 0.010 258);
+  --sidebar-accent-foreground: oklch(0.18 0.012 258);
+  --sidebar-border:    oklch(0.85 0.012 258);
+  --sidebar-ring:      oklch(0.69 0.168 47);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { Barlow_Condensed, DM_Sans, Geist_Mono } from "next/font/google"
+import { ThemeProvider } from "next-themes"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Toaster } from "@/components/ui/sonner"
 import "./globals.css"
@@ -34,10 +35,18 @@ export default function RootLayout({
     <html
       lang="fr"
       className={`${barlowCondensed.variable} ${dmSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col">
-        <TooltipProvider delay={300}>{children}</TooltipProvider>
-        <Toaster position="bottom-right" />
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <TooltipProvider delay={300}>{children}</TooltipProvider>
+          <Toaster position="bottom-right" />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/app/profil/page.tsx
+++ b/app/profil/page.tsx
@@ -4,6 +4,7 @@ import { User } from "lucide-react"
 import { getUser, getUserRole } from "@/lib/supabase/server"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
+import { ThemeSelector } from "@/components/theme-selector"
 
 export const metadata: Metadata = {
   title: "Profil — btpxai",
@@ -62,6 +63,10 @@ export default async function ProfilPage() {
               </Badge>
             </div>
           </div>
+        </div>
+
+        <div className="rounded-sm border border-border bg-card p-5 max-w-sm">
+          <ThemeSelector />
         </div>
       </div>
     </div>

--- a/components/theme-selector.tsx
+++ b/components/theme-selector.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Monitor, Sun, Moon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useEffect, useState } from "react"
+
+const OPTIONS = [
+  { value: "system", label: "Système", Icon: Monitor },
+  { value: "light",  label: "Clair",   Icon: Sun     },
+  { value: "dark",   label: "Sombre",  Icon: Moon    },
+]
+
+export function ThemeSelector() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+
+  return (
+    <section aria-labelledby="theme-heading">
+      <div className="space-y-3">
+        <div>
+          <span
+            id="theme-heading"
+            className="text-[10px] font-medium uppercase tracking-[0.1em] text-muted-foreground"
+          >
+            Apparence
+          </span>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Choisissez le thème de l&apos;interface
+          </p>
+        </div>
+        <div
+          className="inline-flex border border-border rounded-sm overflow-hidden"
+          role="group"
+          aria-label="Sélecteur de thème"
+        >
+          {OPTIONS.map(({ value, label, Icon }, index) => {
+            const isActive = mounted && theme === value
+            return (
+              <button
+                key={value}
+                onClick={() => setTheme(value)}
+                aria-pressed={isActive}
+                className={cn(
+                  "flex items-center gap-2 px-4 py-2.5 text-[11px] font-medium tracking-wider uppercase transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                  index > 0 && "border-l border-border",
+                  isActive
+                    ? "bg-primary/15 text-primary"
+                    : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted"
+                )}
+              >
+                <Icon className="size-3.5 shrink-0" />
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
- Add html.light CSS variables block in globals.css (cold steel daylight palette,
  same amber primary and semantic colors, inverted dark surfaces to light)
- Wire up next-themes ThemeProvider in root layout (attribute="class",
  defaultTheme="system", suppressHydrationWarning on <html>)
- Create ThemeSelector client component (segmented button: Système / Clair / Sombre)
- Add ThemeSelector card to /profil page, accessible to all roles

https://claude.ai/code/session_019RpqpLtJDcx1ji4wVGfF75