### PR TITLE
feat: add company calendar with month/week/day views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ supabase/.temp
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.superpowers/

--- a/app/(bureau)/calendrier/page.tsx
+++ b/app/(bureau)/calendrier/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { CalendarDays } from "lucide-react"
+import { getUser, getUserRole } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { supabaseService } from "@/lib/supabase/service"
+import { createClient } from "@/lib/supabase/server"
+import { getEventTypes } from "@/lib/calendar-event-types"
+import { CalendarClient } from "@/components/calendrier/calendar-client"
+
+export const metadata: Metadata = {
+  title: "Calendrier — BTP×AI",
+}
+
+export default async function CalendrierPage() {
+  const user = await getUser()
+  if (!user) redirect("/login")
+  const role = getUserRole(user)
+  if (role !== "admin" && role !== "bureau") redirect("/profil")
+
+  const { workspaceId } = await requireWorkspace(user.id)
+  const supabase = await createClient()
+  const eventTypes = await getEventTypes(supabase, workspaceId).catch(() => [])
+
+  const { data: usersData } = await supabaseService.auth.admin.listUsers({ perPage: 200 })
+  const workspaceUsers = (usersData?.users ?? [])
+    .filter((u) => {
+      const r = u.user_metadata?.role
+      return r === "ouvrier" || r === "bureau" || r === "admin"
+    })
+    .map((u) => ({
+      id: u.id,
+      email: u.email ?? "",
+      role: (u.user_metadata?.role as string) ?? null,
+    }))
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <CalendarDays className="size-3.5 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground tracking-wider uppercase">
+              Planification
+            </span>
+          </div>
+          <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+            Calendrier
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Planning de l&apos;entreprise — chantiers, RDV et interventions
+          </p>
+        </div>
+      </div>
+
+      <CalendarClient
+        eventTypes={eventTypes}
+        workspaceUsers={workspaceUsers}
+        canCreate
+        canFilter
+      />
+    </div>
+  )
+}

--- a/app/(bureau)/layout.tsx
+++ b/app/(bureau)/layout.tsx
@@ -3,8 +3,7 @@ import { getUser, getUserRole } from "@/lib/supabase/server";
 import { supabaseService } from "@/lib/supabase/service";
 import { getOpenAlertesCount } from "@/lib/terrain-alertes";
 import { requireWorkspace } from "@/lib/workspaces";
-import { AppSidebar } from "@/components/layout/sidebar";
-import { MobileHeader } from "@/components/layout/mobile-header";
+import { SidebarShell } from "@/components/layout/sidebar-shell";
 
 type Role = "admin" | "bureau" | "ouvrier";
 
@@ -53,33 +52,14 @@ export default async function BureauLayout({
   } catch {}
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Desktop sidebar */}
-      <div className="hidden lg:block">
-        <AppSidebar
-          email={user.email!}
-          role={role}
-          alertBadge={alertBadge}
-          workspaceName={workspaceName}
-          logoUrl={logoUrl}
-        />
-      </div>
-
-      {/* Mobile header + drawer */}
-      <MobileHeader
-        email={user.email!}
-        role={role}
-        alertBadge={alertBadge}
-        workspaceName={workspaceName}
-        logoUrl={logoUrl}
-      />
-
-      {/* Main content */}
-      <main className="lg:pl-56 min-h-screen">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 lg:py-8">
-          {children}
-        </div>
-      </main>
-    </div>
+    <SidebarShell
+      email={user.email!}
+      role={role}
+      alertBadge={alertBadge}
+      workspaceName={workspaceName}
+      logoUrl={logoUrl}
+    >
+      {children}
+    </SidebarShell>
   );
 }

--- a/app/(bureau)/parametres/page.tsx
+++ b/app/(bureau)/parametres/page.tsx
@@ -7,6 +7,8 @@ import { requireWorkspace } from "@/lib/workspaces"
 import { getAutoAcknowledgmentEnabled } from "@/lib/acknowledgments"
 import { getLastSyncAt } from "@/lib/sheets"
 import { getMultipleSettings } from "@/lib/settings"
+import { getEventTypes } from "@/lib/calendar-event-types"
+import { createClient } from "@/lib/supabase/server"
 import { SettingsShell } from "@/components/parametres/settings-shell"
 
 export const metadata: Metadata = {
@@ -47,8 +49,9 @@ export default async function ParametresPage({
   const { gmail } = await searchParams
 
   const { workspaceId } = await requireWorkspace(user.id)
+  const supabase = await createClient()
 
-  const [settings, { data: connectionsData }, { data: imapConnectionsData }, autoAckEnabled, lastSyncAt, { data: usersData }] =
+  const [settings, { data: connectionsData }, { data: imapConnectionsData }, autoAckEnabled, lastSyncAt, { data: usersData }, eventTypes] =
     await Promise.all([
       getMultipleSettings(workspaceId, SETTINGS_KEYS),
       supabaseService
@@ -64,6 +67,7 @@ export default async function ParametresPage({
       getAutoAcknowledgmentEnabled(workspaceId),
       getLastSyncAt(workspaceId),
       supabaseService.auth.admin.listUsers({ perPage: 200 }),
+      getEventTypes(supabase, workspaceId).catch(() => []),
     ])
 
   const connections = ((connectionsData ?? []) as unknown) as {
@@ -111,6 +115,7 @@ export default async function ParametresPage({
         autoAckEnabled={autoAckEnabled}
         lastSyncAt={lastSyncAt}
         users={users}
+        eventTypes={eventTypes}
       />
     </div>
   )

--- a/app/(terrain)/terrain/calendrier/page.tsx
+++ b/app/(terrain)/terrain/calendrier/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { CalendarDays } from "lucide-react"
+import { getUser, getUserRole } from "@/lib/supabase/server"
+import { createClient } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { getEventTypes } from "@/lib/calendar-event-types"
+import { CalendarClient } from "@/components/calendrier/calendar-client"
+
+export const metadata: Metadata = {
+  title: "Mon planning — BTP×AI",
+}
+
+export default async function TerrainCalendrierPage() {
+  const user = await getUser()
+  if (!user) redirect("/login")
+  const role = getUserRole(user)
+  if (role !== "ouvrier" && role !== "admin") redirect("/profil")
+
+  const { workspaceId } = await requireWorkspace(user.id)
+  const supabase = await createClient()
+  const eventTypes = await getEventTypes(supabase, workspaceId).catch(() => [])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 bg-background border-b border-border px-4 pt-safe-top">
+        <div className="flex items-center gap-3 py-4">
+          <CalendarDays className="size-5 text-muted-foreground" />
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.25em] text-muted-foreground"
+               style={{ fontFamily: "var(--font-barlow)" }}>
+              BTP×AI — Terrain
+            </p>
+            <h1
+              className="text-2xl font-bold uppercase tracking-wide text-foreground leading-none"
+              style={{ fontFamily: "var(--font-barlow)" }}
+            >
+              Mon planning
+            </h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="px-4 py-4">
+        <CalendarClient
+          eventTypes={eventTypes}
+          workspaceUsers={[]}
+          canCreate={false}
+          canFilter={false}
+        />
+      </main>
+    </div>
+  )
+}

--- a/app/api/calendar/event-types/[id]/route.ts
+++ b/app/api/calendar/event-types/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace, WorkspaceError } from "@/lib/workspaces"
+import { updateEventType, deleteEventType } from "@/lib/calendar-event-types"
+
+const UpdateSchema = z.object({
+  label: z.string().min(1).max(100).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+})
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const body = await req.json()
+    const parsed = UpdateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const updated = await updateEventType(supabase, id, parsed.data)
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const supabase = await createClient()
+    await deleteEventType(supabase, id)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    const message = err instanceof Error ? err.message : "Erreur serveur"
+    const status = message.includes("utilisé") ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/calendar/event-types/route.ts
+++ b/app/api/calendar/event-types/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace, WorkspaceError } from "@/lib/workspaces"
+import { getEventTypes, createEventType } from "@/lib/calendar-event-types"
+
+const CreateSchema = z.object({
+  label: z.string().min(1).max(100),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+})
+
+export async function GET() {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId } = await requireWorkspace(user.id)
+    const supabase = await createClient()
+    const types = await getEventTypes(supabase, workspaceId)
+    return NextResponse.json(types)
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId, role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const body = await req.json()
+    const parsed = CreateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const created = await createEventType(supabase, workspaceId, parsed.data)
+    return NextResponse.json(created, { status: 201 })
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}

--- a/app/api/calendar/events/[id]/route.ts
+++ b/app/api/calendar/events/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace, WorkspaceError } from "@/lib/workspaces"
+import { updateEvent, deleteEvent } from "@/lib/calendar"
+
+const UpdateSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().nullable().optional(),
+  start_at: z.string().datetime().optional(),
+  end_at: z.string().datetime().optional(),
+  event_type_id: z.string().uuid().nullable().optional(),
+  assignee_ids: z.array(z.string().uuid()).optional(),
+})
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const body = await req.json()
+    const parsed = UpdateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const updated = await updateEvent(supabase, id, parsed.data)
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const supabase = await createClient()
+    await deleteEvent(supabase, id)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}

--- a/app/api/calendar/events/route.ts
+++ b/app/api/calendar/events/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace, WorkspaceError } from "@/lib/workspaces"
+import { getEvents, createEvent } from "@/lib/calendar"
+
+const CreateSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().nullable().optional(),
+  start_at: z.string().datetime(),
+  end_at: z.string().datetime(),
+  event_type_id: z.string().uuid().nullable().optional(),
+  assignee_ids: z.array(z.string().uuid()).optional(),
+})
+
+export async function GET(req: Request) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId } = await requireWorkspace(user.id)
+    const { searchParams } = new URL(req.url)
+    const from = searchParams.get("from")
+    const to = searchParams.get("to")
+    const assigneeId = searchParams.get("assigneeId") ?? undefined
+    if (!from || !to) {
+      return NextResponse.json({ error: "Paramètres from/to requis" }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const events = await getEvents(supabase, workspaceId, { from, to, assigneeId })
+    return NextResponse.json(events)
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId, role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const body = await req.json()
+    const parsed = CreateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const event = await createEvent(supabase, workspaceId, parsed.data)
+    return NextResponse.json(event, { status: 201 })
+  } catch (err) {
+    if (err instanceof WorkspaceError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}

--- a/app/api/calendar/events/route.ts
+++ b/app/api/calendar/events/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: Request) {
     const event = await createEvent(supabase, workspaceId, parsed.data)
     return NextResponse.json(event, { status: 201 })
   } catch (err) {
+    console.error("[calendar] POST error:", err)
     if (err instanceof WorkspaceError) {
       return NextResponse.json({ error: err.message }, { status: 403 })
     }

--- a/app/api/superadmin/workspaces/route.ts
+++ b/app/api/superadmin/workspaces/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
 import { getUser, getUserRole } from "@/lib/supabase/server"
 import { supabaseService } from "@/lib/supabase/service"
+import { seedDefaultEventTypes } from "@/lib/calendar-event-types"
 
 const createSchema = z.object({
   name: z.string().min(2, "Nom requis (2 caractères minimum)"),
@@ -61,6 +62,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: "Ce slug est déjà utilisé" }, { status: 409 })
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
+
+  // Seed default calendar event types for the new workspace
+  await seedDefaultEventTypes(supabaseService as any, workspace.id).catch(() => {})
 
   return NextResponse.json({ workspace }, { status: 201 })
 }

--- a/components/calendrier/calendar-client.tsx
+++ b/components/calendrier/calendar-client.tsx
@@ -91,7 +91,11 @@ export function CalendarClient({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     })
-    if (!res.ok) throw new Error("Erreur lors de l'enregistrement")
+    if (!res.ok) {
+      const body = await res.json().catch(() => null)
+      console.error("[calendar] save failed", res.status, body)
+      throw new Error("Erreur lors de l'enregistrement")
+    }
     await refresh()
   }
 

--- a/components/calendrier/calendar-client.tsx
+++ b/components/calendrier/calendar-client.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import {
+  startOfMonth, endOfMonth,
+  startOfWeek, endOfWeek,
+  addDays,
+} from "date-fns"
+import type { CalendarEventWithDetails, CalendarEventType, CalendarView } from "@/types"
+import { CalendarHeader } from "./calendar-header"
+import { CalendarFilters } from "./calendar-filters"
+import { CalendarGrid } from "./calendar-grid"
+import { EventDialog } from "./event-dialog"
+import { useCalendarEvents } from "@/hooks/use-calendar-events"
+
+interface WorkspaceUser { id: string; email: string; role: string | null }
+
+interface CalendarClientProps {
+  eventTypes: CalendarEventType[]
+  workspaceUsers: WorkspaceUser[]
+  canCreate?: boolean
+  canFilter?: boolean
+}
+
+function getRange(view: CalendarView, date: Date): { from: string; to: string } {
+  if (view === "month") {
+    const start = startOfWeek(startOfMonth(date), { weekStartsOn: 1 })
+    const end = endOfWeek(endOfMonth(date), { weekStartsOn: 1 })
+    return { from: start.toISOString(), to: end.toISOString() }
+  }
+  if (view === "week") {
+    const start = startOfWeek(date, { weekStartsOn: 1 })
+    const end = endOfWeek(date, { weekStartsOn: 1 })
+    return { from: start.toISOString(), to: end.toISOString() }
+  }
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const end = addDays(start, 1)
+  return { from: start.toISOString(), to: end.toISOString() }
+}
+
+export function CalendarClient({
+  eventTypes,
+  workspaceUsers,
+  canCreate = false,
+  canFilter = false,
+}: CalendarClientProps) {
+  const [view, setView] = useState<CalendarView>("month")
+  const [currentDate, setCurrentDate] = useState(new Date())
+  const [filterIds, setFilterIds] = useState<string[]>([])
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEventWithDetails | null>(null)
+  const [clickedDate, setClickedDate] = useState<Date | undefined>()
+
+  const { from, to } = getRange(view, currentDate)
+
+  const { events, refresh } = useCalendarEvents({ from, to })
+
+  const filteredEvents = filterIds.length > 0
+    ? events.filter((e) =>
+        e.assignees.some((a) => filterIds.includes(a.user_id))
+      )
+    : events
+
+  const handleEventClick = useCallback((event: CalendarEventWithDetails) => {
+    setSelectedEvent(event)
+    setDialogOpen(true)
+  }, [])
+
+  const handleDayClick = useCallback((date: Date) => {
+    if (!canCreate) return
+    setSelectedEvent(null)
+    setClickedDate(date)
+    setDialogOpen(true)
+  }, [canCreate])
+
+  const handleSave = async (data: {
+    title: string
+    description?: string | null
+    start_at: string
+    end_at: string
+    event_type_id?: string | null
+    assignee_ids: string[]
+  }) => {
+    const url = selectedEvent
+      ? `/api/calendar/events/${selectedEvent.id}`
+      : "/api/calendar/events"
+    const method = selectedEvent ? "PUT" : "POST"
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) throw new Error("Erreur lors de l'enregistrement")
+    await refresh()
+  }
+
+  const handleDelete = async () => {
+    if (!selectedEvent) return
+    await fetch(`/api/calendar/events/${selectedEvent.id}`, { method: "DELETE" })
+    await refresh()
+  }
+
+  return (
+    <div className="space-y-4">
+      <CalendarHeader
+        view={view}
+        currentDate={currentDate}
+        onViewChange={setView}
+        onDateChange={setCurrentDate}
+        canCreate={canCreate}
+        onNewEvent={() => {
+          setSelectedEvent(null)
+          setClickedDate(currentDate)
+          setDialogOpen(true)
+        }}
+      />
+
+      {canFilter && (
+        <CalendarFilters
+          users={workspaceUsers}
+          selectedIds={filterIds}
+          onToggle={(id) =>
+            setFilterIds((prev) =>
+              prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+            )
+          }
+          onClear={() => setFilterIds([])}
+        />
+      )}
+
+      <CalendarGrid
+        view={view}
+        currentDate={currentDate}
+        events={filteredEvents}
+        onEventClick={handleEventClick}
+        onDayClick={handleDayClick}
+      />
+
+      <EventDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        event={selectedEvent}
+        defaultDate={clickedDate}
+        eventTypes={eventTypes}
+        workspaceUsers={workspaceUsers}
+        onSave={handleSave}
+        onDelete={selectedEvent ? handleDelete : undefined}
+      />
+    </div>
+  )
+}

--- a/components/calendrier/calendar-event-chip.tsx
+++ b/components/calendrier/calendar-event-chip.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import type { CalendarEventWithDetails } from "@/types"
+import { format } from "date-fns"
+import { fr } from "date-fns/locale"
+
+interface CalendarEventChipProps {
+  event: CalendarEventWithDetails
+  onClick: (event: CalendarEventWithDetails) => void
+}
+
+export function CalendarEventChip({ event, onClick }: CalendarEventChipProps) {
+  const color = event.event_type?.color ?? "#6366f1"
+  const time = format(new Date(event.start_at), "HH:mm", { locale: fr })
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick(event)
+      }}
+      className="w-full text-left text-[11px] rounded-sm px-1.5 py-0.5 mb-0.5 leading-tight truncate font-medium transition-opacity hover:opacity-80"
+      style={{
+        backgroundColor: color + "22",
+        color: color,
+        borderLeft: `2px solid ${color}`,
+      }}
+      title={event.title}
+    >
+      <span className="opacity-70 mr-1">{time}</span>
+      {event.title}
+    </button>
+  )
+}

--- a/components/calendrier/calendar-filters.tsx
+++ b/components/calendrier/calendar-filters.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+interface WorkspaceUser {
+  id: string
+  email: string
+  role: string | null
+}
+
+interface CalendarFiltersProps {
+  users: WorkspaceUser[]
+  selectedIds: string[]
+  onToggle: (id: string) => void
+  onClear: () => void
+}
+
+export function CalendarFilters({
+  users,
+  selectedIds,
+  onToggle,
+  onClear,
+}: CalendarFiltersProps) {
+  const ouvriers = users.filter((u) => u.role === "ouvrier")
+  if (ouvriers.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-muted-foreground shrink-0">Filtrer :</span>
+      <button
+        onClick={onClear}
+        className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+          selectedIds.length === 0
+            ? "bg-primary text-primary-foreground border-primary"
+            : "bg-background text-muted-foreground border-border hover:border-primary/50"
+        }`}
+      >
+        Tous
+      </button>
+      {ouvriers.map((u) => {
+        const selected = selectedIds.includes(u.id)
+        return (
+          <button
+            key={u.id}
+            onClick={() => onToggle(u.id)}
+            className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+              selected
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-background text-muted-foreground border-border hover:border-primary/50"
+            }`}
+          >
+            {u.email.split("@")[0]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/calendrier/calendar-grid.tsx
+++ b/components/calendrier/calendar-grid.tsx
@@ -252,5 +252,7 @@ function DayView({ currentDate, events, onEventClick }: Omit<CalendarGridProps, 
 export function CalendarGrid(props: CalendarGridProps) {
   if (props.view === "month") return <MonthView {...props} />
   if (props.view === "week") return <WeekView {...props} />
-  return <DayView {...props} onDayClick={() => {}} />
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { onDayClick: _onDayClick, view: _view, ...dayProps } = props
+  return <DayView {...dayProps} />
 }

--- a/components/calendrier/calendar-grid.tsx
+++ b/components/calendrier/calendar-grid.tsx
@@ -1,0 +1,256 @@
+"use client"
+
+import {
+  startOfMonth, endOfMonth,
+  startOfWeek, endOfWeek,
+  eachDayOfInterval,
+  isSameMonth, isSameDay, isToday,
+  format, getHours, getMinutes,
+  addDays,
+} from "date-fns"
+import { fr } from "date-fns/locale"
+import type { CalendarEventWithDetails, CalendarView } from "@/types"
+import { CalendarEventChip } from "./calendar-event-chip"
+
+const MAX_CHIPS_MONTH = 3
+const WEEK_DAYS = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"]
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+
+interface CalendarGridProps {
+  view: CalendarView
+  currentDate: Date
+  events: CalendarEventWithDetails[]
+  onEventClick: (event: CalendarEventWithDetails) => void
+  onDayClick: (date: Date) => void
+}
+
+function MonthView({ currentDate, events, onEventClick, onDayClick }: Omit<CalendarGridProps, "view">) {
+  const monthStart = startOfMonth(currentDate)
+  const monthEnd = endOfMonth(currentDate)
+  const gridStart = startOfWeek(monthStart, { weekStartsOn: 1 })
+  const gridEnd = endOfWeek(monthEnd, { weekStartsOn: 1 })
+  const days = eachDayOfInterval({ start: gridStart, end: gridEnd })
+
+  function eventsForDay(day: Date) {
+    return events.filter((e) => isSameDay(new Date(e.start_at), day))
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      <div className="grid grid-cols-7 border-b border-border">
+        {WEEK_DAYS.map((d) => (
+          <div key={d} className="py-2 text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7">
+        {days.map((day) => {
+          const dayEvents = eventsForDay(day)
+          const overflow = dayEvents.length - MAX_CHIPS_MONTH
+          const visibleEvents = dayEvents.slice(0, MAX_CHIPS_MONTH)
+          const isCurrentMonth = isSameMonth(day, currentDate)
+          const isCurrentDay = isToday(day)
+
+          return (
+            <div
+              key={day.toISOString()}
+              onClick={() => onDayClick(day)}
+              className={`min-h-[100px] p-1.5 border-r border-b border-border last:border-r-0 cursor-pointer transition-colors hover:bg-muted/30 ${
+                !isCurrentMonth ? "opacity-40" : ""
+              }`}
+            >
+              <div className="flex justify-end mb-1">
+                <span
+                  className={`text-xs font-medium w-6 h-6 flex items-center justify-center rounded-full ${
+                    isCurrentDay
+                      ? "bg-primary text-primary-foreground font-bold"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {format(day, "d")}
+                </span>
+              </div>
+
+              {visibleEvents.map((event) => (
+                <CalendarEventChip
+                  key={event.id}
+                  event={event}
+                  onClick={onEventClick}
+                />
+              ))}
+
+              {overflow > 0 && (
+                <p className="text-[10px] text-muted-foreground px-1 mt-0.5">
+                  +{overflow} autre{overflow > 1 ? "s" : ""}
+                </p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function WeekView({ currentDate, events, onEventClick, onDayClick }: Omit<CalendarGridProps, "view">) {
+  const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 })
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i))
+
+  function eventsForDay(day: Date) {
+    return events.filter((e) => isSameDay(new Date(e.start_at), day))
+  }
+
+  function getTopPx(dateStr: string): number {
+    const d = new Date(dateStr)
+    return (getHours(d) * 60 + getMinutes(d)) * (56 / 60)
+  }
+
+  function getHeightPx(startStr: string, endStr: string): number {
+    const mins = (new Date(endStr).getTime() - new Date(startStr).getTime()) / 60000
+    return Math.max(mins * (56 / 60), 20)
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      <div className="grid grid-cols-[48px_repeat(7,1fr)] border-b border-border">
+        <div />
+        {days.map((day) => (
+          <div
+            key={day.toISOString()}
+            onClick={() => onDayClick(day)}
+            className={`py-2 text-center cursor-pointer hover:bg-muted/30 ${isToday(day) ? "bg-primary/5" : ""}`}
+          >
+            <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+              {format(day, "EEE", { locale: fr })}
+            </p>
+            <p className={`text-sm font-semibold ${isToday(day) ? "text-primary" : "text-foreground"}`}>
+              {format(day, "d")}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-[48px_repeat(7,1fr)] overflow-y-auto max-h-[600px]">
+        <div>
+          {HOURS.map((h) => (
+            <div key={h} className="h-14 border-b border-border/50 flex items-start justify-end pr-2 pt-1">
+              <span className="text-[10px] text-muted-foreground">{h.toString().padStart(2, "0")}h</span>
+            </div>
+          ))}
+        </div>
+
+        {days.map((day) => {
+          const dayEvents = eventsForDay(day)
+          return (
+            <div
+              key={day.toISOString()}
+              className="relative border-l border-border"
+              style={{ height: `${24 * 56}px` }}
+            >
+              {HOURS.map((h) => (
+                <div key={h} className="absolute w-full border-b border-border/30" style={{ top: `${h * 56}px`, height: "56px" }} />
+              ))}
+
+              {dayEvents.map((event) => {
+                const top = getTopPx(event.start_at)
+                const height = getHeightPx(event.start_at, event.end_at)
+                const color = event.event_type?.color ?? "#6366f1"
+                return (
+                  <button
+                    key={event.id}
+                    onClick={(e) => { e.stopPropagation(); onEventClick(event) }}
+                    className="absolute left-0.5 right-0.5 rounded-sm px-1 py-0.5 text-left overflow-hidden hover:opacity-80 transition-opacity"
+                    style={{
+                      top: `${top}px`,
+                      height: `${height}px`,
+                      backgroundColor: color + "22",
+                      borderLeft: `2px solid ${color}`,
+                      color,
+                    }}
+                  >
+                    <p className="text-[10px] font-medium truncate leading-tight">{event.title}</p>
+                    <p className="text-[9px] opacity-70">{format(new Date(event.start_at), "HH:mm")}</p>
+                  </button>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function DayView({ currentDate, events, onEventClick }: Omit<CalendarGridProps, "view" | "onDayClick">) {
+  const dayEvents = events.filter((e) => isSameDay(new Date(e.start_at), currentDate))
+
+  function getTopPx(dateStr: string): number {
+    const d = new Date(dateStr)
+    return (getHours(d) * 60 + getMinutes(d)) * (56 / 60)
+  }
+
+  function getHeightPx(startStr: string, endStr: string): number {
+    const mins = (new Date(endStr).getTime() - new Date(startStr).getTime()) / 60000
+    return Math.max(mins * (56 / 60), 20)
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      <div className="py-3 px-4 border-b border-border text-center">
+        <p className="text-sm font-semibold capitalize">
+          {format(currentDate, "EEEE d MMMM yyyy", { locale: fr })}
+        </p>
+        <p className="text-xs text-muted-foreground">{dayEvents.length} événement{dayEvents.length !== 1 ? "s" : ""}</p>
+      </div>
+
+      <div className="grid grid-cols-[48px_1fr] overflow-y-auto max-h-[600px]">
+        <div>
+          {HOURS.map((h) => (
+            <div key={h} className="h-14 border-b border-border/50 flex items-start justify-end pr-2 pt-1">
+              <span className="text-[10px] text-muted-foreground">{h.toString().padStart(2, "0")}h</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="relative border-l border-border" style={{ height: `${24 * 56}px` }}>
+          {HOURS.map((h) => (
+            <div key={h} className="absolute w-full border-b border-border/30" style={{ top: `${h * 56}px`, height: "56px" }} />
+          ))}
+          {dayEvents.map((event) => {
+            const color = event.event_type?.color ?? "#6366f1"
+            return (
+              <button
+                key={event.id}
+                onClick={() => onEventClick(event)}
+                className="absolute left-1 right-1 rounded-sm px-2 py-1 text-left overflow-hidden hover:opacity-80 transition-opacity"
+                style={{
+                  top: `${getTopPx(event.start_at)}px`,
+                  height: `${getHeightPx(event.start_at, event.end_at)}px`,
+                  backgroundColor: color + "22",
+                  borderLeft: `3px solid ${color}`,
+                  color,
+                }}
+              >
+                <p className="text-xs font-semibold truncate">{event.title}</p>
+                <p className="text-[10px] opacity-70">
+                  {format(new Date(event.start_at), "HH:mm")} → {format(new Date(event.end_at), "HH:mm")}
+                </p>
+                {event.description && (
+                  <p className="text-[10px] opacity-60 truncate mt-0.5">{event.description}</p>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function CalendarGrid(props: CalendarGridProps) {
+  if (props.view === "month") return <MonthView {...props} />
+  if (props.view === "week") return <WeekView {...props} />
+  return <DayView {...props} onDayClick={() => {}} />
+}

--- a/components/calendrier/calendar-header.tsx
+++ b/components/calendrier/calendar-header.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { CalendarView } from "@/types"
+import {
+  format,
+  addMonths, subMonths,
+  addWeeks, subWeeks,
+  addDays, subDays,
+  startOfWeek, endOfWeek,
+} from "date-fns"
+import { fr } from "date-fns/locale"
+
+interface CalendarHeaderProps {
+  view: CalendarView
+  currentDate: Date
+  onViewChange: (view: CalendarView) => void
+  onDateChange: (date: Date) => void
+  onNewEvent?: () => void
+  canCreate?: boolean
+}
+
+const VIEWS: { value: CalendarView; label: string }[] = [
+  { value: "month", label: "Mois" },
+  { value: "week", label: "Semaine" },
+  { value: "day", label: "Jour" },
+]
+
+function getTitle(view: CalendarView, date: Date): string {
+  if (view === "month") return format(date, "MMMM yyyy", { locale: fr })
+  if (view === "week") {
+    const start = startOfWeek(date, { weekStartsOn: 1 })
+    const end = endOfWeek(date, { weekStartsOn: 1 })
+    return `${format(start, "d MMM", { locale: fr })} — ${format(end, "d MMM yyyy", { locale: fr })}`
+  }
+  return format(date, "EEEE d MMMM yyyy", { locale: fr })
+}
+
+function navigate(view: CalendarView, date: Date, direction: -1 | 1): Date {
+  if (view === "month") return direction === 1 ? addMonths(date, 1) : subMonths(date, 1)
+  if (view === "week") return direction === 1 ? addWeeks(date, 1) : subWeeks(date, 1)
+  return direction === 1 ? addDays(date, 1) : subDays(date, 1)
+}
+
+export function CalendarHeader({
+  view,
+  currentDate,
+  onViewChange,
+  onDateChange,
+  onNewEvent,
+  canCreate = false,
+}: CalendarHeaderProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => onDateChange(navigate(view, currentDate, -1))}
+          aria-label="Période précédente"
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <h2 className="min-w-[200px] text-center text-sm font-semibold capitalize text-foreground">
+          {getTitle(view, currentDate)}
+        </h2>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => onDateChange(navigate(view, currentDate, 1))}
+          aria-label="Période suivante"
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs h-8"
+          onClick={() => onDateChange(new Date())}
+        >
+          Aujourd'hui
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="flex rounded-md border border-border overflow-hidden">
+          {VIEWS.map((v) => (
+            <button
+              key={v.value}
+              onClick={() => onViewChange(v.value)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                view === v.value
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {v.label}
+            </button>
+          ))}
+        </div>
+        {canCreate && onNewEvent && (
+          <Button size="sm" className="h-8 gap-1.5" onClick={onNewEvent}>
+            <CalendarDays className="size-3.5" />
+            Nouvel événement
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/calendrier/event-dialog.tsx
+++ b/components/calendrier/event-dialog.tsx
@@ -1,0 +1,265 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { format } from "date-fns"
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select"
+import type { CalendarEventWithDetails, CalendarEventType } from "@/types"
+
+const Schema = z.object({
+  title: z.string().min(1, "Titre requis"),
+  date: z.string().min(1, "Date requise"),
+  start_time: z.string().min(1, "Heure de début requise"),
+  end_time: z.string().min(1, "Heure de fin requise"),
+  event_type_id: z.string().optional(),
+  description: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof Schema>
+
+interface WorkspaceUser {
+  id: string
+  email: string
+  role: string | null
+}
+
+interface EventDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  event?: CalendarEventWithDetails | null
+  defaultDate?: Date
+  eventTypes: CalendarEventType[]
+  workspaceUsers: WorkspaceUser[]
+  onSave: (data: {
+    title: string
+    description?: string | null
+    start_at: string
+    end_at: string
+    event_type_id?: string | null
+    assignee_ids: string[]
+  }) => Promise<void>
+  onDelete?: () => Promise<void>
+}
+
+export function EventDialog({
+  open,
+  onOpenChange,
+  event,
+  defaultDate,
+  eventTypes,
+  workspaceUsers,
+  onSave,
+  onDelete,
+}: EventDialogProps) {
+  const isEdit = !!event
+  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([])
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const defaultDateStr = defaultDate
+    ? format(defaultDate, "yyyy-MM-dd")
+    : format(new Date(), "yyyy-MM-dd")
+
+  const { register, handleSubmit, setValue, reset, formState: { errors } } =
+    useForm<FormValues>({
+      resolver: zodResolver(Schema),
+      defaultValues: {
+        title: "",
+        date: defaultDateStr,
+        start_time: "08:00",
+        end_time: "17:00",
+        event_type_id: "",
+        description: "",
+      },
+    })
+
+  useEffect(() => {
+    if (event) {
+      const start = new Date(event.start_at)
+      const end = new Date(event.end_at)
+      reset({
+        title: event.title,
+        date: format(start, "yyyy-MM-dd"),
+        start_time: format(start, "HH:mm"),
+        end_time: format(end, "HH:mm"),
+        event_type_id: event.event_type_id ?? "",
+        description: event.description ?? "",
+      })
+      setSelectedAssignees(event.assignees.map((a) => a.user_id))
+    } else {
+      reset({
+        title: "",
+        date: defaultDateStr,
+        start_time: "08:00",
+        end_time: "17:00",
+        event_type_id: "",
+        description: "",
+      })
+      setSelectedAssignees([])
+    }
+  }, [event, defaultDate, reset, defaultDateStr])
+
+  const toggleAssignee = (userId: string) => {
+    setSelectedAssignees((prev) =>
+      prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
+    )
+  }
+
+  const onSubmit = async (values: FormValues) => {
+    setSaving(true)
+    try {
+      const start_at = `${values.date}T${values.start_time}:00`
+      const end_at = `${values.date}T${values.end_time}:00`
+      await onSave({
+        title: values.title,
+        description: values.description || null,
+        start_at,
+        end_at,
+        event_type_id: values.event_type_id || null,
+        assignee_ids: selectedAssignees,
+      })
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!onDelete) return
+    setDeleting(true)
+    try {
+      await onDelete()
+      onOpenChange(false)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const ouvriers = workspaceUsers.filter((u) => u.role === "ouvrier")
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Modifier l'événement" : "Nouvel événement"}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="title">Titre *</Label>
+            <Input id="title" autoFocus {...register("title")} placeholder="Nom de l'événement" />
+            {errors.title && <p className="text-xs text-destructive">{errors.title.message}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="date">Date *</Label>
+            <Input id="date" type="date" {...register("date")} />
+            {errors.date && <p className="text-xs text-destructive">{errors.date.message}</p>}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="start_time">Début *</Label>
+              <Input id="start_time" type="time" {...register("start_time")} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="end_time">Fin *</Label>
+              <Input id="end_time" type="time" {...register("end_time")} />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Type</Label>
+            <Select onValueChange={(v) => setValue("event_type_id", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choisir un type..." />
+              </SelectTrigger>
+              <SelectContent>
+                {eventTypes.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: t.color }}
+                      />
+                      {t.label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {ouvriers.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>Ouvriers assignés</Label>
+              <div className="flex flex-wrap gap-2">
+                {ouvriers.map((u) => {
+                  const selected = selectedAssignees.includes(u.id)
+                  return (
+                    <button
+                      key={u.id}
+                      type="button"
+                      onClick={() => toggleAssignee(u.id)}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                        selected
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "bg-background text-muted-foreground border-border hover:border-primary/50"
+                      }`}
+                    >
+                      {u.email.split("@")[0]}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="description">Description (optionnel)</Label>
+            <Textarea
+              id="description"
+              {...register("description")}
+              placeholder="Détails supplémentaires..."
+              rows={3}
+              className="resize-none"
+            />
+          </div>
+
+          <DialogFooter className="flex items-center justify-between gap-2 pt-2">
+            {isEdit && onDelete && (
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? "Suppression..." : "Supprimer"}
+              </Button>
+            )}
+            <div className="flex gap-2 ml-auto">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Annuler
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? "Enregistrement..." : isEdit ? "Enregistrer" : "Créer"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/calendrier/event-dialog.tsx
+++ b/components/calendrier/event-dialog.tsx
@@ -1,21 +1,29 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import { format } from "date-fns"
+import { useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { format } from "date-fns";
 import {
-  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
-} from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from "@/components/ui/select"
-import type { CalendarEventWithDetails, CalendarEventType } from "@/types"
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { CalendarEventWithDetails, CalendarEventType } from "@/types";
 
 const Schema = z.object({
   title: z.string().min(1, "Titre requis"),
@@ -24,32 +32,32 @@ const Schema = z.object({
   end_time: z.string().min(1, "Heure de fin requise"),
   event_type_id: z.string().optional(),
   description: z.string().optional(),
-})
+});
 
-type FormValues = z.infer<typeof Schema>
+type FormValues = z.infer<typeof Schema>;
 
 interface WorkspaceUser {
-  id: string
-  email: string
-  role: string | null
+  id: string;
+  email: string;
+  role: string | null;
 }
 
 interface EventDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  event?: CalendarEventWithDetails | null
-  defaultDate?: Date
-  eventTypes: CalendarEventType[]
-  workspaceUsers: WorkspaceUser[]
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  event?: CalendarEventWithDetails | null;
+  defaultDate?: Date;
+  eventTypes: CalendarEventType[];
+  workspaceUsers: WorkspaceUser[];
   onSave: (data: {
-    title: string
-    description?: string | null
-    start_at: string
-    end_at: string
-    event_type_id?: string | null
-    assignee_ids: string[]
-  }) => Promise<void>
-  onDelete?: () => Promise<void>
+    title: string;
+    description?: string | null;
+    start_at: string;
+    end_at: string;
+    event_type_id?: string | null;
+    assignee_ids: string[];
+  }) => Promise<void>;
+  onDelete?: () => Promise<void>;
 }
 
 export function EventDialog({
@@ -62,32 +70,38 @@ export function EventDialog({
   onSave,
   onDelete,
 }: EventDialogProps) {
-  const isEdit = !!event
-  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([])
-  const [saving, setSaving] = useState(false)
-  const [deleting, setDeleting] = useState(false)
+  const isEdit = !!event;
+  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const defaultDateStr = defaultDate
     ? format(defaultDate, "yyyy-MM-dd")
-    : format(new Date(), "yyyy-MM-dd")
+    : format(new Date(), "yyyy-MM-dd");
 
-  const { register, handleSubmit, setValue, reset, formState: { errors } } =
-    useForm<FormValues>({
-      resolver: zodResolver(Schema),
-      defaultValues: {
-        title: "",
-        date: defaultDateStr,
-        start_time: "08:00",
-        end_time: "17:00",
-        event_type_id: "",
-        description: "",
-      },
-    })
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(Schema),
+    defaultValues: {
+      title: "",
+      date: defaultDateStr,
+      start_time: "08:00",
+      end_time: "17:00",
+      event_type_id: "",
+      description: "",
+    },
+  });
 
   useEffect(() => {
     if (event) {
-      const start = new Date(event.start_at)
-      const end = new Date(event.end_at)
+      const start = new Date(event.start_at);
+      const end = new Date(event.end_at);
       reset({
         title: event.title,
         date: format(start, "yyyy-MM-dd"),
@@ -95,8 +109,8 @@ export function EventDialog({
         end_time: format(end, "HH:mm"),
         event_type_id: event.event_type_id ?? "",
         description: event.description ?? "",
-      })
-      setSelectedAssignees(event.assignees.map((a) => a.user_id))
+      });
+      setSelectedAssignees(event.assignees.map((a) => a.user_id));
     } else {
       reset({
         title: "",
@@ -105,22 +119,28 @@ export function EventDialog({
         end_time: "17:00",
         event_type_id: "",
         description: "",
-      })
-      setSelectedAssignees([])
+      });
+      setSelectedAssignees([]);
     }
-  }, [event, defaultDate, reset, defaultDateStr])
+  }, [event, defaultDate, reset, defaultDateStr]);
 
   const toggleAssignee = (userId: string) => {
     setSelectedAssignees((prev) =>
-      prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
-    )
-  }
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId]
+    );
+  };
 
   const onSubmit = async (values: FormValues) => {
-    setSaving(true)
+    setSaving(true);
     try {
-      const start_at = `${values.date}T${values.start_time}:00`
-      const end_at = `${values.date}T${values.end_time}:00`
+      const start_at = new Date(
+        `${values.date}T${values.start_time}:00`
+      ).toISOString();
+      const end_at = new Date(
+        `${values.date}T${values.end_time}:00`
+      ).toISOString();
       await onSave({
         title: values.title,
         description: values.description || null,
@@ -128,44 +148,55 @@ export function EventDialog({
         end_at,
         event_type_id: values.event_type_id || null,
         assignee_ids: selectedAssignees,
-      })
-      onOpenChange(false)
+      });
+      onOpenChange(false);
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
-  }
+  };
 
   const handleDelete = async () => {
-    if (!onDelete) return
-    setDeleting(true)
+    if (!onDelete) return;
+    setDeleting(true);
     try {
-      await onDelete()
-      onOpenChange(false)
+      await onDelete();
+      onOpenChange(false);
     } finally {
-      setDeleting(false)
+      setDeleting(false);
     }
-  }
+  };
 
-  const ouvriers = workspaceUsers.filter((u) => u.role === "ouvrier")
+  const ouvriers = workspaceUsers.filter((u) => u.role === "ouvrier");
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{isEdit ? "Modifier l'événement" : "Nouvel événement"}</DialogTitle>
+          <DialogTitle>
+            {isEdit ? "Modifier l'événement" : "Nouvel événement"}
+          </DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="title">Titre *</Label>
-            <Input id="title" autoFocus {...register("title")} placeholder="Nom de l'événement" />
-            {errors.title && <p className="text-xs text-destructive">{errors.title.message}</p>}
+            <Input
+              id="title"
+              autoFocus
+              {...register("title")}
+              placeholder="Nom de l'événement"
+            />
+            {errors.title && (
+              <p className="text-xs text-destructive">{errors.title.message}</p>
+            )}
           </div>
 
           <div className="space-y-1.5">
             <Label htmlFor="date">Date *</Label>
             <Input id="date" type="date" {...register("date")} />
-            {errors.date && <p className="text-xs text-destructive">{errors.date.message}</p>}
+            {errors.date && (
+              <p className="text-xs text-destructive">{errors.date.message}</p>
+            )}
           </div>
 
           <div className="grid grid-cols-2 gap-3">
@@ -181,9 +212,25 @@ export function EventDialog({
 
           <div className="space-y-1.5">
             <Label>Type</Label>
-            <Select onValueChange={(v) => setValue("event_type_id", v as string)}>
-              <SelectTrigger>
-                <SelectValue placeholder="Choisir un type..." />
+            <Select
+              value={watch("event_type_id") || undefined}
+              onValueChange={(v) => setValue("event_type_id", v ?? undefined)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Choisir un type...">
+                  {(value: string | null) => {
+                    const selected = eventTypes.find((t) => t.id === value);
+                    return selected ? (
+                      <span className="flex items-center gap-2">
+                        <span
+                          className="w-2.5 h-2.5 rounded-full shrink-0"
+                          style={{ backgroundColor: selected.color }}
+                        />
+                        {selected.label}
+                      </span>
+                    ) : null;
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {eventTypes.map((t) => (
@@ -206,7 +253,7 @@ export function EventDialog({
               <Label>Ouvriers assignés</Label>
               <div className="flex flex-wrap gap-2">
                 {ouvriers.map((u) => {
-                  const selected = selectedAssignees.includes(u.id)
+                  const selected = selectedAssignees.includes(u.id);
                   return (
                     <button
                       key={u.id}
@@ -220,7 +267,7 @@ export function EventDialog({
                     >
                       {u.email.split("@")[0]}
                     </button>
-                  )
+                  );
                 })}
               </div>
             </div>
@@ -250,16 +297,24 @@ export function EventDialog({
               </Button>
             )}
             <div className="flex gap-2 ml-auto">
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
                 Annuler
               </Button>
               <Button type="submit" disabled={saving}>
-                {saving ? "Enregistrement..." : isEdit ? "Enregistrer" : "Créer"}
+                {saving
+                  ? "Enregistrement..."
+                  : isEdit
+                    ? "Enregistrer"
+                    : "Créer"}
               </Button>
             </div>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/components/calendrier/event-dialog.tsx
+++ b/components/calendrier/event-dialog.tsx
@@ -181,7 +181,7 @@ export function EventDialog({
 
           <div className="space-y-1.5">
             <Label>Type</Label>
-            <Select onValueChange={(v) => setValue("event_type_id", v)}>
+            <Select onValueChange={(v) => setValue("event_type_id", v as string)}>
               <SelectTrigger>
                 <SelectValue placeholder="Choisir un type..." />
               </SelectTrigger>

--- a/components/calendrier/event-type-badge.tsx
+++ b/components/calendrier/event-type-badge.tsx
@@ -1,0 +1,21 @@
+import type { CalendarEventType } from "@/types"
+
+export function EventTypeBadge({ type }: { type: CalendarEventType | null }) {
+  if (!type) return null
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-sm"
+      style={{
+        backgroundColor: type.color + "22",
+        color: type.color,
+        border: `1px solid ${type.color}44`,
+      }}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ backgroundColor: type.color }}
+      />
+      {type.label}
+    </span>
+  )
+}

--- a/components/layout/mobile-header.tsx
+++ b/components/layout/mobile-header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Menu, X } from "lucide-react"
+import { Menu } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { AppSidebar } from "./sidebar"
 
@@ -51,21 +51,16 @@ export function MobileHeader({
           open ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <div className="relative h-full">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="absolute right-2 top-2 z-10 size-7 text-muted-foreground"
-            onClick={() => setOpen(false)}
-          >
-            <X className="size-4" />
-          </Button>
+        <div className="h-full">
           <AppSidebar
             email={email}
             role={role}
             alertBadge={alertBadge}
             workspaceName={workspaceName}
             logoUrl={logoUrl}
+            onToggle={() => setOpen(false)}
+            toggleLabel="Fermer"
+            variant="drawer"
           />
         </div>
       </div>

--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -11,6 +11,7 @@ import {
   HardHat,
   Package,
   AlertTriangle,
+  CalendarDays,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -28,6 +29,7 @@ const bureauNavBase: Omit<NavItem, "badge">[] = [
   { href: "/clients", label: "Clients", icon: Users },
   { href: "/inbox", label: "Messagerie", icon: Mail },
   { href: "/materiaux", label: "Matériaux", icon: Package },
+  { href: "/calendrier", label: "Calendrier", icon: CalendarDays },
   { href: "/alertes", label: "Alertes", icon: AlertTriangle, isAlert: true },
   { href: "/parametres", label: "Paramètres", icon: Settings },
 ]

--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -14,6 +14,12 @@ import {
   CalendarDays,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 type NavItem = {
   href: string
@@ -47,61 +53,100 @@ function getNavItems(role: Role, alertBadge?: number): NavItem[] {
   )
 }
 
-export function SidebarNav({ role, alertBadge }: { role: Role; alertBadge?: number }) {
+export function SidebarNav({
+  role,
+  alertBadge,
+  collapsed = false,
+}: {
+  role: Role
+  alertBadge?: number
+  collapsed?: boolean
+}) {
   const pathname = usePathname()
   const items = getNavItems(role, alertBadge)
 
   return (
-    <nav className="flex-1 py-4 space-y-0.5">
-      {items.map((item) => {
-        const isActive =
-          item.href === "/dashboard"
-            ? pathname === "/dashboard"
-            : pathname.startsWith(item.href)
+    <TooltipProvider delay={0}>
+      <nav className="flex-1 py-4 space-y-0.5 overflow-x-hidden">
+        {items.map((item) => {
+          const isActive =
+            item.href === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname.startsWith(item.href)
 
-        const showBadge = item.badge !== undefined && item.badge > 0
+          const showBadge = item.badge !== undefined && item.badge > 0
 
-        return (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={cn(
-              "flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-colors relative group",
-              isActive
-                ? "text-primary bg-primary/10 before:absolute before:left-0 before:top-0 before:bottom-0 before:w-0.5 before:bg-primary"
-                : item.isAlert && showBadge
-                  ? "text-red-400/90 hover:text-red-300 hover:bg-red-950/30"
-                  : "text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-            )}
-          >
-            <item.icon
+          const linkContent = (
+            <Link
+              key={item.href}
+              href={item.href}
               className={cn(
-                "size-4 shrink-0 transition-colors",
+                "flex items-center gap-3 py-2.5 text-sm font-medium transition-colors relative group",
+                collapsed ? "justify-center px-0 mx-1 rounded-md" : "px-4",
                 isActive
-                  ? "text-primary"
+                  ? "text-primary bg-primary/10 before:absolute before:left-0 before:top-0 before:bottom-0 before:w-0.5 before:bg-primary"
                   : item.isAlert && showBadge
-                    ? "text-red-400"
-                    : "text-sidebar-foreground/40 group-hover:text-sidebar-foreground/70"
+                    ? "text-red-400/90 hover:text-red-300 hover:bg-red-950/30"
+                    : "text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
               )}
-            />
-            <span className="truncate tracking-wide flex-1">{item.label}</span>
+            >
+              <item.icon
+                className={cn(
+                  "size-4 shrink-0 transition-colors",
+                  isActive
+                    ? "text-primary"
+                    : item.isAlert && showBadge
+                      ? "text-red-400"
+                      : "text-sidebar-foreground/40 group-hover:text-sidebar-foreground/70"
+                )}
+              />
+              {!collapsed && (
+                <span className="truncate tracking-wide flex-1">{item.label}</span>
+              )}
 
-            {showBadge && (
-              <span
-                className="flex items-center justify-center rounded-full min-w-[18px] h-[18px] px-1 text-[10px] font-bold leading-none"
-                style={{
-                  background: "oklch(0.55 0.22 25)",
-                  color: "white",
-                  animation: "alertPulse 2.4s ease infinite",
-                }}
-                data-testid="alert-badge"
-              >
-                {item.badge! > 99 ? "99+" : item.badge}
-              </span>
-            )}
-          </Link>
-        )
-      })}
-    </nav>
+              {!collapsed && showBadge && (
+                <span
+                  className="flex items-center justify-center rounded-full min-w-[18px] h-[18px] px-1 text-[10px] font-bold leading-none"
+                  style={{
+                    background: "oklch(0.55 0.22 25)",
+                    color: "white",
+                    animation: "alertPulse 2.4s ease infinite",
+                  }}
+                  data-testid="alert-badge"
+                >
+                  {item.badge! > 99 ? "99+" : item.badge}
+                </span>
+              )}
+
+              {collapsed && showBadge && (
+                <span
+                  className="absolute top-1 right-1 size-2 rounded-full"
+                  style={{ background: "oklch(0.55 0.22 25)" }}
+                  data-testid="alert-badge"
+                />
+              )}
+            </Link>
+          )
+
+          if (collapsed) {
+            return (
+              <Tooltip key={item.href}>
+                <TooltipTrigger render={<span className="block" />}>
+                  {linkContent}
+                </TooltipTrigger>
+                <TooltipContent side="right" className="text-xs">
+                  {item.label}
+                  {showBadge && (
+                    <span className="ml-1.5 text-red-400">({item.badge})</span>
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            )
+          }
+
+          return linkContent
+        })}
+      </nav>
+    </TooltipProvider>
   )
 }

--- a/components/layout/sidebar-shell.tsx
+++ b/components/layout/sidebar-shell.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { AppSidebar } from "./sidebar"
+import { MobileHeader } from "./mobile-header"
+import { cn } from "@/lib/utils"
+
+type Role = "admin" | "bureau" | "ouvrier"
+
+export function SidebarShell({
+  children,
+  email,
+  role,
+  alertBadge = 0,
+  workspaceName,
+  logoUrl,
+}: {
+  children: React.ReactNode
+  email: string
+  role: Role
+  alertBadge?: number
+  workspaceName?: string | null
+  logoUrl?: string | null
+}) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    const saved = localStorage.getItem("sidebar-collapsed")
+    if (saved !== null) setCollapsed(saved === "true")
+    setMounted(true)
+  }, [])
+
+  const toggle = () => {
+    setCollapsed((prev) => {
+      const next = !prev
+      localStorage.setItem("sidebar-collapsed", String(next))
+      return next
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Desktop sidebar */}
+      <div className="hidden lg:block">
+        <AppSidebar
+          email={email}
+          role={role}
+          alertBadge={alertBadge}
+          workspaceName={workspaceName}
+          logoUrl={logoUrl}
+          collapsed={mounted ? collapsed : false}
+          onToggle={toggle}
+        />
+      </div>
+
+      {/* Mobile header + drawer */}
+      <MobileHeader
+        email={email}
+        role={role}
+        alertBadge={alertBadge}
+        workspaceName={workspaceName}
+        logoUrl={logoUrl}
+      />
+
+      {/* Main content — padding follows sidebar width */}
+      <main
+        className={cn(
+          "min-h-screen transition-[padding-left] duration-200 ease-in-out",
+          mounted && collapsed ? "lg:pl-14" : "lg:pl-56"
+        )}
+      >
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 lg:py-8">
+          {children}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/layout/sidebar-toggle.tsx
+++ b/components/layout/sidebar-toggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function SidebarToggle({
+  collapsed,
+  onToggle,
+  label,
+}: {
+  collapsed: boolean;
+  onToggle: () => void;
+  label?: string;
+}) {
+  return (
+    <div className="border-t border-sidebar-border px-2 py-2">
+      <button
+        onClick={onToggle}
+        aria-label={collapsed ? "Ouvrir la sidebar" : "Réduire la sidebar"}
+        className={cn(
+          "w-full flex items-center gap-3 py-2 px-2 rounded-md text-sm font-medium",
+          "text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent",
+          "transition-colors duration-150 group",
+          collapsed && "justify-center"
+        )}
+      >
+        {collapsed ? (
+          <PanelLeftOpen className="size-4 shrink-0" />
+        ) : (
+          <>
+            <PanelLeftClose className="size-4 shrink-0" />
+            <span className="truncate tracking-wide">{label ?? "Réduire"}</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/components/layout/sidebar-user.tsx
+++ b/components/layout/sidebar-user.tsx
@@ -27,9 +27,11 @@ function initials(email: string): string {
 export function SidebarUser({
   email,
   role,
+  collapsed = false,
 }: {
   email: string
   role: string
+  collapsed?: boolean
 }) {
   const router = useRouter()
   const [loading, setLoading] = useState(false)
@@ -39,6 +41,28 @@ export function SidebarUser({
     const supabase = createClient()
     await supabase.auth.signOut()
     router.push("/login")
+  }
+
+  if (collapsed) {
+    return (
+      <div className="border-t border-sidebar-border p-2 flex flex-col items-center gap-2">
+        <Avatar className="size-7 shrink-0">
+          <AvatarFallback className="bg-primary/20 text-primary text-xs font-bold">
+            {initials(email)}
+          </AvatarFallback>
+        </Avatar>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 text-sidebar-foreground/50 hover:text-destructive hover:bg-destructive/10"
+          onClick={handleSignOut}
+          disabled={loading}
+          title="Se déconnecter"
+        >
+          <LogOut className="size-3.5" />
+        </Button>
+      </div>
+    )
   }
 
   return (

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image"
 import { SidebarNav } from "./sidebar-nav"
 import { SidebarUser } from "./sidebar-user"
+import { SidebarToggle } from "./sidebar-toggle"
+import { cn } from "@/lib/utils"
 
 type Role = "admin" | "bureau" | "ouvrier"
 
@@ -10,20 +12,41 @@ export function AppSidebar({
   alertBadge = 0,
   workspaceName,
   logoUrl,
+  collapsed = false,
+  onToggle,
+  toggleLabel,
+  variant = "fixed",
 }: {
   email: string
   role: Role
   alertBadge?: number
   workspaceName?: string | null
   logoUrl?: string | null
+  collapsed?: boolean
+  onToggle?: () => void
+  toggleLabel?: string
+  variant?: "fixed" | "drawer"
 }) {
   const displayName = workspaceName ?? "BTPxAI"
   const initial = displayName.charAt(0).toUpperCase()
 
   return (
-    <aside className="fixed inset-y-0 left-0 z-40 flex w-56 flex-col bg-sidebar border-r border-sidebar-border">
+    <aside
+      className={cn(
+        "flex flex-col bg-sidebar border-r border-sidebar-border",
+        variant === "fixed"
+          ? "fixed inset-y-0 left-0 z-40 transition-[width] duration-200 ease-in-out overflow-hidden"
+          : "h-full",
+        variant === "fixed" ? (collapsed ? "w-14" : "w-56") : "w-56"
+      )}
+    >
       {/* Brand */}
-      <div className="flex items-center gap-2 px-4 py-5 border-b border-sidebar-border">
+      <div
+        className={cn(
+          "flex items-center border-b border-sidebar-border shrink-0",
+          collapsed ? "justify-center px-0 py-5" : "gap-2 px-4 py-5"
+        )}
+      >
         {logoUrl ? (
           <div className="size-7 rounded-sm overflow-hidden shrink-0 border border-sidebar-border">
             <Image
@@ -41,16 +64,21 @@ export function AppSidebar({
             </span>
           </div>
         )}
-        <span className="font-heading font-700 text-base tracking-wide text-sidebar-foreground truncate">
-          {displayName}
-        </span>
+        {!collapsed && (
+          <span className="font-heading font-700 text-base tracking-wide text-sidebar-foreground truncate">
+            {displayName}
+          </span>
+        )}
       </div>
 
       {/* Navigation */}
-      <SidebarNav role={role} alertBadge={alertBadge} />
+      <SidebarNav role={role} alertBadge={alertBadge} collapsed={collapsed} />
+
+      {/* Toggle button — bas de la nav, avant le user */}
+      {onToggle && <SidebarToggle collapsed={collapsed} onToggle={onToggle} label={toggleLabel} />}
 
       {/* User section */}
-      <SidebarUser email={email} role={role} />
+      <SidebarUser email={email} role={role} collapsed={collapsed} />
     </aside>
   )
 }

--- a/components/parametres/event-types-section.tsx
+++ b/components/parametres/event-types-section.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { useState } from "react"
+import { Plus, Pencil, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { CalendarEventType } from "@/types"
+
+interface EventTypesSectionProps {
+  initialTypes: CalendarEventType[]
+}
+
+const COLOR_PRESETS = [
+  "#3b82f6", "#ec4899", "#8b5cf6", "#f97316",
+  "#06b6d4", "#f59e0b", "#22c55e", "#6b7280", "#a3a3a3",
+]
+
+export function EventTypesSection({ initialTypes }: EventTypesSectionProps) {
+  const [types, setTypes] = useState(initialTypes)
+  const [showAdd, setShowAdd] = useState(false)
+  const [newLabel, setNewLabel] = useState("")
+  const [newColor, setNewColor] = useState(COLOR_PRESETS[0])
+  const [saving, setSaving] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editLabel, setEditLabel] = useState("")
+  const [editColor, setEditColor] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const handleAdd = async () => {
+    if (!newLabel.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/calendar/event-types", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: newLabel.trim(), color: newColor }),
+      })
+      if (!res.ok) throw new Error("Erreur lors de la création")
+      const created = await res.json()
+      setTypes((prev) => [...prev, created])
+      setNewLabel("")
+      setNewColor(COLOR_PRESETS[0])
+      setShowAdd(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleUpdate = async (id: string) => {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/calendar/event-types/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: editLabel, color: editColor }),
+      })
+      if (!res.ok) throw new Error("Erreur")
+      const updated = await res.json()
+      setTypes((prev) => prev.map((t) => (t.id === id ? updated : t)))
+      setEditingId(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setError(null)
+    const res = await fetch(`/api/calendar/event-types/${id}`, { method: "DELETE" })
+    if (res.status === 409) {
+      setError("Ce type est utilisé par des événements existants et ne peut pas être supprimé.")
+      return
+    }
+    if (!res.ok) { setError("Erreur lors de la suppression"); return }
+    setTypes((prev) => prev.filter((t) => t.id !== id))
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Types d&apos;événements</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Catégories disponibles lors de la création d&apos;un événement calendrier
+          </p>
+        </div>
+        {!showAdd && (
+          <Button size="sm" variant="outline" onClick={() => setShowAdd(true)}>
+            <Plus className="size-3.5 mr-1" />
+            Ajouter
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-xs text-destructive bg-destructive/10 px-3 py-2 rounded-md">{error}</p>
+      )}
+
+      {showAdd && (
+        <div className="flex items-end gap-3 p-3 border border-border rounded-md bg-muted/30">
+          <div className="flex-1 space-y-1.5">
+            <Label className="text-xs">Nom</Label>
+            <Input
+              autoFocus
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              placeholder="Ex: Réunion fournisseur"
+              className="h-8 text-sm"
+              onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs">Couleur</Label>
+            <div className="flex gap-1.5">
+              {COLOR_PRESETS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setNewColor(c)}
+                  className={`w-5 h-5 rounded-full transition-transform hover:scale-110 ${
+                    newColor === c ? "ring-2 ring-offset-1 ring-foreground scale-110" : ""
+                  }`}
+                  style={{ backgroundColor: c }}
+                />
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)}>Annuler</Button>
+            <Button size="sm" onClick={handleAdd} disabled={saving || !newLabel.trim()}>
+              {saving ? "..." : "Créer"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        {types.map((t) => (
+          <div key={t.id} className="flex items-center gap-3 px-3 py-2 rounded-md border border-border hover:bg-muted/20">
+            {editingId === t.id ? (
+              <>
+                <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: editColor }} />
+                <Input
+                  value={editLabel}
+                  onChange={(e) => setEditLabel(e.target.value)}
+                  className="h-7 text-sm flex-1"
+                  onKeyDown={(e) => e.key === "Enter" && handleUpdate(t.id)}
+                />
+                <div className="flex gap-1">
+                  {COLOR_PRESETS.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      onClick={() => setEditColor(c)}
+                      className={`w-4 h-4 rounded-full ${editColor === c ? "ring-2 ring-offset-1 ring-foreground" : ""}`}
+                      style={{ backgroundColor: c }}
+                    />
+                  ))}
+                </div>
+                <Button size="sm" variant="ghost" onClick={() => setEditingId(null)}>Annuler</Button>
+                <Button size="sm" onClick={() => handleUpdate(t.id)} disabled={saving}>OK</Button>
+              </>
+            ) : (
+              <>
+                <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: t.color }} />
+                <span className="text-sm flex-1">{t.label}</span>
+                {t.is_preset && (
+                  <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                    preset
+                  </span>
+                )}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={() => { setEditingId(t.id); setEditLabel(t.label); setEditColor(t.color) }}
+                >
+                  <Pencil className="size-3" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                  onClick={() => handleDelete(t.id)}
+                >
+                  <Trash2 className="size-3" />
+                </Button>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/parametres/settings-shell.tsx
+++ b/components/parametres/settings-shell.tsx
@@ -12,6 +12,8 @@ import { SheetsSyncSection } from "./sheets-sync-section"
 import { GmailConnectionSection } from "./gmail-connection-section"
 import { ImapConnectionSection } from "./imap-connection-section"
 import { UsersSection } from "./users-section"
+import { EventTypesSection } from "./event-types-section"
+import type { CalendarEventType } from "@/types"
 
 type Tab = "entreprise" | "automatisations" | "integrations" | "equipe"
 
@@ -45,6 +47,7 @@ type Props = {
   autoAckEnabled: boolean
   lastSyncAt: string | null
   users: AdminUser[]
+  eventTypes: CalendarEventType[]
 }
 
 export function SettingsShell({
@@ -55,6 +58,7 @@ export function SettingsShell({
   autoAckEnabled,
   lastSyncAt,
   users,
+  eventTypes,
 }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("entreprise")
 
@@ -106,6 +110,9 @@ export function SettingsShell({
                 }
               })()}
             />
+            <section className="rounded-lg border border-border p-6">
+              <EventTypesSection initialTypes={eventTypes} />
+            </section>
           </>
         )}
 

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/cypress/e2e/calendar.cy.ts
+++ b/cypress/e2e/calendar.cy.ts
@@ -1,0 +1,64 @@
+describe("Calendrier — Bureau", () => {
+  beforeEach(() => {
+    cy.loginAsBureau()
+    cy.visit("/calendrier")
+  })
+
+  it("affiche la page calendrier avec la grille mensuelle", () => {
+    cy.contains("h1", "Calendrier").should("be.visible")
+    cy.contains("button", "Mois").should("be.visible")
+    cy.contains("Lun").should("be.visible")
+    cy.contains("Dim").should("be.visible")
+  })
+
+  it("navigue vers le mois suivant via la flèche", () => {
+    cy.get('[aria-label="Période suivante"]').click()
+    cy.get('[aria-label="Période précédente"]').should("be.visible")
+  })
+
+  it("revient à aujourd'hui avec le bouton Aujourd'hui", () => {
+    cy.get('[aria-label="Période suivante"]').click()
+    cy.contains("button", "Aujourd'hui").click()
+    cy.contains("button", "Aujourd'hui").should("be.visible")
+  })
+
+  it("change de vue vers Semaine", () => {
+    cy.contains("button", "Semaine").click()
+    cy.contains("button", "Semaine").should("be.visible")
+  })
+
+  it("change de vue vers Jour", () => {
+    cy.contains("button", "Jour").click()
+    cy.contains("button", "Jour").should("be.visible")
+  })
+
+  it("ouvre la modale de création en cliquant sur Nouvel événement", () => {
+    cy.contains("button", "Nouvel événement").click()
+    cy.contains("Nouvel événement").should("be.visible")
+  })
+
+  it("ferme la modale avec Annuler", () => {
+    cy.contains("button", "Nouvel événement").click()
+    cy.contains("button", "Annuler").click()
+    cy.contains("button", "Nouvel événement").should("be.visible")
+  })
+})
+
+describe("Calendrier — Ouvrier", () => {
+  beforeEach(() => {
+    cy.loginAsOuvrier()
+    cy.visit("/terrain/calendrier")
+  })
+
+  it("affiche le planning avec le titre Mon planning", () => {
+    cy.contains("Mon planning").should("be.visible")
+  })
+
+  it("n'affiche pas de bouton Nouvel événement", () => {
+    cy.contains("button", "Nouvel événement").should("not.exist")
+  })
+
+  it("n'affiche pas les filtres par ouvrier", () => {
+    cy.contains("Filtrer :").should("not.exist")
+  })
+})

--- a/docs/superpowers/plans/2026-05-11-calendar.md
+++ b/docs/superpowers/plans/2026-05-11-calendar.md
@@ -1,0 +1,2795 @@
+# Calendrier d'entreprise — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un calendrier d'entreprise avec vues mois/semaine/jour, événements typés et colorés, assignation d'ouvriers, filtres par ouvrier pour le bureau, et gestion des types depuis les paramètres.
+
+**Architecture:** Deux nouvelles tables Supabase (`calendar_event_types`, `calendar_events` + jointure `calendar_event_assignees`), RLS différencié bureau/ouvrier, implémentation custom de la grille calendrier avec `date-fns`, sans librairie calendrier externe.
+
+**Tech Stack:** Next.js 15 App Router, Supabase (Postgres + RLS), TypeScript strict, Tailwind CSS, shadcn/ui (Dialog, Select, Popover, Command), date-fns v4, Vitest, Cypress.
+
+**Design spec:** `docs/superpowers/specs/2026-05-11-calendar-design.md`
+
+**Branche:** `feat/calendar`
+
+---
+
+## Fichiers créés / modifiés
+
+```
+# Nouveaux
+app/(bureau)/calendrier/page.tsx
+app/(terrain)/terrain/calendrier/page.tsx
+app/api/calendar/events/route.ts
+app/api/calendar/events/[id]/route.ts
+app/api/calendar/event-types/route.ts
+app/api/calendar/event-types/[id]/route.ts
+components/calendrier/calendar-grid.tsx
+components/calendrier/calendar-header.tsx
+components/calendrier/calendar-event-chip.tsx
+components/calendrier/calendar-filters.tsx
+components/calendrier/event-dialog.tsx
+components/calendrier/event-type-badge.tsx
+components/parametres/event-types-section.tsx
+lib/calendar.ts
+lib/calendar-event-types.ts
+supabase/migrations/20260511_calendar.sql
+
+# Modifiés
+types/index.ts                              — nouveaux types Calendar*
+components/layout/sidebar-nav.tsx           — entrée Calendrier
+app/(bureau)/parametres/page.tsx            — chargement event types
+components/parametres/settings-shell.tsx    — onglet types d'événements
+```
+
+---
+
+## Task 1 : Branche git
+
+**Files:** aucun
+
+- [ ] **Créer et basculer sur la branche feature**
+
+```bash
+git checkout -b feat/calendar
+git push -u origin feat/calendar
+```
+
+Expected: branche créée et trackée sur origin.
+
+---
+
+## Task 2 : Migration Supabase
+
+**Files:**
+- Create: `supabase/migrations/20260511_calendar.sql`
+
+- [ ] **Écrire le fichier de migration**
+
+```sql
+-- supabase/migrations/20260511_calendar.sql
+
+-- Types d'événements configurables par workspace
+CREATE TABLE IF NOT EXISTS calendar_event_types (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  label       text NOT NULL,
+  color       text NOT NULL DEFAULT '#6366f1',
+  is_preset   boolean NOT NULL DEFAULT false,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Événements du calendrier
+CREATE TABLE IF NOT EXISTS calendar_events (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id  uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  title         text NOT NULL,
+  description   text,
+  start_at      timestamptz NOT NULL,
+  end_at        timestamptz NOT NULL,
+  event_type_id uuid REFERENCES calendar_event_types(id) ON DELETE SET NULL,
+  created_by    uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Ouvriers assignés (N-N)
+CREATE TABLE IF NOT EXISTS calendar_event_assignees (
+  event_id uuid NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  user_id  uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  PRIMARY KEY (event_id, user_id)
+);
+
+-- Index perf
+CREATE INDEX IF NOT EXISTS idx_calendar_events_workspace_start
+  ON calendar_events(workspace_id, start_at);
+CREATE INDEX IF NOT EXISTS idx_calendar_event_assignees_user
+  ON calendar_event_assignees(user_id);
+
+-- RLS
+ALTER TABLE calendar_event_types ENABLE ROW LEVEL SECURITY;
+ALTER TABLE calendar_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE calendar_event_assignees ENABLE ROW LEVEL SECURITY;
+
+-- calendar_event_types : lecture par membres du workspace, écriture admin/bureau
+CREATE POLICY "workspace members can read event types"
+  ON calendar_event_types FOR SELECT
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "admin bureau can manage event types"
+  ON calendar_event_types FOR ALL
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members
+      WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+    )
+  );
+
+-- calendar_events : bureau/admin voient tout, ouvrier uniquement ses événements
+CREATE POLICY "bureau admin see all events"
+  ON calendar_events FOR SELECT
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members
+      WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+    )
+  );
+
+CREATE POLICY "ouvrier sees assigned events"
+  ON calendar_events FOR SELECT
+  USING (
+    id IN (
+      SELECT event_id FROM calendar_event_assignees WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "bureau admin can manage events"
+  ON calendar_events FOR ALL
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members
+      WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+    )
+  );
+
+-- calendar_event_assignees : mêmes règles
+CREATE POLICY "bureau admin see all assignees"
+  ON calendar_event_assignees FOR SELECT
+  USING (
+    event_id IN (
+      SELECT id FROM calendar_events
+      WHERE workspace_id IN (
+        SELECT workspace_id FROM workspace_members
+        WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+      )
+    )
+  );
+
+CREATE POLICY "ouvrier sees own assignees"
+  ON calendar_event_assignees FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "bureau admin manage assignees"
+  ON calendar_event_assignees FOR ALL
+  USING (
+    event_id IN (
+      SELECT id FROM calendar_events
+      WHERE workspace_id IN (
+        SELECT workspace_id FROM workspace_members
+        WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+      )
+    )
+  );
+```
+
+- [ ] **Appliquer la migration dans Supabase**
+
+Ouvrir le SQL Editor du projet Supabase et exécuter le contenu de `supabase/migrations/20260511_calendar.sql`.
+Ou via CLI : `supabase db push` (si CLI configuré).
+
+- [ ] **Vérifier que les 3 tables existent dans le dashboard Supabase**
+
+- [ ] **Régénérer les types TypeScript**
+
+```bash
+npm run db:types
+```
+
+Expected : `types/supabase.ts` mis à jour avec `calendar_events`, `calendar_event_types`, `calendar_event_assignees`.
+
+- [ ] **Commit**
+
+```bash
+git add supabase/migrations/20260511_calendar.sql types/supabase.ts
+git commit -m "chore: add calendar tables migration and regenerate types"
+```
+
+---
+
+## Task 3 : Types métier
+
+**Files:**
+- Modify: `types/index.ts`
+
+- [ ] **Ajouter les types Calendar à la fin de `types/index.ts`**
+
+```typescript
+// ─── Calendar types ───────────────────────────────────────────────────────────
+
+export type CalendarEventType = {
+  id: string
+  workspace_id: string
+  label: string
+  color: string
+  is_preset: boolean
+  created_at: string
+}
+
+export type CalendarEvent = {
+  id: string
+  workspace_id: string
+  title: string
+  description: string | null
+  start_at: string
+  end_at: string
+  event_type_id: string | null
+  created_by: string | null
+  created_at: string
+}
+
+export type CalendarEventWithDetails = CalendarEvent & {
+  event_type: CalendarEventType | null
+  assignees: { user_id: string }[]
+}
+
+export type CreateCalendarEventInput = {
+  title: string
+  description?: string | null
+  start_at: string
+  end_at: string
+  event_type_id?: string | null
+  assignee_ids?: string[]
+}
+
+export type UpdateCalendarEventInput = Partial<CreateCalendarEventInput>
+
+export type CreateCalendarEventTypeInput = {
+  label: string
+  color: string
+}
+
+export type UpdateCalendarEventTypeInput = Partial<CreateCalendarEventTypeInput>
+
+export type CalendarView = "month" | "week" | "day"
+```
+
+- [ ] **Commit**
+
+```bash
+git add types/index.ts
+git commit -m "feat: add Calendar types to types/index.ts"
+```
+
+---
+
+## Task 4 : lib/calendar-event-types.ts
+
+**Files:**
+- Create: `lib/calendar-event-types.ts`
+- Create: `lib/calendar-event-types.test.ts`
+
+- [ ] **Écrire le test en premier**
+
+```typescript
+// lib/calendar-event-types.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  getEventTypes,
+  createEventType,
+  updateEventType,
+  deleteEventType,
+  seedDefaultEventTypes,
+} from "./calendar-event-types"
+
+const mockFrom = vi.fn()
+const supabase = { from: mockFrom } as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("getEventTypes", () => {
+  it("returns event types for workspace", async () => {
+    const types = [{ id: "1", label: "Chantier", color: "#3b82f6" }]
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({ data: types, error: null }),
+        }),
+      }),
+    })
+    const result = await getEventTypes(supabase, "ws-1")
+    expect(result).toEqual(types)
+  })
+})
+
+describe("createEventType", () => {
+  it("inserts a new event type", async () => {
+    const created = { id: "new-id", label: "Livraison", color: "#f97316" }
+    mockFrom.mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: created, error: null }),
+        }),
+      }),
+    })
+    const result = await createEventType(supabase, "ws-1", {
+      label: "Livraison",
+      color: "#f97316",
+    })
+    expect(result).toEqual(created)
+  })
+})
+
+describe("deleteEventType", () => {
+  it("throws if type is used by an event", async () => {
+    mockFrom
+      .mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({ data: [{ id: "ev-1" }], error: null }),
+          }),
+        }),
+      })
+    await expect(deleteEventType(supabase, "type-id")).rejects.toThrow(
+      "Ce type est utilisé par des événements existants"
+    )
+  })
+})
+```
+
+- [ ] **Lancer le test pour vérifier qu'il échoue**
+
+```bash
+npm run test -- lib/calendar-event-types.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Implémenter `lib/calendar-event-types.ts`**
+
+```typescript
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+import type {
+  CalendarEventType,
+  CreateCalendarEventTypeInput,
+  UpdateCalendarEventTypeInput,
+} from "@/types"
+
+type Supabase = SupabaseClient<Database>
+
+export const DEFAULT_EVENT_TYPES: CreateCalendarEventTypeInput[] = [
+  { label: "Chantier / Travaux",    color: "#3b82f6" },
+  { label: "Rendez-vous client",    color: "#ec4899" },
+  { label: "Visite pré-chantier",   color: "#8b5cf6" },
+  { label: "Livraison matériaux",   color: "#f97316" },
+  { label: "Réunion d'équipe",      color: "#06b6d4" },
+  { label: "Formation / Sécurité",  color: "#f59e0b" },
+  { label: "Réception de chantier", color: "#22c55e" },
+  { label: "Permanence / Astreinte",color: "#6b7280" },
+  { label: "Administratif",         color: "#a3a3a3" },
+]
+
+export async function getEventTypes(
+  supabase: Supabase,
+  workspaceId: string
+): Promise<CalendarEventType[]> {
+  const { data, error } = await supabase
+    .from("calendar_event_types")
+    .select("*")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: true })
+  if (error) throw error
+  return data as CalendarEventType[]
+}
+
+export async function createEventType(
+  supabase: Supabase,
+  workspaceId: string,
+  input: CreateCalendarEventTypeInput
+): Promise<CalendarEventType> {
+  const { data, error } = await supabase
+    .from("calendar_event_types")
+    .insert({ workspace_id: workspaceId, ...input })
+    .select()
+    .single()
+  if (error) throw error
+  return data as CalendarEventType
+}
+
+export async function updateEventType(
+  supabase: Supabase,
+  id: string,
+  input: UpdateCalendarEventTypeInput
+): Promise<CalendarEventType> {
+  const { data, error } = await supabase
+    .from("calendar_event_types")
+    .update(input)
+    .eq("id", id)
+    .select()
+    .single()
+  if (error) throw error
+  return data as CalendarEventType
+}
+
+export async function deleteEventType(
+  supabase: Supabase,
+  id: string
+): Promise<void> {
+  const { data: usedBy } = await supabase
+    .from("calendar_events")
+    .select("id")
+    .eq("event_type_id", id)
+    .limit(1)
+  if (usedBy && usedBy.length > 0) {
+    throw new Error("Ce type est utilisé par des événements existants")
+  }
+  const { error } = await supabase
+    .from("calendar_event_types")
+    .delete()
+    .eq("id", id)
+  if (error) throw error
+}
+
+export async function seedDefaultEventTypes(
+  supabase: Supabase,
+  workspaceId: string
+): Promise<void> {
+  const rows = DEFAULT_EVENT_TYPES.map((t) => ({
+    workspace_id: workspaceId,
+    label: t.label,
+    color: t.color,
+    is_preset: true,
+  }))
+  const { error } = await supabase
+    .from("calendar_event_types")
+    .insert(rows)
+  if (error) throw error
+}
+```
+
+- [ ] **Lancer les tests pour vérifier qu'ils passent**
+
+```bash
+npm run test -- lib/calendar-event-types.test.ts
+```
+
+Expected: 3 tests PASS.
+
+- [ ] **Commit**
+
+```bash
+git add lib/calendar-event-types.ts lib/calendar-event-types.test.ts
+git commit -m "feat: add calendar event types CRUD lib"
+```
+
+---
+
+## Task 5 : lib/calendar.ts
+
+**Files:**
+- Create: `lib/calendar.ts`
+- Create: `lib/calendar.test.ts`
+
+- [ ] **Écrire les tests**
+
+```typescript
+// lib/calendar.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getEvents, createEvent, updateEvent, deleteEvent } from "./calendar"
+
+const mockFrom = vi.fn()
+const supabase = { from: mockFrom } as any
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("getEvents", () => {
+  it("fetches events within date range for workspace", async () => {
+    const events = [{ id: "ev-1", title: "Test", start_at: "2026-05-11T08:00:00Z" }]
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: events, error: null }),
+      }),
+    })
+    const result = await getEvents(supabase, "ws-1", {
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-31T23:59:59Z",
+    })
+    expect(result).toEqual(events)
+  })
+})
+
+describe("createEvent", () => {
+  it("inserts event and assignees", async () => {
+    const created = { id: "new-ev", title: "Chantier" }
+    // Mock event insert
+    mockFrom
+      .mockReturnValueOnce({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: created, error: null }),
+          }),
+        }),
+      })
+      // Mock assignees insert
+      .mockReturnValueOnce({
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      })
+    const result = await createEvent(supabase, "ws-1", {
+      title: "Chantier",
+      start_at: "2026-05-11T08:00:00Z",
+      end_at: "2026-05-11T17:00:00Z",
+      assignee_ids: ["user-1"],
+    })
+    expect(result).toEqual(created)
+  })
+})
+```
+
+- [ ] **Lancer pour vérifier l'échec**
+
+```bash
+npm run test -- lib/calendar.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Implémenter `lib/calendar.ts`**
+
+```typescript
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+import type {
+  CalendarEvent,
+  CalendarEventWithDetails,
+  CreateCalendarEventInput,
+  UpdateCalendarEventInput,
+} from "@/types"
+
+type Supabase = SupabaseClient<Database>
+
+export type GetEventsFilters = {
+  from: string
+  to: string
+  assigneeId?: string   // filtre par ouvrier (bureau only)
+}
+
+export async function getEvents(
+  supabase: Supabase,
+  workspaceId: string,
+  filters: GetEventsFilters
+): Promise<CalendarEventWithDetails[]> {
+  let query = supabase
+    .from("calendar_events")
+    .select(`
+      *,
+      event_type:calendar_event_types(*),
+      assignees:calendar_event_assignees(user_id)
+    `)
+    .eq("workspace_id", workspaceId)
+    .gte("start_at", filters.from)
+    .lte("start_at", filters.to)
+    .order("start_at", { ascending: true })
+
+  const { data, error } = await query
+  if (error) throw error
+
+  let events = data as unknown as CalendarEventWithDetails[]
+
+  if (filters.assigneeId) {
+    events = events.filter((e) =>
+      e.assignees.some((a) => a.user_id === filters.assigneeId)
+    )
+  }
+
+  return events
+}
+
+export async function getEvent(
+  supabase: Supabase,
+  id: string
+): Promise<CalendarEventWithDetails> {
+  const { data, error } = await supabase
+    .from("calendar_events")
+    .select(`
+      *,
+      event_type:calendar_event_types(*),
+      assignees:calendar_event_assignees(user_id)
+    `)
+    .eq("id", id)
+    .single()
+  if (error) throw error
+  return data as unknown as CalendarEventWithDetails
+}
+
+export async function createEvent(
+  supabase: Supabase,
+  workspaceId: string,
+  input: CreateCalendarEventInput
+): Promise<CalendarEvent> {
+  const { assignee_ids, ...rest } = input
+  const { data, error } = await supabase
+    .from("calendar_events")
+    .insert({ workspace_id: workspaceId, ...rest })
+    .select()
+    .single()
+  if (error) throw error
+
+  if (assignee_ids && assignee_ids.length > 0) {
+    const { error: assignError } = await supabase
+      .from("calendar_event_assignees")
+      .insert(assignee_ids.map((user_id) => ({ event_id: data.id, user_id })))
+    if (assignError) throw assignError
+  }
+
+  return data as CalendarEvent
+}
+
+export async function updateEvent(
+  supabase: Supabase,
+  id: string,
+  input: UpdateCalendarEventInput
+): Promise<CalendarEvent> {
+  const { assignee_ids, ...rest } = input
+
+  if (Object.keys(rest).length > 0) {
+    const { error } = await supabase
+      .from("calendar_events")
+      .update(rest)
+      .eq("id", id)
+    if (error) throw error
+  }
+
+  if (assignee_ids !== undefined) {
+    await supabase
+      .from("calendar_event_assignees")
+      .delete()
+      .eq("event_id", id)
+
+    if (assignee_ids.length > 0) {
+      const { error } = await supabase
+        .from("calendar_event_assignees")
+        .insert(assignee_ids.map((user_id) => ({ event_id: id, user_id })))
+      if (error) throw error
+    }
+  }
+
+  return getEvent(supabase, id)
+}
+
+export async function deleteEvent(
+  supabase: Supabase,
+  id: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("calendar_events")
+    .delete()
+    .eq("id", id)
+  if (error) throw error
+}
+```
+
+- [ ] **Lancer les tests**
+
+```bash
+npm run test -- lib/calendar.test.ts
+```
+
+Expected: 2 tests PASS.
+
+- [ ] **Commit**
+
+```bash
+git add lib/calendar.ts lib/calendar.test.ts
+git commit -m "feat: add calendar events CRUD lib"
+```
+
+---
+
+## Task 6 : API routes — event-types
+
+**Files:**
+- Create: `app/api/calendar/event-types/route.ts`
+- Create: `app/api/calendar/event-types/[id]/route.ts`
+
+- [ ] **Créer `app/api/calendar/event-types/route.ts`**
+
+```typescript
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { getEventTypes, createEventType } from "@/lib/calendar-event-types"
+
+const CreateSchema = z.object({
+  label: z.string().min(1).max(100),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+})
+
+export async function GET() {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId } = await requireWorkspace(user.id)
+    const supabase = await createClient()
+    const types = await getEventTypes(supabase, workspaceId)
+    return NextResponse.json(types)
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId, role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const body = await req.json()
+    const parsed = CreateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const created = await createEventType(supabase, workspaceId, parsed.data)
+    return NextResponse.json(created, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+```
+
+- [ ] **Créer `app/api/calendar/event-types/[id]/route.ts`**
+
+```typescript
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { updateEventType, deleteEventType } from "@/lib/calendar-event-types"
+
+const UpdateSchema = z.object({
+  label: z.string().min(1).max(100).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+})
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const body = await req.json()
+    const parsed = UpdateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const updated = await updateEventType(supabase, id, parsed.data)
+    return NextResponse.json(updated)
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const supabase = await createClient()
+    await deleteEventType(supabase, id)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Erreur serveur"
+    const status = message.includes("utilisé") ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add app/api/calendar/event-types/
+git commit -m "feat: add calendar event-types API routes"
+```
+
+---
+
+## Task 7 : API routes — events
+
+**Files:**
+- Create: `app/api/calendar/events/route.ts`
+- Create: `app/api/calendar/events/[id]/route.ts`
+
+- [ ] **Créer `app/api/calendar/events/route.ts`**
+
+```typescript
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { getEvents, createEvent } from "@/lib/calendar"
+
+const CreateSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().nullable().optional(),
+  start_at: z.string().datetime(),
+  end_at: z.string().datetime(),
+  event_type_id: z.string().uuid().nullable().optional(),
+  assignee_ids: z.array(z.string().uuid()).optional(),
+})
+
+export async function GET(req: Request) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId } = await requireWorkspace(user.id)
+    const { searchParams } = new URL(req.url)
+    const from = searchParams.get("from")
+    const to = searchParams.get("to")
+    const assigneeId = searchParams.get("assigneeId") ?? undefined
+    if (!from || !to) {
+      return NextResponse.json({ error: "Paramètres from/to requis" }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const events = await getEvents(supabase, workspaceId, { from, to, assigneeId })
+    return NextResponse.json(events)
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { workspaceId, role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const body = await req.json()
+    const parsed = CreateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const event = await createEvent(supabase, workspaceId, parsed.data)
+    return NextResponse.json(event, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+```
+
+- [ ] **Créer `app/api/calendar/events/[id]/route.ts`**
+
+```typescript
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { createClient, getUser } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { updateEvent, deleteEvent } from "@/lib/calendar"
+
+const UpdateSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().nullable().optional(),
+  start_at: z.string().datetime().optional(),
+  end_at: z.string().datetime().optional(),
+  event_type_id: z.string().uuid().nullable().optional(),
+  assignee_ids: z.array(z.string().uuid()).optional(),
+})
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const body = await req.json()
+    const parsed = UpdateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const updated = await updateEvent(supabase, id, parsed.data)
+    return NextResponse.json(updated)
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUser()
+    if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 })
+    const { role } = await requireWorkspace(user.id)
+    if (role !== "admin" && role !== "bureau") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+    }
+    const { id } = await params
+    const supabase = await createClient()
+    await deleteEvent(supabase, id)
+    return new NextResponse(null, { status: 204 })
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 })
+  }
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add app/api/calendar/events/
+git commit -m "feat: add calendar events API routes"
+```
+
+---
+
+## Task 8 : Composants de base (badge + chip)
+
+**Files:**
+- Create: `components/calendrier/event-type-badge.tsx`
+- Create: `components/calendrier/calendar-event-chip.tsx`
+
+- [ ] **Créer `components/calendrier/event-type-badge.tsx`**
+
+```tsx
+import type { CalendarEventType } from "@/types"
+
+export function EventTypeBadge({ type }: { type: CalendarEventType | null }) {
+  if (!type) return null
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-sm"
+      style={{
+        backgroundColor: type.color + "22",
+        color: type.color,
+        border: `1px solid ${type.color}44`,
+      }}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ backgroundColor: type.color }}
+      />
+      {type.label}
+    </span>
+  )
+}
+```
+
+- [ ] **Créer `components/calendrier/calendar-event-chip.tsx`**
+
+```tsx
+"use client"
+
+import type { CalendarEventWithDetails } from "@/types"
+import { format } from "date-fns"
+import { fr } from "date-fns/locale"
+
+interface CalendarEventChipProps {
+  event: CalendarEventWithDetails
+  onClick: (event: CalendarEventWithDetails) => void
+}
+
+export function CalendarEventChip({ event, onClick }: CalendarEventChipProps) {
+  const color = event.event_type?.color ?? "#6366f1"
+  const time = format(new Date(event.start_at), "HH:mm", { locale: fr })
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick(event)
+      }}
+      className="w-full text-left text-[11px] rounded-sm px-1.5 py-0.5 mb-0.5 leading-tight truncate font-medium transition-opacity hover:opacity-80"
+      style={{
+        backgroundColor: color + "22",
+        color: color,
+        borderLeft: `2px solid ${color}`,
+      }}
+      title={event.title}
+    >
+      <span className="opacity-70 mr-1">{time}</span>
+      {event.title}
+    </button>
+  )
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add components/calendrier/event-type-badge.tsx components/calendrier/calendar-event-chip.tsx
+git commit -m "feat: add CalendarEventChip and EventTypeBadge components"
+```
+
+---
+
+## Task 9 : CalendarHeader
+
+**Files:**
+- Create: `components/calendrier/calendar-header.tsx`
+
+- [ ] **Créer `components/calendrier/calendar-header.tsx`**
+
+```tsx
+"use client"
+
+import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { CalendarView } from "@/types"
+import {
+  format,
+  addMonths, subMonths,
+  addWeeks, subWeeks,
+  addDays, subDays,
+  startOfWeek, endOfWeek,
+} from "date-fns"
+import { fr } from "date-fns/locale"
+
+interface CalendarHeaderProps {
+  view: CalendarView
+  currentDate: Date
+  onViewChange: (view: CalendarView) => void
+  onDateChange: (date: Date) => void
+  onNewEvent?: () => void
+  canCreate?: boolean
+}
+
+const VIEWS: { value: CalendarView; label: string }[] = [
+  { value: "month", label: "Mois" },
+  { value: "week", label: "Semaine" },
+  { value: "day", label: "Jour" },
+]
+
+function getTitle(view: CalendarView, date: Date): string {
+  if (view === "month") return format(date, "MMMM yyyy", { locale: fr })
+  if (view === "week") {
+    const start = startOfWeek(date, { weekStartsOn: 1 })
+    const end = endOfWeek(date, { weekStartsOn: 1 })
+    return `${format(start, "d MMM", { locale: fr })} — ${format(end, "d MMM yyyy", { locale: fr })}`
+  }
+  return format(date, "EEEE d MMMM yyyy", { locale: fr })
+}
+
+function navigate(view: CalendarView, date: Date, direction: -1 | 1): Date {
+  if (view === "month") return direction === 1 ? addMonths(date, 1) : subMonths(date, 1)
+  if (view === "week") return direction === 1 ? addWeeks(date, 1) : subWeeks(date, 1)
+  return direction === 1 ? addDays(date, 1) : subDays(date, 1)
+}
+
+export function CalendarHeader({
+  view,
+  currentDate,
+  onViewChange,
+  onDateChange,
+  onNewEvent,
+  canCreate = false,
+}: CalendarHeaderProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      {/* Nav gauche */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => onDateChange(navigate(view, currentDate, -1))}
+          aria-label="Période précédente"
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <h2 className="min-w-[200px] text-center text-sm font-semibold capitalize text-foreground">
+          {getTitle(view, currentDate)}
+        </h2>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => onDateChange(navigate(view, currentDate, 1))}
+          aria-label="Période suivante"
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs h-8"
+          onClick={() => onDateChange(new Date())}
+        >
+          Aujourd'hui
+        </Button>
+      </div>
+
+      {/* Droite : toggle vue + bouton nouveau */}
+      <div className="flex items-center gap-2">
+        <div className="flex rounded-md border border-border overflow-hidden">
+          {VIEWS.map((v) => (
+            <button
+              key={v.value}
+              onClick={() => onViewChange(v.value)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                view === v.value
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {v.label}
+            </button>
+          ))}
+        </div>
+        {canCreate && onNewEvent && (
+          <Button size="sm" className="h-8 gap-1.5" onClick={onNewEvent}>
+            <CalendarDays className="size-3.5" />
+            Nouvel événement
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add components/calendrier/calendar-header.tsx
+git commit -m "feat: add CalendarHeader component with view toggle and navigation"
+```
+
+---
+
+## Task 10 : EventDialog (modale création/édition)
+
+**Files:**
+- Create: `components/calendrier/event-dialog.tsx`
+
+- [ ] **Créer `components/calendrier/event-dialog.tsx`**
+
+```tsx
+"use client"
+
+import { useState, useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { format } from "date-fns"
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select"
+import type { CalendarEventWithDetails, CalendarEventType } from "@/types"
+
+const Schema = z.object({
+  title: z.string().min(1, "Titre requis"),
+  date: z.string().min(1, "Date requise"),
+  start_time: z.string().min(1, "Heure de début requise"),
+  end_time: z.string().min(1, "Heure de fin requise"),
+  event_type_id: z.string().optional(),
+  description: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof Schema>
+
+interface WorkspaceUser {
+  id: string
+  email: string
+  role: string | null
+}
+
+interface EventDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  event?: CalendarEventWithDetails | null
+  defaultDate?: Date
+  eventTypes: CalendarEventType[]
+  workspaceUsers: WorkspaceUser[]
+  onSave: (data: {
+    title: string
+    description?: string | null
+    start_at: string
+    end_at: string
+    event_type_id?: string | null
+    assignee_ids: string[]
+  }) => Promise<void>
+  onDelete?: () => Promise<void>
+}
+
+export function EventDialog({
+  open,
+  onOpenChange,
+  event,
+  defaultDate,
+  eventTypes,
+  workspaceUsers,
+  onSave,
+  onDelete,
+}: EventDialogProps) {
+  const isEdit = !!event
+  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([])
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const defaultDateStr = defaultDate
+    ? format(defaultDate, "yyyy-MM-dd")
+    : format(new Date(), "yyyy-MM-dd")
+
+  const { register, handleSubmit, setValue, reset, formState: { errors } } =
+    useForm<FormValues>({
+      resolver: zodResolver(Schema),
+      defaultValues: {
+        title: "",
+        date: defaultDateStr,
+        start_time: "08:00",
+        end_time: "17:00",
+        event_type_id: "",
+        description: "",
+      },
+    })
+
+  useEffect(() => {
+    if (event) {
+      const start = new Date(event.start_at)
+      const end = new Date(event.end_at)
+      reset({
+        title: event.title,
+        date: format(start, "yyyy-MM-dd"),
+        start_time: format(start, "HH:mm"),
+        end_time: format(end, "HH:mm"),
+        event_type_id: event.event_type_id ?? "",
+        description: event.description ?? "",
+      })
+      setSelectedAssignees(event.assignees.map((a) => a.user_id))
+    } else {
+      reset({
+        title: "",
+        date: defaultDateStr,
+        start_time: "08:00",
+        end_time: "17:00",
+        event_type_id: "",
+        description: "",
+      })
+      setSelectedAssignees([])
+    }
+  }, [event, defaultDate, reset, defaultDateStr])
+
+  const toggleAssignee = (userId: string) => {
+    setSelectedAssignees((prev) =>
+      prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
+    )
+  }
+
+  const onSubmit = async (values: FormValues) => {
+    setSaving(true)
+    try {
+      const start_at = `${values.date}T${values.start_time}:00`
+      const end_at = `${values.date}T${values.end_time}:00`
+      await onSave({
+        title: values.title,
+        description: values.description || null,
+        start_at,
+        end_at,
+        event_type_id: values.event_type_id || null,
+        assignee_ids: selectedAssignees,
+      })
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!onDelete) return
+    setDeleting(true)
+    try {
+      await onDelete()
+      onOpenChange(false)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const ouvriers = workspaceUsers.filter((u) => u.role === "ouvrier")
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Modifier l'événement" : "Nouvel événement"}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Titre */}
+          <div className="space-y-1.5">
+            <Label htmlFor="title">Titre *</Label>
+            <Input id="title" autoFocus {...register("title")} placeholder="Nom de l'événement" />
+            {errors.title && <p className="text-xs text-destructive">{errors.title.message}</p>}
+          </div>
+
+          {/* Date */}
+          <div className="space-y-1.5">
+            <Label htmlFor="date">Date *</Label>
+            <Input id="date" type="date" {...register("date")} />
+            {errors.date && <p className="text-xs text-destructive">{errors.date.message}</p>}
+          </div>
+
+          {/* Heures */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="start_time">Début *</Label>
+              <Input id="start_time" type="time" {...register("start_time")} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="end_time">Fin *</Label>
+              <Input id="end_time" type="time" {...register("end_time")} />
+            </div>
+          </div>
+
+          {/* Type */}
+          <div className="space-y-1.5">
+            <Label>Type</Label>
+            <Select onValueChange={(v) => setValue("event_type_id", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choisir un type..." />
+              </SelectTrigger>
+              <SelectContent>
+                {eventTypes.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: t.color }}
+                      />
+                      {t.label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Ouvriers assignés */}
+          {ouvriers.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>Ouvriers assignés</Label>
+              <div className="flex flex-wrap gap-2">
+                {ouvriers.map((u) => {
+                  const selected = selectedAssignees.includes(u.id)
+                  return (
+                    <button
+                      key={u.id}
+                      type="button"
+                      onClick={() => toggleAssignee(u.id)}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                        selected
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "bg-background text-muted-foreground border-border hover:border-primary/50"
+                      }`}
+                    >
+                      {u.email.split("@")[0]}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="description">Description (optionnel)</Label>
+            <Textarea
+              id="description"
+              {...register("description")}
+              placeholder="Détails supplémentaires..."
+              rows={3}
+              className="resize-none"
+            />
+          </div>
+
+          <DialogFooter className="flex items-center justify-between gap-2 pt-2">
+            {isEdit && onDelete && (
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? "Suppression..." : "Supprimer"}
+              </Button>
+            )}
+            <div className="flex gap-2 ml-auto">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Annuler
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? "Enregistrement..." : isEdit ? "Enregistrer" : "Créer"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add components/calendrier/event-dialog.tsx
+git commit -m "feat: add EventDialog component for create/edit"
+```
+
+---
+
+## Task 11 : CalendarFilters
+
+**Files:**
+- Create: `components/calendrier/calendar-filters.tsx`
+
+- [ ] **Créer `components/calendrier/calendar-filters.tsx`**
+
+```tsx
+"use client"
+
+interface WorkspaceUser {
+  id: string
+  email: string
+  role: string | null
+}
+
+interface CalendarFiltersProps {
+  users: WorkspaceUser[]
+  selectedIds: string[]
+  onToggle: (id: string) => void
+  onClear: () => void
+}
+
+export function CalendarFilters({
+  users,
+  selectedIds,
+  onToggle,
+  onClear,
+}: CalendarFiltersProps) {
+  const ouvriers = users.filter((u) => u.role === "ouvrier")
+  if (ouvriers.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-muted-foreground shrink-0">Filtrer :</span>
+      <button
+        onClick={onClear}
+        className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+          selectedIds.length === 0
+            ? "bg-primary text-primary-foreground border-primary"
+            : "bg-background text-muted-foreground border-border hover:border-primary/50"
+        }`}
+      >
+        Tous
+      </button>
+      {ouvriers.map((u) => {
+        const selected = selectedIds.includes(u.id)
+        return (
+          <button
+            key={u.id}
+            onClick={() => onToggle(u.id)}
+            className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+              selected
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-background text-muted-foreground border-border hover:border-primary/50"
+            }`}
+          >
+            {u.email.split("@")[0]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add components/calendrier/calendar-filters.tsx
+git commit -m "feat: add CalendarFilters component"
+```
+
+---
+
+## Task 12 : CalendarGrid (mois + semaine + jour)
+
+**Files:**
+- Create: `components/calendrier/calendar-grid.tsx`
+
+- [ ] **Créer `components/calendrier/calendar-grid.tsx`**
+
+```tsx
+"use client"
+
+import {
+  startOfMonth, endOfMonth,
+  startOfWeek, endOfWeek,
+  eachDayOfInterval,
+  isSameMonth, isSameDay, isToday,
+  format, getHours, getMinutes,
+  addDays,
+} from "date-fns"
+import { fr } from "date-fns/locale"
+import type { CalendarEventWithDetails, CalendarView } from "@/types"
+import { CalendarEventChip } from "./calendar-event-chip"
+
+const MAX_CHIPS_MONTH = 3
+const WEEK_DAYS = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"]
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+
+interface CalendarGridProps {
+  view: CalendarView
+  currentDate: Date
+  events: CalendarEventWithDetails[]
+  onEventClick: (event: CalendarEventWithDetails) => void
+  onDayClick: (date: Date) => void
+}
+
+// ── Month view ───────────────────────────────────────────────────────────────
+
+function MonthView({ currentDate, events, onEventClick, onDayClick }: Omit<CalendarGridProps, "view">) {
+  const monthStart = startOfMonth(currentDate)
+  const monthEnd = endOfMonth(currentDate)
+  const gridStart = startOfWeek(monthStart, { weekStartsOn: 1 })
+  const gridEnd = endOfWeek(monthEnd, { weekStartsOn: 1 })
+  const days = eachDayOfInterval({ start: gridStart, end: gridEnd })
+
+  function eventsForDay(day: Date) {
+    return events.filter((e) => isSameDay(new Date(e.start_at), day))
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      {/* Header jours */}
+      <div className="grid grid-cols-7 border-b border-border">
+        {WEEK_DAYS.map((d) => (
+          <div key={d} className="py-2 text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Grille */}
+      <div className="grid grid-cols-7">
+        {days.map((day) => {
+          const dayEvents = eventsForDay(day)
+          const overflow = dayEvents.length - MAX_CHIPS_MONTH
+          const visibleEvents = dayEvents.slice(0, MAX_CHIPS_MONTH)
+          const isCurrentMonth = isSameMonth(day, currentDate)
+          const isCurrentDay = isToday(day)
+
+          return (
+            <div
+              key={day.toISOString()}
+              onClick={() => onDayClick(day)}
+              className={`min-h-[100px] p-1.5 border-r border-b border-border last:border-r-0 cursor-pointer transition-colors hover:bg-muted/30 ${
+                !isCurrentMonth ? "opacity-40" : ""
+              }`}
+            >
+              <div className="flex justify-end mb-1">
+                <span
+                  className={`text-xs font-medium w-6 h-6 flex items-center justify-center rounded-full ${
+                    isCurrentDay
+                      ? "bg-primary text-primary-foreground font-bold"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {format(day, "d")}
+                </span>
+              </div>
+
+              {visibleEvents.map((event) => (
+                <CalendarEventChip
+                  key={event.id}
+                  event={event}
+                  onClick={onEventClick}
+                />
+              ))}
+
+              {overflow > 0 && (
+                <p className="text-[10px] text-muted-foreground px-1 mt-0.5">
+                  +{overflow} autre{overflow > 1 ? "s" : ""}
+                </p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ── Week view ────────────────────────────────────────────────────────────────
+
+function WeekView({ currentDate, events, onEventClick, onDayClick }: Omit<CalendarGridProps, "view">) {
+  const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 })
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i))
+
+  function eventsForDay(day: Date) {
+    return events.filter((e) => isSameDay(new Date(e.start_at), day))
+  }
+
+  function getTopPercent(dateStr: string): number {
+    const d = new Date(dateStr)
+    return ((getHours(d) * 60 + getMinutes(d)) / (24 * 60)) * 100
+  }
+
+  function getHeightPercent(startStr: string, endStr: string): number {
+    const start = new Date(startStr)
+    const end = new Date(endStr)
+    const mins = (end.getTime() - start.getTime()) / 60000
+    return Math.max((mins / (24 * 60)) * 100, 2)
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      {/* Header */}
+      <div className="grid grid-cols-[48px_repeat(7,1fr)] border-b border-border">
+        <div />
+        {days.map((day) => (
+          <div
+            key={day.toISOString()}
+            onClick={() => onDayClick(day)}
+            className={`py-2 text-center cursor-pointer hover:bg-muted/30 ${isToday(day) ? "bg-primary/5" : ""}`}
+          >
+            <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+              {format(day, "EEE", { locale: fr })}
+            </p>
+            <p className={`text-sm font-semibold ${isToday(day) ? "text-primary" : "text-foreground"}`}>
+              {format(day, "d")}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Timeline */}
+      <div className="grid grid-cols-[48px_repeat(7,1fr)] overflow-y-auto max-h-[600px]">
+        {/* Heures */}
+        <div>
+          {HOURS.map((h) => (
+            <div key={h} className="h-14 border-b border-border/50 flex items-start justify-end pr-2 pt-1">
+              <span className="text-[10px] text-muted-foreground">{h.toString().padStart(2, "0")}h</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Colonnes jours */}
+        {days.map((day) => {
+          const dayEvents = eventsForDay(day)
+          return (
+            <div
+              key={day.toISOString()}
+              className="relative border-l border-border"
+              style={{ height: `${24 * 56}px` }}
+            >
+              {/* Lignes heures */}
+              {HOURS.map((h) => (
+                <div key={h} className="absolute w-full border-b border-border/30" style={{ top: `${h * 56}px`, height: "56px" }} />
+              ))}
+
+              {/* Événements positionnés */}
+              {dayEvents.map((event) => {
+                const top = getTopPercent(event.start_at)
+                const height = getHeightPercent(event.start_at, event.end_at)
+                const color = event.event_type?.color ?? "#6366f1"
+                return (
+                  <button
+                    key={event.id}
+                    onClick={(e) => { e.stopPropagation(); onEventClick(event) }}
+                    className="absolute left-0.5 right-0.5 rounded-sm px-1 py-0.5 text-left overflow-hidden hover:opacity-80 transition-opacity"
+                    style={{
+                      top: `${(top / 100) * 24 * 56}px`,
+                      height: `${Math.max((height / 100) * 24 * 56, 20)}px`,
+                      backgroundColor: color + "22",
+                      borderLeft: `2px solid ${color}`,
+                      color,
+                    }}
+                  >
+                    <p className="text-[10px] font-medium truncate leading-tight">{event.title}</p>
+                    <p className="text-[9px] opacity-70">{format(new Date(event.start_at), "HH:mm")}</p>
+                  </button>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ── Day view ─────────────────────────────────────────────────────────────────
+
+function DayView({ currentDate, events, onEventClick }: Omit<CalendarGridProps, "view" | "onDayClick">) {
+  const dayEvents = events.filter((e) => isSameDay(new Date(e.start_at), currentDate))
+
+  function getTopPx(dateStr: string): number {
+    const d = new Date(dateStr)
+    return (getHours(d) * 60 + getMinutes(d)) * (56 / 60)
+  }
+
+  function getHeightPx(startStr: string, endStr: string): number {
+    const mins = (new Date(endStr).getTime() - new Date(startStr).getTime()) / 60000
+    return Math.max(mins * (56 / 60), 20)
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      <div className="py-3 px-4 border-b border-border text-center">
+        <p className="text-sm font-semibold capitalize">
+          {format(currentDate, "EEEE d MMMM yyyy", { locale: fr })}
+        </p>
+        <p className="text-xs text-muted-foreground">{dayEvents.length} événement{dayEvents.length !== 1 ? "s" : ""}</p>
+      </div>
+
+      <div className="grid grid-cols-[48px_1fr] overflow-y-auto max-h-[600px]">
+        <div>
+          {HOURS.map((h) => (
+            <div key={h} className="h-14 border-b border-border/50 flex items-start justify-end pr-2 pt-1">
+              <span className="text-[10px] text-muted-foreground">{h.toString().padStart(2, "0")}h</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="relative border-l border-border" style={{ height: `${24 * 56}px` }}>
+          {HOURS.map((h) => (
+            <div key={h} className="absolute w-full border-b border-border/30" style={{ top: `${h * 56}px`, height: "56px" }} />
+          ))}
+          {dayEvents.map((event) => {
+            const color = event.event_type?.color ?? "#6366f1"
+            return (
+              <button
+                key={event.id}
+                onClick={() => onEventClick(event)}
+                className="absolute left-1 right-1 rounded-sm px-2 py-1 text-left overflow-hidden hover:opacity-80 transition-opacity"
+                style={{
+                  top: `${getTopPx(event.start_at)}px`,
+                  height: `${getHeightPx(event.start_at, event.end_at)}px`,
+                  backgroundColor: color + "22",
+                  borderLeft: `3px solid ${color}`,
+                  color,
+                }}
+              >
+                <p className="text-xs font-semibold truncate">{event.title}</p>
+                <p className="text-[10px] opacity-70">
+                  {format(new Date(event.start_at), "HH:mm")} → {format(new Date(event.end_at), "HH:mm")}
+                </p>
+                {event.description && (
+                  <p className="text-[10px] opacity-60 truncate mt-0.5">{event.description}</p>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Export ───────────────────────────────────────────────────────────────────
+
+export function CalendarGrid(props: CalendarGridProps) {
+  if (props.view === "month") return <MonthView {...props} />
+  if (props.view === "week") return <WeekView {...props} />
+  return <DayView {...props} onDayClick={() => {}} />
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add components/calendrier/calendar-grid.tsx
+git commit -m "feat: add CalendarGrid component (month/week/day views)"
+```
+
+---
+
+## Task 13 : Page calendrier bureau
+
+**Files:**
+- Create: `app/(bureau)/calendrier/page.tsx`
+- Create: `components/calendrier/calendar-client.tsx`
+- Create: `hooks/use-calendar-events.ts`
+
+- [ ] **Créer `app/(bureau)/calendrier/page.tsx`**
+
+```tsx
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { CalendarDays } from "lucide-react"
+import { getUser, getUserRole } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { supabaseService } from "@/lib/supabase/service"
+import { createClient } from "@/lib/supabase/server"
+import { getEventTypes } from "@/lib/calendar-event-types"
+import { CalendarClient } from "@/components/calendrier/calendar-client"
+
+export const metadata: Metadata = {
+  title: "Calendrier — BTP×AI",
+}
+
+export default async function CalendrierPage() {
+  const user = await getUser()
+  if (!user) redirect("/login")
+  const role = getUserRole(user)
+  if (role !== "admin" && role !== "bureau") redirect("/profil")
+
+  const { workspaceId } = await requireWorkspace(user.id)
+  const supabase = await createClient()
+  const eventTypes = await getEventTypes(supabase, workspaceId).catch(() => [])
+
+  const { data: usersData } = await supabaseService.auth.admin.listUsers({ perPage: 200 })
+  const workspaceUsers = (usersData?.users ?? [])
+    .filter((u) => {
+      const r = u.user_metadata?.role
+      return r === "ouvrier" || r === "bureau" || r === "admin"
+    })
+    .map((u) => ({
+      id: u.id,
+      email: u.email ?? "",
+      role: (u.user_metadata?.role as string) ?? null,
+    }))
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <CalendarDays className="size-3.5 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground tracking-wider uppercase">
+              Planification
+            </span>
+          </div>
+          <h1 className="font-heading text-3xl font-700 tracking-wide uppercase text-foreground">
+            Calendrier
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Planning de l'entreprise — chantiers, RDV et interventions
+          </p>
+        </div>
+      </div>
+
+      <CalendarClient
+        eventTypes={eventTypes}
+        workspaceUsers={workspaceUsers}
+        canCreate
+        canFilter
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Créer `components/calendrier/calendar-client.tsx`** (orchestrateur client-side)
+
+```tsx
+"use client"
+
+import { useState, useCallback } from "react"
+import {
+  startOfMonth, endOfMonth,
+  startOfWeek, endOfWeek,
+  addDays,
+  format,
+} from "date-fns"
+import type { CalendarEventWithDetails, CalendarEventType, CalendarView } from "@/types"
+import { CalendarHeader } from "./calendar-header"
+import { CalendarFilters } from "./calendar-filters"
+import { CalendarGrid } from "./calendar-grid"
+import { EventDialog } from "./event-dialog"
+import { useCalendarEvents } from "@/hooks/use-calendar-events"
+
+interface WorkspaceUser { id: string; email: string; role: string | null }
+
+interface CalendarClientProps {
+  eventTypes: CalendarEventType[]
+  workspaceUsers: WorkspaceUser[]
+  canCreate?: boolean
+  canFilter?: boolean
+}
+
+function getRange(view: CalendarView, date: Date): { from: string; to: string } {
+  if (view === "month") {
+    const start = startOfWeek(startOfMonth(date), { weekStartsOn: 1 })
+    const end = endOfWeek(endOfMonth(date), { weekStartsOn: 1 })
+    return { from: start.toISOString(), to: end.toISOString() }
+  }
+  if (view === "week") {
+    const start = startOfWeek(date, { weekStartsOn: 1 })
+    const end = endOfWeek(date, { weekStartsOn: 1 })
+    return { from: start.toISOString(), to: end.toISOString() }
+  }
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const end = addDays(start, 1)
+  return { from: start.toISOString(), to: end.toISOString() }
+}
+
+export function CalendarClient({
+  eventTypes,
+  workspaceUsers,
+  canCreate = false,
+  canFilter = false,
+}: CalendarClientProps) {
+  const [view, setView] = useState<CalendarView>("month")
+  const [currentDate, setCurrentDate] = useState(new Date())
+  const [filterIds, setFilterIds] = useState<string[]>([])
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEventWithDetails | null>(null)
+  const [clickedDate, setClickedDate] = useState<Date | undefined>()
+
+  const { from, to } = getRange(view, currentDate)
+  const assigneeId = filterIds.length === 1 ? filterIds[0] : undefined
+
+  const { events, refresh } = useCalendarEvents({ from, to, assigneeId })
+
+  // Client-side filter for multiple selected ouvriers
+  const filteredEvents = filterIds.length > 0
+    ? events.filter((e) =>
+        e.assignees.some((a) => filterIds.includes(a.user_id))
+      )
+    : events
+
+  const handleEventClick = useCallback((event: CalendarEventWithDetails) => {
+    setSelectedEvent(event)
+    setDialogOpen(true)
+  }, [])
+
+  const handleDayClick = useCallback((date: Date) => {
+    if (!canCreate) return
+    setSelectedEvent(null)
+    setClickedDate(date)
+    setDialogOpen(true)
+  }, [canCreate])
+
+  const handleSave = async (data: {
+    title: string
+    description?: string | null
+    start_at: string
+    end_at: string
+    event_type_id?: string | null
+    assignee_ids: string[]
+  }) => {
+    const url = selectedEvent
+      ? `/api/calendar/events/${selectedEvent.id}`
+      : "/api/calendar/events"
+    const method = selectedEvent ? "PUT" : "POST"
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) throw new Error("Erreur lors de l'enregistrement")
+    await refresh()
+  }
+
+  const handleDelete = async () => {
+    if (!selectedEvent) return
+    await fetch(`/api/calendar/events/${selectedEvent.id}`, { method: "DELETE" })
+    await refresh()
+  }
+
+  return (
+    <div className="space-y-4">
+      <CalendarHeader
+        view={view}
+        currentDate={currentDate}
+        onViewChange={setView}
+        onDateChange={setCurrentDate}
+        canCreate={canCreate}
+        onNewEvent={() => {
+          setSelectedEvent(null)
+          setClickedDate(currentDate)
+          setDialogOpen(true)
+        }}
+      />
+
+      {canFilter && (
+        <CalendarFilters
+          users={workspaceUsers}
+          selectedIds={filterIds}
+          onToggle={(id) =>
+            setFilterIds((prev) =>
+              prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+            )
+          }
+          onClear={() => setFilterIds([])}
+        />
+      )}
+
+      <CalendarGrid
+        view={view}
+        currentDate={currentDate}
+        events={filteredEvents}
+        onEventClick={handleEventClick}
+        onDayClick={handleDayClick}
+      />
+
+      <EventDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        event={selectedEvent}
+        defaultDate={clickedDate}
+        eventTypes={eventTypes}
+        workspaceUsers={workspaceUsers}
+        onSave={handleSave}
+        onDelete={selectedEvent ? handleDelete : undefined}
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Créer `hooks/use-calendar-events.ts`**
+
+```typescript
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type { CalendarEventWithDetails } from "@/types"
+
+interface UseCalendarEventsOptions {
+  from: string
+  to: string
+  assigneeId?: string
+}
+
+export function useCalendarEvents({ from, to, assigneeId }: UseCalendarEventsOptions) {
+  const [events, setEvents] = useState<CalendarEventWithDetails[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchEvents = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams({ from, to })
+      if (assigneeId) params.set("assigneeId", assigneeId)
+      const res = await fetch(`/api/calendar/events?${params}`)
+      if (!res.ok) return
+      const data = await res.json()
+      setEvents(data)
+    } finally {
+      setLoading(false)
+    }
+  }, [from, to, assigneeId])
+
+  useEffect(() => {
+    fetchEvents()
+  }, [fetchEvents])
+
+  return { events, loading, refresh: fetchEvents }
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add app/(bureau)/calendrier/ components/calendrier/calendar-client.tsx hooks/use-calendar-events.ts
+git commit -m "feat: add bureau calendar page and CalendarClient orchestrator"
+```
+
+---
+
+## Task 14 : Page calendrier terrain (ouvrier)
+
+**Files:**
+- Create: `app/(terrain)/terrain/calendrier/page.tsx`
+
+- [ ] **Créer `app/(terrain)/terrain/calendrier/page.tsx`**
+
+```tsx
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { CalendarDays } from "lucide-react"
+import { getUser, getUserRole } from "@/lib/supabase/server"
+import { createClient } from "@/lib/supabase/server"
+import { requireWorkspace } from "@/lib/workspaces"
+import { getEventTypes } from "@/lib/calendar-event-types"
+import { CalendarClient } from "@/components/calendrier/calendar-client"
+
+export const metadata: Metadata = {
+  title: "Mon planning — BTP×AI",
+}
+
+export default async function TerrainCalendrierPage() {
+  const user = await getUser()
+  if (!user) redirect("/login")
+  const role = getUserRole(user)
+  if (role !== "ouvrier" && role !== "admin") redirect("/profil")
+
+  const { workspaceId } = await requireWorkspace(user.id)
+  const supabase = await createClient()
+  const eventTypes = await getEventTypes(supabase, workspaceId).catch(() => [])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 bg-background border-b border-border px-4 pt-safe-top">
+        <div className="flex items-center gap-3 py-4">
+          <CalendarDays className="size-5 text-muted-foreground" />
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.25em] text-muted-foreground">
+              BTP×AI — Terrain
+            </p>
+            <h1
+              className="text-2xl font-bold uppercase tracking-wide text-foreground leading-none"
+              style={{ fontFamily: "var(--font-barlow)" }}
+            >
+              Mon planning
+            </h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="px-4 py-4">
+        <CalendarClient
+          eventTypes={eventTypes}
+          workspaceUsers={[]}
+          canCreate={false}
+          canFilter={false}
+        />
+      </main>
+    </div>
+  )
+}
+```
+
+- [ ] **Commit**
+
+```bash
+git add app/(terrain)/terrain/calendrier/
+git commit -m "feat: add terrain calendar page (read-only, assigned events)"
+```
+
+---
+
+## Task 15 : Sidebar nav — entrée Calendrier
+
+**Files:**
+- Modify: `components/layout/sidebar-nav.tsx`
+
+- [ ] **Ajouter CalendarDays dans les imports et l'entrée Calendrier dans `bureauNavBase`**
+
+Dans `components/layout/sidebar-nav.tsx`, ligne 1 — ajouter `CalendarDays` aux imports :
+
+```typescript
+import {
+  LayoutDashboard,
+  FileText,
+  Users,
+  Mail,
+  Settings,
+  HardHat,
+  Package,
+  AlertTriangle,
+  CalendarDays,       // ← ajouter
+} from "lucide-react"
+```
+
+Dans `bureauNavBase`, après `{ href: "/materiaux", ... }` et avant `{ href: "/alertes", ... }` :
+
+```typescript
+  { href: "/calendrier", label: "Calendrier", icon: CalendarDays },
+```
+
+- [ ] **Vérifier visuellement que l'entrée apparaît bien**
+
+```bash
+npm run dev
+```
+
+Ouvrir http://localhost:3000 et vérifier la sidebar.
+
+- [ ] **Commit**
+
+```bash
+git add components/layout/sidebar-nav.tsx
+git commit -m "feat: add Calendrier entry to sidebar nav"
+```
+
+---
+
+## Task 16 : Paramètres — section Types d'événements
+
+**Files:**
+- Create: `components/parametres/event-types-section.tsx`
+- Modify: `app/(bureau)/parametres/page.tsx`
+- Modify: `components/parametres/settings-shell.tsx`
+
+- [ ] **Créer `components/parametres/event-types-section.tsx`**
+
+```tsx
+"use client"
+
+import { useState } from "react"
+import { Plus, Pencil, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { CalendarEventType } from "@/types"
+
+interface EventTypesSectionProps {
+  initialTypes: CalendarEventType[]
+}
+
+const COLOR_PRESETS = [
+  "#3b82f6", "#ec4899", "#8b5cf6", "#f97316",
+  "#06b6d4", "#f59e0b", "#22c55e", "#6b7280", "#a3a3a3",
+]
+
+export function EventTypesSection({ initialTypes }: EventTypesSectionProps) {
+  const [types, setTypes] = useState(initialTypes)
+  const [showAdd, setShowAdd] = useState(false)
+  const [newLabel, setNewLabel] = useState("")
+  const [newColor, setNewColor] = useState(COLOR_PRESETS[0])
+  const [saving, setSaving] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editLabel, setEditLabel] = useState("")
+  const [editColor, setEditColor] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const handleAdd = async () => {
+    if (!newLabel.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/calendar/event-types", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: newLabel.trim(), color: newColor }),
+      })
+      if (!res.ok) throw new Error("Erreur lors de la création")
+      const created = await res.json()
+      setTypes((prev) => [...prev, created])
+      setNewLabel("")
+      setNewColor(COLOR_PRESETS[0])
+      setShowAdd(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleUpdate = async (id: string) => {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/calendar/event-types/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: editLabel, color: editColor }),
+      })
+      if (!res.ok) throw new Error("Erreur")
+      const updated = await res.json()
+      setTypes((prev) => prev.map((t) => (t.id === id ? updated : t)))
+      setEditingId(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setError(null)
+    const res = await fetch(`/api/calendar/event-types/${id}`, { method: "DELETE" })
+    if (res.status === 409) {
+      setError("Ce type est utilisé par des événements existants et ne peut pas être supprimé.")
+      return
+    }
+    if (!res.ok) { setError("Erreur lors de la suppression"); return }
+    setTypes((prev) => prev.filter((t) => t.id !== id))
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Types d'événements</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Catégories disponibles lors de la création d'un événement calendrier
+          </p>
+        </div>
+        {!showAdd && (
+          <Button size="sm" variant="outline" onClick={() => setShowAdd(true)}>
+            <Plus className="size-3.5 mr-1" />
+            Ajouter
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-xs text-destructive bg-destructive/10 px-3 py-2 rounded-md">{error}</p>
+      )}
+
+      {showAdd && (
+        <div className="flex items-end gap-3 p-3 border border-border rounded-md bg-muted/30">
+          <div className="flex-1 space-y-1.5">
+            <Label className="text-xs">Nom</Label>
+            <Input
+              autoFocus
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              placeholder="Ex: Réunion fournisseur"
+              className="h-8 text-sm"
+              onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs">Couleur</Label>
+            <div className="flex gap-1.5">
+              {COLOR_PRESETS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setNewColor(c)}
+                  className={`w-5 h-5 rounded-full transition-transform hover:scale-110 ${
+                    newColor === c ? "ring-2 ring-offset-1 ring-foreground scale-110" : ""
+                  }`}
+                  style={{ backgroundColor: c }}
+                />
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)}>Annuler</Button>
+            <Button size="sm" onClick={handleAdd} disabled={saving || !newLabel.trim()}>
+              {saving ? "..." : "Créer"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        {types.map((t) => (
+          <div key={t.id} className="flex items-center gap-3 px-3 py-2 rounded-md border border-border hover:bg-muted/20">
+            {editingId === t.id ? (
+              <>
+                <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: editColor }} />
+                <Input
+                  value={editLabel}
+                  onChange={(e) => setEditLabel(e.target.value)}
+                  className="h-7 text-sm flex-1"
+                  onKeyDown={(e) => e.key === "Enter" && handleUpdate(t.id)}
+                />
+                <div className="flex gap-1">
+                  {COLOR_PRESETS.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      onClick={() => setEditColor(c)}
+                      className={`w-4 h-4 rounded-full ${editColor === c ? "ring-2 ring-offset-1 ring-foreground" : ""}`}
+                      style={{ backgroundColor: c }}
+                    />
+                  ))}
+                </div>
+                <Button size="sm" variant="ghost" onClick={() => setEditingId(null)}>Annuler</Button>
+                <Button size="sm" onClick={() => handleUpdate(t.id)} disabled={saving}>OK</Button>
+              </>
+            ) : (
+              <>
+                <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: t.color }} />
+                <span className="text-sm flex-1">{t.label}</span>
+                {t.is_preset && (
+                  <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                    preset
+                  </span>
+                )}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={() => { setEditingId(t.id); setEditLabel(t.label); setEditColor(t.color) }}
+                >
+                  <Pencil className="size-3" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                  onClick={() => handleDelete(t.id)}
+                >
+                  <Trash2 className="size-3" />
+                </Button>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Modifier `app/(bureau)/parametres/page.tsx`** — ajouter le chargement des types
+
+Ajouter dans les imports :
+```typescript
+import { getEventTypes } from "@/lib/calendar-event-types"
+```
+
+Dans le `Promise.all`, ajouter en fin de liste :
+```typescript
+getEventTypes(supabase, workspaceId).catch(() => []),
+```
+
+Destructurer le résultat supplémentaire :
+```typescript
+const [..., eventTypes] = await Promise.all([...])
+```
+
+Passer au composant `SettingsShell` :
+```tsx
+<SettingsShell
+  ...props existants...
+  eventTypes={eventTypes}
+/>
+```
+
+- [ ] **Modifier `components/parametres/settings-shell.tsx`** — ajouter la section dans l'onglet Entreprise
+
+**Imports** — ajouter en haut du fichier (après les imports existants) :
+```typescript
+import { EventTypesSection } from "./event-types-section"
+import type { CalendarEventType } from "@/types"
+```
+
+**Type `Props`** — ajouter le champ `eventTypes` :
+```typescript
+type Props = {
+  settings: Record<string, string>
+  connections: GmailConnectionSummary[]
+  imapConnections: ImapConnectionSummary[]
+  gmailParam?: string
+  autoAckEnabled: boolean
+  lastSyncAt: string | null
+  users: AdminUser[]
+  eventTypes: CalendarEventType[]        // ← ajouter
+}
+```
+
+**Destructuration** dans `export function SettingsShell({ ..., users }: Props)` — ajouter `eventTypes` :
+```typescript
+export function SettingsShell({
+  settings,
+  connections,
+  imapConnections,
+  gmailParam,
+  autoAckEnabled,
+  lastSyncAt,
+  users,
+  eventTypes,       // ← ajouter
+}: Props) {
+```
+
+**Contenu** — dans le bloc `{activeTab === "entreprise" && (`, après `<QuoteConditionsSection ... />` et avant la fermeture `</>` :
+```tsx
+<section className="rounded-lg border border-border p-6">
+  <EventTypesSection initialTypes={eventTypes} />
+</section>
+```
+
+- [ ] **Commit**
+
+```bash
+git add components/parametres/event-types-section.tsx app/(bureau)/parametres/page.tsx components/parametres/settings-shell.tsx
+git commit -m "feat: add event types management in parametres"
+```
+
+---
+
+## Task 17 : Seed des types par défaut
+
+**Files:**
+- Modify: `scripts/seed-admin.ts` (ou créer un script dédié)
+
+Les presets doivent être disponibles pour tout nouveau workspace. Deux approches :
+1. Appeler `seedDefaultEventTypes` dans le script de seed existant
+2. L'appeler lors de la création d'un workspace (si un tel flux existe)
+
+- [ ] **Ajouter le seed dans `scripts/seed-admin.ts`**
+
+Localiser la fin du script de seed. Ajouter après la création du workspace :
+
+```typescript
+import { seedDefaultEventTypes } from "@/lib/calendar-event-types"
+
+// Après avoir récupéré le workspaceId...
+const { supabaseService } = await import("@/lib/supabase/service")
+await seedDefaultEventTypes(supabaseService, workspaceId)
+console.log("✅ Types d'événements par défaut créés")
+```
+
+- [ ] **Pour les workspaces existants**, exécuter manuellement dans le SQL Editor Supabase :
+
+```sql
+-- Remplacer 'YOUR_WORKSPACE_ID' par le vrai UUID
+SELECT id FROM workspaces LIMIT 5; -- trouver le bon ID
+
+INSERT INTO calendar_event_types (workspace_id, label, color, is_preset) VALUES
+('YOUR_WORKSPACE_ID', 'Chantier / Travaux',     '#3b82f6', true),
+('YOUR_WORKSPACE_ID', 'Rendez-vous client',      '#ec4899', true),
+('YOUR_WORKSPACE_ID', 'Visite pré-chantier',     '#8b5cf6', true),
+('YOUR_WORKSPACE_ID', 'Livraison matériaux',     '#f97316', true),
+('YOUR_WORKSPACE_ID', 'Réunion d''équipe',       '#06b6d4', true),
+('YOUR_WORKSPACE_ID', 'Formation / Sécurité',    '#f59e0b', true),
+('YOUR_WORKSPACE_ID', 'Réception de chantier',   '#22c55e', true),
+('YOUR_WORKSPACE_ID', 'Permanence / Astreinte',  '#6b7280', true),
+('YOUR_WORKSPACE_ID', 'Administratif',           '#a3a3a3', true)
+ON CONFLICT DO NOTHING;
+```
+
+- [ ] **Commit**
+
+```bash
+git add scripts/seed-admin.ts
+git commit -m "feat: seed default calendar event types on workspace creation"
+```
+
+---
+
+## Task 18 : Tests Vitest
+
+**Files:**
+- Already created: `lib/calendar-event-types.test.ts`, `lib/calendar.test.ts`
+
+- [ ] **Lancer tous les tests unitaires**
+
+```bash
+npm run test
+```
+
+Expected: tous les tests PASS.
+
+- [ ] **Ajouter un test pour `getEvents` avec filtre assigneeId**
+
+Dans `lib/calendar.test.ts`, ajouter :
+
+```typescript
+describe("getEvents with assigneeId filter", () => {
+  it("filters events client-side by assignee", async () => {
+    const events = [
+      { id: "ev-1", title: "E1", start_at: "2026-05-11T08:00:00Z", assignees: [{ user_id: "u-1" }] },
+      { id: "ev-2", title: "E2", start_at: "2026-05-11T09:00:00Z", assignees: [{ user_id: "u-2" }] },
+    ]
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: events, error: null }),
+      }),
+    })
+    const result = await getEvents(supabase, "ws-1", {
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-31T23:59:59Z",
+      assigneeId: "u-1",
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("ev-1")
+  })
+})
+```
+
+- [ ] **Relancer**
+
+```bash
+npm run test -- lib/calendar.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Commit**
+
+```bash
+git add lib/calendar.test.ts
+git commit -m "test: add assigneeId filter test for getEvents"
+```
+
+---
+
+## Task 19 : Tests Cypress E2E
+
+**Files:**
+- Create: `cypress/e2e/calendar.cy.ts`
+
+- [ ] **Créer `cypress/e2e/calendar.cy.ts`**
+
+```typescript
+describe("Calendrier — Bureau", () => {
+  beforeEach(() => {
+    cy.setCookie("cypress-test-user", "bureau")
+    cy.visit("/calendrier")
+  })
+
+  it("affiche la page calendrier avec la grille mensuelle", () => {
+    cy.contains("h1", "Calendrier").should("be.visible")
+    cy.contains("button", "Mois").should("have.class", "bg-primary")
+    // Jours de la semaine
+    cy.contains("Lun").should("be.visible")
+    cy.contains("Dim").should("be.visible")
+  })
+
+  it("navigue vers le mois suivant via la flèche →", () => {
+    const currentMonth = new Date().toLocaleString("fr-FR", { month: "long" })
+    cy.get('[aria-label="Période suivante"]').click()
+    cy.contains(currentMonth).should("not.exist")
+  })
+
+  it("revient à aujourd'hui avec le bouton Aujourd'hui", () => {
+    cy.get('[aria-label="Période suivante"]').click()
+    cy.contains("button", "Aujourd'hui").click()
+    const currentMonth = new Date().toLocaleString("fr-FR", { month: "long" })
+    cy.contains(currentMonth).should("be.visible")
+  })
+
+  it("change de vue vers Semaine", () => {
+    cy.contains("button", "Semaine").click()
+    cy.contains("button", "Semaine").should("have.class", "bg-primary")
+  })
+
+  it("change de vue vers Jour", () => {
+    cy.contains("button", "Jour").click()
+    cy.contains("button", "Jour").should("have.class", "bg-primary")
+  })
+
+  it("ouvre la modale de création en cliquant sur Nouvel événement", () => {
+    cy.contains("button", "Nouvel événement").click()
+    cy.contains("Nouvel événement").should("be.visible")
+    cy.get("input#title").should("be.focused")
+  })
+
+  it("ferme la modale avec Annuler", () => {
+    cy.contains("button", "Nouvel événement").click()
+    cy.contains("button", "Annuler").click()
+    cy.get("input#title").should("not.exist")
+  })
+})
+
+describe("Calendrier — Ouvrier", () => {
+  beforeEach(() => {
+    cy.setCookie("cypress-test-user", "ouvrier")
+    cy.visit("/terrain/calendrier")
+  })
+
+  it("affiche le planning avec le titre Mon planning", () => {
+    cy.contains("Mon planning").should("be.visible")
+  })
+
+  it("n'affiche pas de bouton Nouvel événement", () => {
+    cy.contains("button", "Nouvel événement").should("not.exist")
+  })
+
+  it("n'affiche pas les filtres par ouvrier", () => {
+    cy.contains("Filtrer :").should("not.exist")
+  })
+})
+```
+
+- [ ] **Lancer les tests Cypress**
+
+```bash
+npm run test:e2e
+```
+
+Expected: tous les tests PASS.
+
+- [ ] **Commit**
+
+```bash
+git add cypress/e2e/calendar.cy.ts
+git commit -m "test: add Cypress E2E tests for calendar feature"
+```
+
+---
+
+## Task 20 : Vérification finale et PR
+
+- [ ] **Vérifier le build TypeScript sans erreurs**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0 errors.
+
+- [ ] **Lancer tous les tests unitaires**
+
+```bash
+npm run test
+```
+
+Expected: PASS.
+
+- [ ] **Tester manuellement en dev**
+
+```bash
+npm run dev
+```
+
+Vérifier :
+- [ ] Sidebar affiche "Calendrier" entre "Matériaux" et "Alertes"
+- [ ] `/calendrier` charge la grille mensuelle
+- [ ] Navigation ← → change le mois/semaine/jour
+- [ ] Clic "Nouvel événement" → modale avec autofocus sur titre
+- [ ] Création d'un événement → apparaît dans la grille
+- [ ] Clic sur un événement → modale en mode édition avec bouton Supprimer
+- [ ] Vue ouvrier `/terrain/calendrier` → pas de bouton créer ni de filtres
+- [ ] `/parametres` → section Types d'événements avec les presets listés
+
+- [ ] **Créer la PR**
+
+```bash
+gh pr create \
+  --title "feat: add company calendar with month/week/day views" \
+  --body "Closes #<issue>
+
+## Summary
+- Nouveau calendrier d'entreprise avec vues mois, semaine et jour
+- Événements typés et colorés, assignation d'ouvriers multiple
+- Filtre par ouvrier pour les rôles bureau/admin
+- Gestion des types d'événements dans les paramètres (9 presets + ajout custom)
+- Vue lecture seule pour les ouvriers (events assignés uniquement)
+
+## Test plan
+- \`npm run test\` — tests unitaires CRUD
+- \`npm run test:e2e\` — Cypress bureau + ouvrier
+- Test manuel : créer un événement, filtrer, naviguer, gérer les types
+" \
+  --base main
+```

--- a/docs/superpowers/specs/2026-05-11-calendar-design.md
+++ b/docs/superpowers/specs/2026-05-11-calendar-design.md
@@ -1,0 +1,228 @@
+# Calendrier d'entreprise — Design Spec
+
+**Date :** 2026-05-11  
+**Statut :** Approuvé
+
+---
+
+## Contexte
+
+L'entreprise de métallerie gère des chantiers, des RDV clients, des livraisons et des interventions terrain impliquant plusieurs ouvriers. Aujourd'hui il n'existe aucun outil dans l'application pour planifier et visualiser ces événements. Les utilisateurs bureau et admin ont besoin d'une vue d'ensemble du planning de l'entreprise, et les ouvriers ont besoin de voir uniquement les événements qui les concernent.
+
+---
+
+## Fonctionnalités
+
+### Événements
+
+Un événement comprend :
+- **Titre** (obligatoire)
+- **Date** (obligatoire)
+- **Heure de début** (obligatoire, `timestamptz`)
+- **Heure de fin** (obligatoire, `timestamptz`)
+- **Type** (obligatoire, lié à `calendar_event_types`)
+- **Ouvriers assignés** (1 ou plusieurs, table de jointure)
+- **Description** (optionnel, textarea)
+
+### Vues
+
+Trois vues disponibles via des boutons toggle :
+- **Mois** : grille 7 colonnes, étiquettes colorées par type avec titre tronqué, `+N autres` si overflow
+- **Semaine** : 7 colonnes avec créneaux horaires, événements positionnés selon durée
+- **Jour** : colonne unique, timeline heure par heure
+
+Navigation via boutons `←` / `→` pour aller au mois/semaine/jour précédent ou suivant. Bouton `Aujourd'hui` pour revenir à la date courante.
+
+### Permissions
+
+| Rôle | Accès | Filtre |
+|------|-------|--------|
+| `admin`, `bureau` | Tous les événements du workspace | Peut filtrer par ouvrier |
+| `ouvrier` | Uniquement les événements où il est assigné | Aucun filtre |
+
+### Types d'événements
+
+Configurables par les admins depuis les paramètres (`/parametres` → section "Types d'événements"). Chaque type a un label et une couleur hex.
+
+**Presets fournis à la création du workspace :**
+1. Chantier / Travaux
+2. Rendez-vous client
+3. Visite pré-chantier
+4. Livraison matériaux
+5. Réunion d'équipe
+6. Formation / Sécurité
+7. Réception de chantier
+8. Permanence / Astreinte
+9. Administratif
+
+Les admins peuvent ajouter de nouveaux types, renommer ou supprimer (suppression bloquée si des événements utilisent le type).
+
+---
+
+## Architecture
+
+### Schéma base de données
+
+```sql
+-- Types d'événements configurables par workspace
+CREATE TABLE calendar_event_types (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  label text NOT NULL,
+  color text NOT NULL,          -- couleur hex ex: "#6366f1"
+  is_preset boolean DEFAULT false,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Événements du calendrier
+CREATE TABLE calendar_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text,
+  start_at timestamptz NOT NULL,
+  end_at timestamptz NOT NULL,
+  event_type_id uuid REFERENCES calendar_event_types(id) ON DELETE SET NULL,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz DEFAULT now()
+);
+
+-- Ouvriers assignés à un événement (N-N)
+CREATE TABLE calendar_event_assignees (
+  event_id uuid NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  PRIMARY KEY (event_id, user_id)
+);
+```
+
+**RLS :**
+- `bureau`/`admin` : voient tous les événements du workspace
+- `ouvrier` : voient uniquement les événements où `user_id` apparaît dans `calendar_event_assignees`
+- Création/modification/suppression : `bureau` et `admin` uniquement
+
+### Routes Next.js
+
+```
+app/(bureau)/calendrier/page.tsx                    — calendrier bureau/admin
+app/(terrain)/terrain/calendrier/page.tsx           — calendrier ouvrier (filtré)
+app/(bureau)/parametres/                            — section types ajoutée ici
+app/api/calendar/events/route.ts                    — GET, POST
+app/api/calendar/events/[id]/route.ts               — PUT, DELETE
+app/api/calendar/event-types/route.ts               — GET, POST
+app/api/calendar/event-types/[id]/route.ts          — PUT, DELETE
+```
+
+### Composants
+
+```
+components/calendrier/
+  calendar-grid.tsx           — grille principale (mois/semaine/jour), reçoit events[]
+  calendar-header.tsx         — navigation ← → + toggle Mois/Sem/Jour + bouton Aujourd'hui
+  calendar-event-chip.tsx     — étiquette colorée dans la grille (titre tronqué, type color)
+  calendar-filters.tsx        — filtre par ouvrier (bureau/admin uniquement)
+  event-dialog.tsx            — modale Dialog création/édition événement
+  event-type-badge.tsx        — badge coloré avec label du type
+```
+
+### Lib / CRUD
+
+```
+lib/calendar.ts
+  getEvents(supabase, workspaceId, filters)       — avec filtre période + ouvrier
+  getEvent(supabase, id)
+  createEvent(supabase, workspaceId, input)
+  updateEvent(supabase, id, input)
+  deleteEvent(supabase, id)
+
+lib/calendar-event-types.ts
+  getEventTypes(supabase, workspaceId)
+  createEventType(supabase, workspaceId, input)
+  updateEventType(supabase, id, input)
+  deleteEventType(supabase, id)                   — erreur si type utilisé
+  seedDefaultEventTypes(supabase, workspaceId)    — appelé à la création workspace
+```
+
+---
+
+## UI / UX
+
+### Affichage des événements (vue mois)
+
+- Étiquettes colorées avec titre visible directement dans chaque case-jour
+- La couleur de bordure gauche et du fond correspond au type d'événement
+- Si plus de 3 événements sur un jour : afficher les 2 premiers + `+N autres` cliquable
+- Clic sur une étiquette → ouvre la modale en mode édition
+- Clic sur une case vide → ouvre la modale en mode création (date pré-remplie)
+
+### Navigation
+
+```
+[← ] [ Mai 2025 ] [ →]    [Aujourd'hui]       [Mois] [Semaine] [Jour]
+```
+
+### Filtre par ouvrier (bureau/admin)
+
+Chips cliquables avec avatar + prénom. Sélection multiple. "Tous" par défaut. Quand plusieurs ouvriers sont sélectionnés, le filtre est inclusif (OR) : affiche les événements où **au moins un** des ouvriers sélectionnés est assigné.
+
+### Modale création/édition
+
+Champs dans l'ordre :
+1. Titre (input text, autofocus)
+2. Date (date picker)
+3. Heure début / Heure fin (côte à côte)
+4. Type (select avec aperçu couleur)
+5. Ouvriers assignés (combobox multi-select avec avatars)
+6. Description (textarea, optionnel)
+
+Actions : `Annuler` + `Créer` (ou `Enregistrer` en édition). En mode édition, bouton `Supprimer` en rouge en bas à gauche.
+
+### Sidebar
+
+Nouvelle entrée `Calendrier` avec icône `CalendarDays` ajoutée dans `components/layout/sidebar-nav.tsx`, entre "Matériaux" et "Alertes".
+
+### Vue ouvrier
+
+Route `/terrain/calendrier` — même interface mais :
+- Filtre par ouvrier masqué
+- Seuls les événements assignés à l'utilisateur connecté s'affichent
+- Création d'événements désactivée (lecture seule)
+
+---
+
+## Paramètres — Types d'événements
+
+Nouvelle section dans `/parametres` :
+- Liste des types avec couleur et label
+- Bouton `+ Ajouter un type` → mini-formulaire inline (label + color picker)
+- Bouton édition et suppression par ligne
+- Suppression bloquée avec message d'erreur si des événements utilisent ce type
+
+---
+
+## Tests
+
+### Vitest (unitaires — `lib/calendar.ts`)
+- `getEvents` filtre correctement par workspace et par ouvrier
+- `createEvent` valide les champs obligatoires
+- `deleteEventType` lève une erreur si le type est utilisé
+
+### Cypress (E2E)
+- Bureau : créer un événement → vérifier qu'il apparaît dans la grille mensuelle
+- Bureau : filtrer par ouvrier → seuls les événements de cet ouvrier s'affichent
+- Ouvrier : se connecter → ne voit que ses événements assignés, pas de bouton créer
+- Navigation : cliquer `→` passe au mois suivant, `←` revient en arrière
+- Admin : ajouter un type d'événement dans les paramètres → disponible dans la modale
+
+---
+
+## Dépendances
+
+| Outil | Usage | Statut |
+|-------|-------|--------|
+| `date-fns` | Manipulation dates, navigation mois/semaine/jour | Déjà installé |
+| `shadcn/ui Dialog` | Modale création/édition | Déjà disponible |
+| `shadcn/ui Select` | Sélection type d'événement | Déjà disponible |
+| `shadcn/ui Command` | Multi-select ouvriers | Déjà disponible |
+| `shadcn/ui Popover` | Date picker, color picker | Déjà disponible |
+
+Pas de librairie calendrier externe — implémentation custom avec Tailwind CSS.

--- a/hooks/use-calendar-events.ts
+++ b/hooks/use-calendar-events.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type { CalendarEventWithDetails } from "@/types"
+
+interface UseCalendarEventsOptions {
+  from: string
+  to: string
+  assigneeId?: string
+}
+
+export function useCalendarEvents({ from, to, assigneeId }: UseCalendarEventsOptions) {
+  const [events, setEvents] = useState<CalendarEventWithDetails[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchEvents = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams({ from, to })
+      if (assigneeId) params.set("assigneeId", assigneeId)
+      const res = await fetch(`/api/calendar/events?${params}`)
+      if (!res.ok) return
+      const data = await res.json()
+      setEvents(data)
+    } finally {
+      setLoading(false)
+    }
+  }, [from, to, assigneeId])
+
+  useEffect(() => {
+    fetchEvents()
+  }, [fetchEvents])
+
+  return { events, loading, refresh: fetchEvents }
+}

--- a/lib/calendar-event-types.test.ts
+++ b/lib/calendar-event-types.test.ts
@@ -47,6 +47,23 @@ describe("createEventType", () => {
   })
 })
 
+describe("updateEventType", () => {
+  it("updates label and color", async () => {
+    const updated = { id: "type-1", label: "Nouveau label", color: "#22c55e" }
+    mockFrom.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: updated, error: null }),
+          }),
+        }),
+      }),
+    })
+    const result = await updateEventType(supabase, "type-1", { label: "Nouveau label", color: "#22c55e" })
+    expect(result).toEqual(updated)
+  })
+})
+
 describe("deleteEventType", () => {
   it("throws if type is used by an event", async () => {
     mockFrom

--- a/lib/calendar-event-types.test.ts
+++ b/lib/calendar-event-types.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  getEventTypes,
+  createEventType,
+  updateEventType,
+  deleteEventType,
+  seedDefaultEventTypes,
+} from "./calendar-event-types"
+
+const mockFrom = vi.fn()
+const supabase = { from: mockFrom } as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("getEventTypes", () => {
+  it("returns event types for workspace", async () => {
+    const types = [{ id: "1", label: "Chantier", color: "#3b82f6" }]
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({ data: types, error: null }),
+        }),
+      }),
+    })
+    const result = await getEventTypes(supabase, "ws-1")
+    expect(result).toEqual(types)
+  })
+})
+
+describe("createEventType", () => {
+  it("inserts a new event type", async () => {
+    const created = { id: "new-id", label: "Livraison", color: "#f97316" }
+    mockFrom.mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: created, error: null }),
+        }),
+      }),
+    })
+    const result = await createEventType(supabase, "ws-1", {
+      label: "Livraison",
+      color: "#f97316",
+    })
+    expect(result).toEqual(created)
+  })
+})
+
+describe("deleteEventType", () => {
+  it("throws if type is used by an event", async () => {
+    mockFrom
+      .mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({ data: [{ id: "ev-1" }], error: null }),
+          }),
+        }),
+      })
+    await expect(deleteEventType(supabase, "type-id")).rejects.toThrow(
+      "Ce type est utilisé par des événements existants"
+    )
+  })
+})
+
+describe("seedDefaultEventTypes", () => {
+  it("inserts 9 default event types", async () => {
+    const insertMock = vi.fn().mockResolvedValue({ error: null })
+    mockFrom.mockReturnValue({ insert: insertMock })
+    await seedDefaultEventTypes(supabase, "ws-1")
+    expect(insertMock).toHaveBeenCalledOnce()
+    const rows = insertMock.mock.calls[0][0]
+    expect(rows).toHaveLength(9)
+    expect(rows[0].workspace_id).toBe("ws-1")
+    expect(rows[0].is_preset).toBe(true)
+  })
+})

--- a/lib/calendar-event-types.ts
+++ b/lib/calendar-event-types.ts
@@ -1,0 +1,104 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+import type {
+  CalendarEventType,
+  CreateCalendarEventTypeInput,
+  UpdateCalendarEventTypeInput,
+} from "@/types"
+
+type Supabase = SupabaseClient<Database>
+
+export const DEFAULT_EVENT_TYPES: CreateCalendarEventTypeInput[] = [
+  { label: "Chantier / Travaux",     color: "#3b82f6" },
+  { label: "Rendez-vous client",     color: "#ec4899" },
+  { label: "Visite pré-chantier",    color: "#8b5cf6" },
+  { label: "Livraison matériaux",    color: "#f97316" },
+  { label: "Réunion d'équipe",       color: "#06b6d4" },
+  { label: "Formation / Sécurité",   color: "#f59e0b" },
+  { label: "Réception de chantier",  color: "#22c55e" },
+  { label: "Permanence / Astreinte", color: "#6b7280" },
+  { label: "Administratif",          color: "#a3a3a3" },
+]
+
+export async function getEventTypes(
+  supabase: Supabase,
+  workspaceId: string
+): Promise<CalendarEventType[]> {
+  // @ts-ignore
+  const { data, error } = await supabase
+    .from("calendar_event_types")
+    .select("*")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: true })
+  if (error) throw error
+  return data as CalendarEventType[]
+}
+
+export async function createEventType(
+  supabase: Supabase,
+  workspaceId: string,
+  input: CreateCalendarEventTypeInput
+): Promise<CalendarEventType> {
+  // @ts-ignore
+  const { data, error } = await supabase
+    .from("calendar_event_types")
+    .insert({ workspace_id: workspaceId, ...input })
+    .select()
+    .single()
+  if (error) throw error
+  return data as CalendarEventType
+}
+
+export async function updateEventType(
+  supabase: Supabase,
+  id: string,
+  input: UpdateCalendarEventTypeInput
+): Promise<CalendarEventType> {
+  // @ts-ignore
+  const { data, error } = await supabase
+    .from("calendar_event_types")
+    .update(input)
+    .eq("id", id)
+    .select()
+    .single()
+  if (error) throw error
+  return data as CalendarEventType
+}
+
+export async function deleteEventType(
+  supabase: Supabase,
+  id: string
+): Promise<void> {
+  // @ts-ignore
+  const { data: usedBy } = await supabase
+    .from("calendar_events")
+    .select("id")
+    .eq("event_type_id", id)
+    .limit(1)
+  if (usedBy && usedBy.length > 0) {
+    throw new Error("Ce type est utilisé par des événements existants")
+  }
+  // @ts-ignore
+  const { error } = await supabase
+    .from("calendar_event_types")
+    .delete()
+    .eq("id", id)
+  if (error) throw error
+}
+
+export async function seedDefaultEventTypes(
+  supabase: Supabase,
+  workspaceId: string
+): Promise<void> {
+  const rows = DEFAULT_EVENT_TYPES.map((t) => ({
+    workspace_id: workspaceId,
+    label: t.label,
+    color: t.color,
+    is_preset: true,
+  }))
+  // @ts-ignore
+  const { error } = await supabase
+    .from("calendar_event_types")
+    .insert(rows)
+  if (error) throw error
+}

--- a/lib/calendar-event-types.ts
+++ b/lib/calendar-event-types.ts
@@ -24,8 +24,8 @@ export async function getEventTypes(
   supabase: Supabase,
   workspaceId: string
 ): Promise<CalendarEventType[]> {
-  // @ts-ignore
-  const { data, error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data, error } = await (supabase as any)
     .from("calendar_event_types")
     .select("*")
     .eq("workspace_id", workspaceId)
@@ -39,8 +39,8 @@ export async function createEventType(
   workspaceId: string,
   input: CreateCalendarEventTypeInput
 ): Promise<CalendarEventType> {
-  // @ts-ignore
-  const { data, error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data, error } = await (supabase as any)
     .from("calendar_event_types")
     .insert({ workspace_id: workspaceId, ...input })
     .select()
@@ -54,8 +54,8 @@ export async function updateEventType(
   id: string,
   input: UpdateCalendarEventTypeInput
 ): Promise<CalendarEventType> {
-  // @ts-ignore
-  const { data, error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data, error } = await (supabase as any)
     .from("calendar_event_types")
     .update(input)
     .eq("id", id)
@@ -69,8 +69,8 @@ export async function deleteEventType(
   supabase: Supabase,
   id: string
 ): Promise<void> {
-  // @ts-ignore
-  const { data: usedBy } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data: usedBy } = await (supabase as any)
     .from("calendar_events")
     .select("id")
     .eq("event_type_id", id)
@@ -78,8 +78,8 @@ export async function deleteEventType(
   if (usedBy && usedBy.length > 0) {
     throw new Error("Ce type est utilisé par des événements existants")
   }
-  // @ts-ignore
-  const { error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { error } = await (supabase as any)
     .from("calendar_event_types")
     .delete()
     .eq("id", id)
@@ -96,8 +96,8 @@ export async function seedDefaultEventTypes(
     color: t.color,
     is_preset: true,
   }))
-  // @ts-ignore
-  const { error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { error } = await (supabase as any)
     .from("calendar_event_types")
     .insert(rows)
   if (error) throw error

--- a/lib/calendar.test.ts
+++ b/lib/calendar.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getEvents, createEvent, updateEvent, deleteEvent } from "./calendar"
+
+const mockFrom = vi.fn()
+const supabase = { from: mockFrom } as any
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("getEvents", () => {
+  it("fetches events within date range for workspace", async () => {
+    const events = [{ id: "ev-1", title: "Test", start_at: "2026-05-11T08:00:00Z", assignees: [] }]
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: events, error: null }),
+      }),
+    })
+    const result = await getEvents(supabase, "ws-1", {
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-31T23:59:59Z",
+    })
+    expect(result).toEqual(events)
+  })
+
+  it("filters events client-side by assigneeId", async () => {
+    const events = [
+      { id: "ev-1", title: "E1", start_at: "2026-05-11T08:00:00Z", assignees: [{ user_id: "u-1" }] },
+      { id: "ev-2", title: "E2", start_at: "2026-05-11T09:00:00Z", assignees: [{ user_id: "u-2" }] },
+    ]
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: events, error: null }),
+      }),
+    })
+    const result = await getEvents(supabase, "ws-1", {
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-31T23:59:59Z",
+      assigneeId: "u-1",
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("ev-1")
+  })
+})
+
+describe("createEvent", () => {
+  it("inserts event and assignees", async () => {
+    const created = { id: "new-ev", title: "Chantier" }
+    mockFrom
+      .mockReturnValueOnce({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: created, error: null }),
+          }),
+        }),
+      })
+      .mockReturnValueOnce({
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      })
+    const result = await createEvent(supabase, "ws-1", {
+      title: "Chantier",
+      start_at: "2026-05-11T08:00:00Z",
+      end_at: "2026-05-11T17:00:00Z",
+      assignee_ids: ["user-1"],
+    })
+    expect(result).toEqual(created)
+    expect(mockFrom).toHaveBeenCalledTimes(2)
+  })
+
+  it("skips assignees insert if no assignee_ids", async () => {
+    const created = { id: "new-ev", title: "Chantier" }
+    mockFrom.mockReturnValueOnce({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: created, error: null }),
+        }),
+      }),
+    })
+    await createEvent(supabase, "ws-1", {
+      title: "Chantier",
+      start_at: "2026-05-11T08:00:00Z",
+      end_at: "2026-05-11T17:00:00Z",
+    })
+    expect(mockFrom).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("deleteEvent", () => {
+  it("deletes event by id", async () => {
+    const deleteMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    })
+    mockFrom.mockReturnValue({ delete: deleteMock })
+    await deleteEvent(supabase, "ev-1")
+    expect(deleteMock).toHaveBeenCalledOnce()
+  })
+})

--- a/lib/calendar.test.ts
+++ b/lib/calendar.test.ts
@@ -45,6 +45,22 @@ describe("getEvents", () => {
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe("ev-1")
   })
+
+  it("returns empty array when no events in range", async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    })
+    const result = await getEvents(supabase, "ws-1", {
+      from: "2026-06-01T00:00:00Z",
+      to: "2026-06-30T23:59:59Z",
+    })
+    expect(result).toEqual([])
+  })
 })
 
 describe("createEvent", () => {

--- a/lib/calendar.test.ts
+++ b/lib/calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { getEvents, createEvent, updateEvent, deleteEvent } from "./calendar"
+import { getEvents, getEvent, createEvent, updateEvent, deleteEvent } from "./calendar"
 
 const mockFrom = vi.fn()
 const supabase = { from: mockFrom } as any
@@ -50,6 +50,7 @@ describe("getEvents", () => {
 describe("createEvent", () => {
   it("inserts event and assignees", async () => {
     const created = { id: "new-ev", title: "Chantier" }
+    const withDetails = { id: "new-ev", title: "Chantier", assignees: [], event_type: null }
     mockFrom
       .mockReturnValueOnce({
         insert: vi.fn().mockReturnValue({
@@ -61,31 +62,48 @@ describe("createEvent", () => {
       .mockReturnValueOnce({
         insert: vi.fn().mockResolvedValue({ error: null }),
       })
+      .mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: withDetails, error: null }),
+          }),
+        }),
+      })
     const result = await createEvent(supabase, "ws-1", {
       title: "Chantier",
       start_at: "2026-05-11T08:00:00Z",
       end_at: "2026-05-11T17:00:00Z",
       assignee_ids: ["user-1"],
     })
-    expect(result).toEqual(created)
-    expect(mockFrom).toHaveBeenCalledTimes(2)
+    expect(result).toEqual(withDetails)
+    expect(mockFrom).toHaveBeenCalledTimes(3)
   })
 
   it("skips assignees insert if no assignee_ids", async () => {
     const created = { id: "new-ev", title: "Chantier" }
-    mockFrom.mockReturnValueOnce({
-      insert: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({ data: created, error: null }),
+    const withDetails = { id: "new-ev", title: "Chantier", assignees: [], event_type: null }
+    mockFrom
+      .mockReturnValueOnce({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: created, error: null }),
+          }),
         }),
-      }),
-    })
-    await createEvent(supabase, "ws-1", {
+      })
+      .mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: withDetails, error: null }),
+          }),
+        }),
+      })
+    const result = await createEvent(supabase, "ws-1", {
       title: "Chantier",
       start_at: "2026-05-11T08:00:00Z",
       end_at: "2026-05-11T17:00:00Z",
     })
-    expect(mockFrom).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(withDetails)
+    expect(mockFrom).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -97,5 +115,64 @@ describe("deleteEvent", () => {
     mockFrom.mockReturnValue({ delete: deleteMock })
     await deleteEvent(supabase, "ev-1")
     expect(deleteMock).toHaveBeenCalledOnce()
+  })
+})
+
+describe("getEvent", () => {
+  it("fetches single event with details", async () => {
+    const event = { id: "ev-1", title: "Test", assignees: [], event_type: null }
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: event, error: null }),
+        }),
+      }),
+    })
+    const result = await getEvent(supabase, "ev-1")
+    expect(result).toEqual(event)
+    expect(result.id).toBe("ev-1")
+  })
+})
+
+describe("updateEvent", () => {
+  it("updates event fields only when no assignee_ids", async () => {
+    const event = { id: "ev-1", title: "Updated", assignees: [], event_type: null }
+    mockFrom
+      .mockReturnValueOnce({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      })
+      .mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: event, error: null }),
+          }),
+        }),
+      })
+    const result = await updateEvent(supabase, "ev-1", { title: "Updated" })
+    expect(result.title).toBe("Updated")
+  })
+
+  it("replaces assignees when assignee_ids provided", async () => {
+    const event = { id: "ev-1", title: "Test", assignees: [{ user_id: "u-2" }], event_type: null }
+    const deleteMock = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) })
+    const insertMock = vi.fn().mockResolvedValue({ error: null })
+    // When only assignee_ids are provided, rest is empty so no update call is made.
+    // Calls: delete assignees, insert assignees, getEvent (select)
+    mockFrom
+      .mockReturnValueOnce({ delete: deleteMock })
+      .mockReturnValueOnce({ insert: insertMock })
+      .mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: event, error: null }),
+          }),
+        }),
+      })
+    const result = await updateEvent(supabase, "ev-1", { assignee_ids: ["u-2"] })
+    expect(deleteMock).toHaveBeenCalledOnce()
+    expect(insertMock).toHaveBeenCalledOnce()
+    expect(result.assignees[0].user_id).toBe("u-2")
   })
 })

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,7 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
 import type { Database } from "@/types/supabase"
 import type {
-  CalendarEvent,
   CalendarEventWithDetails,
   CreateCalendarEventInput,
   UpdateCalendarEventInput,

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -20,8 +20,8 @@ export async function getEvents(
   workspaceId: string,
   filters: GetEventsFilters
 ): Promise<CalendarEventWithDetails[]> {
-  // @ts-ignore
-  const { data, error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data, error } = await (supabase as any)
     .from("calendar_events")
     .select(`
       *,
@@ -50,8 +50,8 @@ export async function getEvent(
   supabase: Supabase,
   id: string
 ): Promise<CalendarEventWithDetails> {
-  // @ts-ignore
-  const { data, error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data, error } = await (supabase as any)
     .from("calendar_events")
     .select(`
       *,
@@ -68,10 +68,10 @@ export async function createEvent(
   supabase: Supabase,
   workspaceId: string,
   input: CreateCalendarEventInput
-): Promise<CalendarEvent> {
+): Promise<CalendarEventWithDetails> {
   const { assignee_ids, ...rest } = input
-  // @ts-ignore
-  const { data, error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { data, error } = await (supabase as any)
     .from("calendar_events")
     .insert({ workspace_id: workspaceId, ...rest })
     .select()
@@ -79,14 +79,14 @@ export async function createEvent(
   if (error) throw error
 
   if (assignee_ids && assignee_ids.length > 0) {
-    // @ts-ignore
-    const { error: assignError } = await supabase
+    // Tables not yet in generated types — migration pending
+    const { error: assignError } = await (supabase as any)
       .from("calendar_event_assignees")
-      .insert(assignee_ids.map((user_id) => ({ event_id: data.id, user_id })))
+      .insert(assignee_ids.map((user_id: string) => ({ event_id: data.id, user_id })))
     if (assignError) throw assignError
   }
 
-  return data as CalendarEvent
+  return getEvent(supabase, data.id)
 }
 
 export async function updateEvent(
@@ -97,8 +97,8 @@ export async function updateEvent(
   const { assignee_ids, ...rest } = input
 
   if (Object.keys(rest).length > 0) {
-    // @ts-ignore
-    const { error } = await supabase
+    // Tables not yet in generated types — migration pending
+    const { error } = await (supabase as any)
       .from("calendar_events")
       .update(rest)
       .eq("id", id)
@@ -106,17 +106,17 @@ export async function updateEvent(
   }
 
   if (assignee_ids !== undefined) {
-    // @ts-ignore
-    await supabase
+    // Tables not yet in generated types — migration pending
+    await (supabase as any)
       .from("calendar_event_assignees")
       .delete()
       .eq("event_id", id)
 
     if (assignee_ids.length > 0) {
-      // @ts-ignore
-      const { error } = await supabase
+      // Tables not yet in generated types — migration pending
+      const { error } = await (supabase as any)
         .from("calendar_event_assignees")
-        .insert(assignee_ids.map((user_id) => ({ event_id: id, user_id })))
+        .insert(assignee_ids.map((user_id: string) => ({ event_id: id, user_id })))
       if (error) throw error
     }
   }
@@ -128,8 +128,8 @@ export async function deleteEvent(
   supabase: Supabase,
   id: string
 ): Promise<void> {
-  // @ts-ignore
-  const { error } = await supabase
+  // Tables not yet in generated types — migration pending
+  const { error } = await (supabase as any)
     .from("calendar_events")
     .delete()
     .eq("id", id)

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,0 +1,137 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+import type {
+  CalendarEvent,
+  CalendarEventWithDetails,
+  CreateCalendarEventInput,
+  UpdateCalendarEventInput,
+} from "@/types"
+
+type Supabase = SupabaseClient<Database>
+
+export type GetEventsFilters = {
+  from: string
+  to: string
+  assigneeId?: string
+}
+
+export async function getEvents(
+  supabase: Supabase,
+  workspaceId: string,
+  filters: GetEventsFilters
+): Promise<CalendarEventWithDetails[]> {
+  // @ts-ignore
+  const { data, error } = await supabase
+    .from("calendar_events")
+    .select(`
+      *,
+      event_type:calendar_event_types(*),
+      assignees:calendar_event_assignees(user_id)
+    `)
+    .eq("workspace_id", workspaceId)
+    .gte("start_at", filters.from)
+    .lte("start_at", filters.to)
+    .order("start_at", { ascending: true })
+
+  if (error) throw error
+
+  let events = data as unknown as CalendarEventWithDetails[]
+
+  if (filters.assigneeId) {
+    events = events.filter((e) =>
+      e.assignees.some((a) => a.user_id === filters.assigneeId)
+    )
+  }
+
+  return events
+}
+
+export async function getEvent(
+  supabase: Supabase,
+  id: string
+): Promise<CalendarEventWithDetails> {
+  // @ts-ignore
+  const { data, error } = await supabase
+    .from("calendar_events")
+    .select(`
+      *,
+      event_type:calendar_event_types(*),
+      assignees:calendar_event_assignees(user_id)
+    `)
+    .eq("id", id)
+    .single()
+  if (error) throw error
+  return data as unknown as CalendarEventWithDetails
+}
+
+export async function createEvent(
+  supabase: Supabase,
+  workspaceId: string,
+  input: CreateCalendarEventInput
+): Promise<CalendarEvent> {
+  const { assignee_ids, ...rest } = input
+  // @ts-ignore
+  const { data, error } = await supabase
+    .from("calendar_events")
+    .insert({ workspace_id: workspaceId, ...rest })
+    .select()
+    .single()
+  if (error) throw error
+
+  if (assignee_ids && assignee_ids.length > 0) {
+    // @ts-ignore
+    const { error: assignError } = await supabase
+      .from("calendar_event_assignees")
+      .insert(assignee_ids.map((user_id) => ({ event_id: data.id, user_id })))
+    if (assignError) throw assignError
+  }
+
+  return data as CalendarEvent
+}
+
+export async function updateEvent(
+  supabase: Supabase,
+  id: string,
+  input: UpdateCalendarEventInput
+): Promise<CalendarEventWithDetails> {
+  const { assignee_ids, ...rest } = input
+
+  if (Object.keys(rest).length > 0) {
+    // @ts-ignore
+    const { error } = await supabase
+      .from("calendar_events")
+      .update(rest)
+      .eq("id", id)
+    if (error) throw error
+  }
+
+  if (assignee_ids !== undefined) {
+    // @ts-ignore
+    await supabase
+      .from("calendar_event_assignees")
+      .delete()
+      .eq("event_id", id)
+
+    if (assignee_ids.length > 0) {
+      // @ts-ignore
+      const { error } = await supabase
+        .from("calendar_event_assignees")
+        .insert(assignee_ids.map((user_id) => ({ event_id: id, user_id })))
+      if (error) throw error
+    }
+  }
+
+  return getEvent(supabase, id)
+}
+
+export async function deleteEvent(
+  supabase: Supabase,
+  id: string
+): Promise<void> {
+  // @ts-ignore
+  const { error } = await supabase
+    .from("calendar_events")
+    .delete()
+    .eq("id", id)
+  if (error) throw error
+}

--- a/supabase/migrations/20260511000022_calendar.sql
+++ b/supabase/migrations/20260511000022_calendar.sql
@@ -1,0 +1,116 @@
+-- supabase/migrations/20260511000022_calendar.sql
+
+-- Types d'événements configurables par workspace
+CREATE TABLE IF NOT EXISTS calendar_event_types (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  label       text NOT NULL,
+  color       text NOT NULL DEFAULT '#6366f1',
+  is_preset   boolean NOT NULL DEFAULT false,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Événements du calendrier
+CREATE TABLE IF NOT EXISTS calendar_events (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id  uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  title         text NOT NULL,
+  description   text,
+  start_at      timestamptz NOT NULL,
+  end_at        timestamptz NOT NULL,
+  event_type_id uuid REFERENCES calendar_event_types(id) ON DELETE SET NULL,
+  created_by    uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Ouvriers assignés (N-N)
+CREATE TABLE IF NOT EXISTS calendar_event_assignees (
+  event_id uuid NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  user_id  uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  PRIMARY KEY (event_id, user_id)
+);
+
+-- Index perf
+CREATE INDEX IF NOT EXISTS idx_calendar_events_workspace_start
+  ON calendar_events(workspace_id, start_at);
+CREATE INDEX IF NOT EXISTS idx_calendar_event_assignees_user
+  ON calendar_event_assignees(user_id);
+
+-- RLS
+ALTER TABLE calendar_event_types ENABLE ROW LEVEL SECURITY;
+ALTER TABLE calendar_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE calendar_event_assignees ENABLE ROW LEVEL SECURITY;
+
+-- calendar_event_types : lecture par membres du workspace, écriture admin/bureau
+CREATE POLICY "workspace members can read event types"
+  ON calendar_event_types FOR SELECT
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "admin bureau can manage event types"
+  ON calendar_event_types FOR ALL
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members
+      WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+    )
+  );
+
+-- calendar_events : bureau/admin voient tout, ouvrier uniquement ses événements
+CREATE POLICY "bureau admin see all events"
+  ON calendar_events FOR SELECT
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members
+      WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+    )
+  );
+
+CREATE POLICY "ouvrier sees assigned events"
+  ON calendar_events FOR SELECT
+  USING (
+    id IN (
+      SELECT event_id FROM calendar_event_assignees WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "bureau admin can manage events"
+  ON calendar_events FOR ALL
+  USING (
+    workspace_id IN (
+      SELECT workspace_id FROM workspace_members
+      WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+    )
+  );
+
+-- calendar_event_assignees : mêmes règles
+CREATE POLICY "bureau admin see all assignees"
+  ON calendar_event_assignees FOR SELECT
+  USING (
+    event_id IN (
+      SELECT id FROM calendar_events
+      WHERE workspace_id IN (
+        SELECT workspace_id FROM workspace_members
+        WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+      )
+    )
+  );
+
+CREATE POLICY "ouvrier sees own assignees"
+  ON calendar_event_assignees FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "bureau admin manage assignees"
+  ON calendar_event_assignees FOR ALL
+  USING (
+    event_id IN (
+      SELECT id FROM calendar_events
+      WHERE workspace_id IN (
+        SELECT workspace_id FROM workspace_members
+        WHERE user_id = auth.uid() AND role IN ('admin', 'bureau')
+      )
+    )
+  );

--- a/supabase/migrations/20260513000023_fix_calendar_rls_recursion.sql
+++ b/supabase/migrations/20260513000023_fix_calendar_rls_recursion.sql
@@ -1,0 +1,38 @@
+-- Fix: infinite recursion in calendar_event_assignees RLS policies
+--
+-- Cause: calendar_events policy "ouvrier sees assigned events" queries
+--        calendar_event_assignees, whose "bureau admin see all assignees"
+--        policy queries back calendar_events → infinite loop.
+--
+-- Fix: replace the recursive sub-select with a SECURITY DEFINER function
+--      that reads calendar_events bypassing RLS.
+
+DROP POLICY IF EXISTS "bureau admin see all assignees" ON calendar_event_assignees;
+DROP POLICY IF EXISTS "bureau admin manage assignees" ON calendar_event_assignees;
+
+CREATE OR REPLACE FUNCTION public.is_bureau_admin_for_event(p_event_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM calendar_events ce
+    JOIN workspace_members wm ON wm.workspace_id = ce.workspace_id
+    WHERE ce.id = p_event_id
+      AND wm.user_id = auth.uid()
+      AND wm.role IN ('admin', 'bureau')
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.is_bureau_admin_for_event(uuid) TO authenticated;
+
+CREATE POLICY "bureau admin see all assignees"
+  ON calendar_event_assignees FOR SELECT
+  USING (public.is_bureau_admin_for_event(event_id));
+
+CREATE POLICY "bureau admin manage assignees"
+  ON calendar_event_assignees FOR ALL
+  USING (public.is_bureau_admin_for_event(event_id));

--- a/types/index.ts
+++ b/types/index.ts
@@ -298,3 +298,51 @@ export type ProjectWithClient = {
   created_at: string
   clients: { id: string; name: string } | null
 }
+
+// ─── Calendar types ───────────────────────────────────────────────────────────
+
+export type CalendarEventType = {
+  id: string
+  workspace_id: string
+  label: string
+  color: string
+  is_preset: boolean
+  created_at: string
+}
+
+export type CalendarEvent = {
+  id: string
+  workspace_id: string
+  title: string
+  description: string | null
+  start_at: string
+  end_at: string
+  event_type_id: string | null
+  created_by: string | null
+  created_at: string
+}
+
+export type CalendarEventWithDetails = CalendarEvent & {
+  event_type: CalendarEventType | null
+  assignees: { user_id: string }[]
+}
+
+export type CreateCalendarEventInput = {
+  title: string
+  description?: string | null
+  start_at: string
+  end_at: string
+  event_type_id?: string | null
+  assignee_ids?: string[]
+}
+
+export type UpdateCalendarEventInput = Partial<CreateCalendarEventInput>
+
+export type CreateCalendarEventTypeInput = {
+  label: string
+  color: string
+}
+
+export type UpdateCalendarEventTypeInput = Partial<CreateCalendarEventTypeInput>
+
+export type CalendarView = "month" | "week" | "day"


### PR DESCRIPTION
## Summary

- Nouveau calendrier d'entreprise (`/calendrier`) avec vues mois, semaine et jour et navigation ← → entre périodes
- Événements typés et colorés (par type d'activité), assignation de plusieurs ouvriers par événement
- Filtre par ouvrier pour les rôles bureau/admin (filtre inclusif multi-sélection)
- Vue lecture seule pour les ouvriers sur `/terrain/calendrier` (uniquement leurs événements assignés)
- Gestion des types d'événements dans les paramètres avec 9 presets BTP et ajout/édition/suppression custom
- Seed automatique des presets à la création d'un workspace

## Architecture

- 3 nouvelles tables Supabase : `calendar_event_types`, `calendar_events`, `calendar_event_assignees` avec RLS différencié bureau/ouvrier
- CRUD isolé dans `lib/calendar.ts` et `lib/calendar-event-types.ts`
- Grille calendrier implémentée en custom Tailwind (pas de lib externe) avec `date-fns`
- Composants dans `components/calendrier/` : CalendarGrid, CalendarHeader, EventDialog, CalendarFilters, CalendarEventChip, EventTypeBadge

## Test plan

- [ ] Appliquer la migration SQL `supabase/migrations/20260511000022_calendar.sql` dans le dashboard Supabase
- [ ] `npm run test` — 251 tests unitaires passent
- [ ] `npm run test:e2e` — tests Cypress bureau + ouvrier (`cypress/e2e/calendar.cy.ts`)
- [ ] Test manuel bureau : créer un événement → apparaît dans la grille mensuelle
- [ ] Test manuel bureau : navigation ← → change le mois/semaine/jour
- [ ] Test manuel bureau : filtre par ouvrier fonctionne
- [ ] Test manuel ouvrier : `/terrain/calendrier` — pas de bouton créer ni filtres
- [ ] Test manuel paramètres : section "Types d'événements" visible avec les 9 presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)